### PR TITLE
release: v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.4 (patch)

**patch release，发布 #9 的修复。**

### 包含的变更（相对 master）

| 文件 | 说明 |
|------|------|
| \`src/config.ts\` | 修复 4239962 引入的 \`modelContextLimit\` 150K 硬上限回归 |
| \`tests/config.test.ts\` | 新增 6 个回归测试 |
| \`package.json\` | \`0.1.3\` → \`0.1.4\` |

### 修复内容

4239962 把 \`modelContextLimit\` 一律 cap 到 150K，这会污染 acp-kernel 所有基于该 limit 的下游阈值，最危险的是 \`truncate.threshold = 1.0 × limit\` —— 会在 150K 就开始**截断（丢弃）消息**而非压缩。

本版本移除该 cap，\`modelContextLimit\` 如实反映模型上下文窗口。详见 #9。

### 与 #9 的关系

本 PR 基于 \`2026-08-01_fix-model-context-limit\` 分支，**已包含 #9 的全部修复代码**。
- ✅ 合并本 PR 即可发布包含修复的 0.1.4
- 合并后 #9 可关闭（内容已包含在此）

### 质量检查

- typecheck ✅
- 22 测试通过（原 16 + 新 6）✅
- build 成功（dist/index.js 126 KB）✅

### 合并后

CI（\`.github/workflows/release.yml\`）检测到 \`*_release-v*\` 分支合并会自动：
1. 打 tag \`v0.1.4\`
2. 发布 npm \`pai-acp@0.1.4\`（latest）
3. 创建 GitHub Release v0.1.4

> 本 PR 不自动合并，等人工 review 后合并。