### PR TITLE
release: v0.1.1 — version display, dev standards, CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,6 +2,8 @@ import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens } from "acp-kernel";
 
+declare const CURRENT_VERSION: string;
+
 type CommandOptions = Omit<RegisteredCommand, "name" | "sourceInfo">;
 
 export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options: CommandOptions }> {
@@ -89,9 +91,12 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
 
   const lines: string[] = [];
 
+  const versionStr = CURRENT_VERSION ? `pai-acp@${CURRENT_VERSION}` : "";
+
   lines.push("╭─────────────────────────────────────────────╮");
   lines.push("│           ACP Context Analysis              │");
   lines.push("╰─────────────────────────────────────────────╯");
+  if (versionStr) lines.push(versionStr);
   lines.push("");
   lines.push(`Context: ${displayPct}% (${fmtTokens(displayTotal)} / ${fmtTokens(limit)})`);
 


### PR DESCRIPTION
## Summary
- `/acp` command now shows `pai-acp@VERSION`
- AGENTS.md development specification
- CI workflows (ci.yml: test matrix Node 22/24; release.yml: auto npm publish)
- Branch protection configured on master

## Test plan
- [x] 16 tests pass
- [x] Build succeeds
- [x] `/acp` shows version in Pi

**Merge to trigger auto-publish.** CI will tag v0.1.1 and publish to npm.