### PR TITLE
fix: modelContextLimit 反映模型真实上下文窗口，移除 150K 硬上限

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,15 +16,15 @@ export interface AdapterConfig {
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;
   const envLimitNum = envLimit ? Number(envLimit) : NaN;
-  const DEFAULT_TARGET = 150_000;
+  const FALLBACK_LIMIT = 150_000;
   const limit =
     !Number.isNaN(envLimitNum) && envLimitNum > 0
       ? envLimitNum
       : adapter.modelContextLimit && adapter.modelContextLimit > 0
         ? adapter.modelContextLimit
         : liveContextLimit > 0
-          ? Math.min(liveContextLimit, DEFAULT_TARGET)
-          : DEFAULT_TARGET;
+          ? liveContextLimit
+          : FALLBACK_LIMIT;
   return defaultConfig(limit, {
     protectedTools: adapter.protectedTools ?? [],
     preserveRecentMessages: adapter.preserveRecentMessages ?? 5,

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,18 +14,17 @@ export interface AdapterConfig {
 }
 
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
-  // Env override (ACP_MODEL_CONTEXT_LIMIT) takes precedence — useful for forcing
-  // compression to trigger early during observation/testing.
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;
   const envLimitNum = envLimit ? Number(envLimit) : NaN;
+  const DEFAULT_TARGET = 150_000;
   const limit =
     !Number.isNaN(envLimitNum) && envLimitNum > 0
       ? envLimitNum
       : adapter.modelContextLimit && adapter.modelContextLimit > 0
         ? adapter.modelContextLimit
         : liveContextLimit > 0
-          ? liveContextLimit
-          : 200000;
+          ? Math.min(liveContextLimit, DEFAULT_TARGET)
+          : DEFAULT_TARGET;
   return defaultConfig(limit, {
     protectedTools: adapter.protectedTools ?? [],
     preserveRecentMessages: adapter.preserveRecentMessages ?? 5,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveConfig, type AdapterConfig } from "../src/config.js";
+
+const EMPTY: AdapterConfig = {};
+
+test("resolveConfig uses the live model context window as-is (no cap on large windows)", () => {
+  const cfg = resolveConfig(EMPTY, 1_000_000);
+  assert.equal(cfg.modelContextLimit, 1_000_000, "1M window must NOT be capped to 150K");
+});
+
+test("resolveConfig passes small windows through unchanged too", () => {
+  assert.equal(resolveConfig(EMPTY, 32_000).modelContextLimit, 32_000);
+  assert.equal(resolveConfig(EMPTY, 200_000).modelContextLimit, 200_000);
+});
+
+test("resolveConfig falls back to 150K only when the live window is unavailable", () => {
+  assert.equal(resolveConfig(EMPTY, 0).modelContextLimit, 150_000);
+});
+
+test("resolveConfig prefers adapter.modelContextLimit over the live window", () => {
+  const cfg = resolveConfig({ modelContextLimit: 500_000 }, 1_000_000);
+  assert.equal(cfg.modelContextLimit, 500_000);
+});
+
+test("resolveConfig prefers ACP_MODEL_CONTEXT_LIMIT env var over everything", () => {
+  const prev = process.env.ACP_MODEL_CONTEXT_LIMIT;
+  process.env.ACP_MODEL_CONTEXT_LIMIT = "999999";
+  try {
+    const cfg = resolveConfig({ modelContextLimit: 500_000 }, 1_000_000);
+    assert.equal(cfg.modelContextLimit, 999_999);
+  } finally {
+    if (prev === undefined) delete process.env.ACP_MODEL_CONTEXT_LIMIT;
+    else process.env.ACP_MODEL_CONTEXT_LIMIT = prev;
+  }
+});
+
+test("resolveConfig ignores a non-positive ACP_MODEL_CONTEXT_LIMIT and falls through", () => {
+  const prev = process.env.ACP_MODEL_CONTEXT_LIMIT;
+  process.env.ACP_MODEL_CONTEXT_LIMIT = "0";
+  try {
+    const cfg = resolveConfig(EMPTY, 1_000_000);
+    assert.equal(cfg.modelContextLimit, 1_000_000, "env=0 must fall through to live window, not 0");
+  } finally {
+    if (prev === undefined) delete process.env.ACP_MODEL_CONTEXT_LIMIT;
+    else process.env.ACP_MODEL_CONTEXT_LIMIT = prev;
+  }
+});


### PR DESCRIPTION
## 问题

commit 4239962 在 \`resolveConfig\` 里引入了 \`DEFAULT_TARGET = 150_000\` 和 \`Math.min(liveContextLimit, 150_000)\`，把每个模型的 \`modelContextLimit\` 一律砍到 150K。

这是错误的，因为 \`modelContextLimit\` 是 acp-kernel 所有阈值的**分母**，而 acp-kernel 已经把它们设计成基于 limit 的比例：

| 阈值 | 公式 | 砍到 150K 的后果 |
|------|------|------------------|
| \`truncate.threshold\` | \`1.0 × limit\` | **150K 就开始截断消息（丢消息，不是压缩！）** |
| \`nudge.maxContextLimitPct\` | \`0.55 × limit\` | 提醒点错误下移 |
| \`nudge.emergencyThresholdPct\` | \`0.8 × limit\` | 紧急点错误下移 |
| \`growthFloor\` | \`max(20000, limit × 0.05)\` | growth 逻辑失真 |

也就是说，这个改动会让 kernel **误以为模型只有 150K 上下文**，所有下游阈值被连带污染，尤其 \`truncate\` 会在 150K 就开始删消息。

原 commit 的意图（「让 1M 模型压缩更激进」）有专门的旋钮：\`coreOverrides → nudge.growthCap / nudge.maxContextLimitPct / emergencyThresholdPct\`，且 \`AdapterConfig.coreOverrides\` 已经暴露了覆盖入口。应该用这些，而不是篡改分母。

## 修复

- 移除 \`Math.min(live, 150K)\` 这个 cap
- \`modelContextLimit\` 现在如实反映模型的 \`contextWindow\`（\`ctx.model.contextWindow\`，live 每轮读取）
- 150K 仅在**读不到模型窗口**（\`liveContextLimit = 0\`）时作为兜底

**优先级：** \`ACP_MODEL_CONTEXT_LIMIT\` 环境变量 > \`adapter.modelContextLimit\` > 模型真实 \`contextWindow\` > 150K 兜底

## 测试

新增 \`tests/config.test.ts\`（6 个用例），覆盖全部优先级分支及「不再 cap 大模型窗口」回归保护：

- 1M 窗口不再被砍到 150K ✅
- 32K / 200K 窗口原样透传 ✅
- \`live=0\` 时兜底 150K ✅
- \`adapter.modelContextLimit\` 优先于 live ✅
- \`ACP_MODEL_CONTEXT_LIMIT\` 优先于一切 ✅
- \`env=0\` 正确回退到 live ✅

全部 22 个测试通过（原 16 + 新 6），typecheck 通过，build 成功。

## 备注

这个改动也顺便纠正了流程问题：4239962 是直接 commit 到 master、绕过 PR 的，本 PR 恢复正常的 PR 流程。本 PR 不合并，等人工 review 后合并。