### PR TITLE
release: v0.1.3 — reduce update check interval to 3min

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,7 +7,7 @@ declare const CURRENT_VERSION: string;
 
 const PACKAGE_NAME = "pai-acp";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
-const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const CHECK_INTERVAL_MS = 3 * 60 * 1000;
 const THROTTLE_FILE = `${process.env.HOME ?? ""}/.pi/agent/.pai-acp-update-check`;
 
 function parseVersion(v: string): number[] {


### PR DESCRIPTION
## Changes
- Update check interval: 6h → 3min
- Based on master (includes PR #5 grep fix)

## Test
- CI passed (test 22/24, pr-validation)
- Auto-update verified: 0.1.0 → 0.1.2 triggered correctly

After merge, CI should auto-publish v0.1.3 to npm.