### PR TITLE
fix: reconstruct parallel tool-call assistant message from split core messages

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -109,14 +109,64 @@ export function coreOutToAgentMessages(
   coreOut: CoreMessage[],
   originalById: Map<string, AgentMessage>,
 ): AgentMessage[] {
-  return coreOut
-    .filter((core) => !core.id.startsWith("acp_summary_"))
-    .map((core) => {
+  const out: AgentMessage[] = [];
+  const emittedSplit = new Set<string>();
+
+  for (const core of coreOut) {
+    if (core.id.startsWith("acp_summary_")) continue;
+
+    const hashIdx = core.id.indexOf("#");
+    if (hashIdx < 0) {
       const original = originalById.get(core.id);
-      if (original) return patchRefTag(original, core);
-      return null;
-    })
-    .filter((m): m is AgentMessage => m !== null);
+      if (original) out.push(patchRefTag(original, core));
+      continue;
+    }
+
+    const baseId = core.id.substring(0, hashIdx);
+    if (emittedSplit.has(baseId)) continue;
+    emittedSplit.add(baseId);
+
+    const original = originalById.get(baseId);
+    if (!original) continue;
+
+    const survivingCallIds = new Set(
+      coreOut
+        .filter((c) => c.id.startsWith(`${baseId}#`) && !c.id.startsWith("acp_summary_"))
+        .map((c) => c.toolCallId)
+        .filter((id): id is string => !!id),
+    );
+
+    out.push(reconstructToolCallMessage(original, core, survivingCallIds));
+  }
+
+  return out;
+}
+
+function reconstructToolCallMessage(
+  original: AgentMessage,
+  firstCore: CoreMessage,
+  survivingCallIds: Set<string>,
+): AgentMessage {
+  const base = original as AnyMessage;
+  const match = firstCore.text ? firstCore.text.match(REF_TAG) : null;
+  const tag = match ? match[0] : null;
+
+  const rawBlocks: unknown[] = Array.isArray(base.content)
+    ? base.content
+    : typeof base.content === "string"
+      ? [{ type: "text", text: base.content }]
+      : [];
+
+  const filtered = rawBlocks.filter((block) => {
+    const b = block as { type?: string; id?: string };
+    if (b.type === "toolCall") return survivingCallIds.has(b.id ?? "");
+    return true;
+  });
+
+  const peeled = peelRefTagBlocks(filtered);
+  const content = tag ? [{ type: "text", text: tag }, ...peeled] : peeled;
+
+  return { ...(original as object), content } as AgentMessage;
 }
 
 function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
@@ -148,12 +198,4 @@ function peelRefTagBlocks(blocks: unknown[]): unknown[] {
     }
   }
   return out;
-}
-
-function synthesize(core: CoreMessage): AgentMessage {
-  return {
-    role: "user",
-    content: [{ type: "text", text: core.text ?? "" }],
-    timestamp: Date.now(),
-  } as AgentMessage;
 }

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -32,8 +32,23 @@ function assistantToolCall(name: string): object {
     timestamp: Date.now(),
   };
 }
-function toolResult(name: string, text: string): object {
-  return { role: "toolResult", toolCallId: "tc1", toolName: name, content: [{ type: "text", text }], isError: false, timestamp: Date.now() };
+function assistantParallelToolCalls(calls: { id: string; name: string; args?: unknown }[]): object {
+  return {
+    role: "assistant",
+    content: [
+      { type: "text", text: "Running multiple tools" },
+      ...calls.map((c) => ({ type: "toolCall", id: c.id, name: c.name, arguments: c.args ?? {} })),
+    ],
+    api: "anthropic",
+    provider: "anthropic",
+    model: "m",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+    stopReason: "toolUse",
+    timestamp: Date.now(),
+  };
+}
+function toolResult(callId: string, name: string, text: string): object {
+  return { role: "toolResult", toolCallId: callId, toolName: name, content: [{ type: "text", text }], isError: false, timestamp: Date.now() };
 }
 
 test("entriesToCoreMessages projects user/assistant/toolResult roles and extracts text", () => {
@@ -41,7 +56,7 @@ test("entriesToCoreMessages projects user/assistant/toolResult roles and extract
     msgEntry("a", user("hello world")),
     msgEntry("b", userBlocks("block text")),
     msgEntry("c", assistantToolCall("read")),
-    msgEntry("d", toolResult("read", "file contents")),
+    msgEntry("d", toolResult("tc1", "read", "file contents")),
   ];
   const core = entriesToCoreMessages(entries);
 
@@ -96,4 +111,53 @@ test("coreOutToAgentMessages filters out synthetic summary messages (compress-as
 
   const out = coreOutToAgentMessages(coreOut, originalById);
   assert.equal(out.length, 0, "synthetic summary messages should be filtered out");
+});
+
+test("coreOutToAgentMessages reconstructs parallel tool-call assistant message from split core messages", () => {
+  const assistantMsg = assistantParallelToolCalls([
+    { id: "call_a", name: "read" },
+    { id: "call_b", name: "write" },
+    { id: "call_c", name: "list" },
+  ]);
+  const originalById = new Map([["entry1", assistantMsg as SessionMessageEntry["message"]]]);
+
+  const coreOut: CoreMessage[] = [
+    { id: "entry1#call_a", role: "assistant", contentType: "tool-call", toolName: "read", toolCallId: "call_a", text: "[m00003] Running multiple tools\n{}" },
+    { id: "entry1#call_b", role: "assistant", contentType: "tool-call", toolName: "write", toolCallId: "call_b", text: "[m00003] {}" },
+    { id: "entry1#call_c", role: "assistant", contentType: "tool-call", toolName: "list", toolCallId: "call_c", text: "[m00003] {}" },
+  ];
+
+  const out = coreOutToAgentMessages(coreOut, originalById);
+  assert.equal(out.length, 1, "3 split tool-calls merge into 1 assistant message");
+
+  const content = (out[0] as { content: Array<{ type: string; id?: string; text?: string }> }).content;
+  const toolCalls = content.filter((b) => b.type === "toolCall");
+  assert.equal(toolCalls.length, 3, "all 3 toolCall blocks preserved");
+  assert.deepEqual(toolCalls.map((b) => b.id), ["call_a", "call_b", "call_c"]);
+
+  const textBlocks = content.filter((b) => b.type === "text");
+  assert.ok(textBlocks.length >= 1, "text block preserved");
+  assert.ok(textBlocks[0]!.text!.startsWith("[m00003]"), "ref tag prepended");
+});
+
+test("coreOutToAgentMessages drops pruned tool-call blocks when only some survive", () => {
+  const assistantMsg = assistantParallelToolCalls([
+    { id: "call_a", name: "read" },
+    { id: "call_b", name: "write" },
+    { id: "call_c", name: "list" },
+  ]);
+  const originalById = new Map([["entry1", assistantMsg as SessionMessageEntry["message"]]]);
+
+  const coreOut: CoreMessage[] = [
+    { id: "entry1#call_a", role: "assistant", contentType: "tool-call", toolName: "read", toolCallId: "call_a", text: "[m00003] {}" },
+    { id: "entry1#call_c", role: "assistant", contentType: "tool-call", toolName: "list", toolCallId: "call_c", text: "[m00003] {}" },
+  ];
+
+  const out = coreOutToAgentMessages(coreOut, originalById);
+  assert.equal(out.length, 1);
+
+  const content = (out[0] as { content: Array<{ type: string; id?: string }> }).content;
+  const toolCalls = content.filter((b) => b.type === "toolCall");
+  assert.equal(toolCalls.length, 2, "only 2 surviving tool-call blocks");
+  assert.deepEqual(toolCalls.map((b) => b.id), ["call_a", "call_c"]);
 });


### PR DESCRIPTION
## Summary

- Fix: `coreOutToAgentMessages()` was dropping parallel tool-call messages, causing 400 errors on the next LLM turn
- Root cause: `projectMessage()` splits assistant parallel tool-calls into core messages with id `entryId#callId`, but `originalById` map keyed by `entry.id` only → lookup fails → messages dropped → orphaned tool results → 400

## Fix

Rewrote `coreOutToAgentMessages()` to detect `#callId` suffix, group by base entry ID, and reconstruct ONE assistant message with all surviving toolCall blocks + text blocks + ref tag. Handles partial pruning (some tool-calls compressed, others survive).

## Tests

- 2 new regression tests: full reconstruction (3 parallel calls → 1 message) + partial pruning (2 of 3 survive)
- All 16 tests pass, typecheck clean