### PR TITLE
fix: code-review findings — token accounting, decompress, auto-update, dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
 
 ### Auto-update
 
-On each Pi startup, pai-acp checks npm for a newer version and auto-installs it. No manual updates needed — just restart Pi.
+On each Pi startup, pai-acp checks npm for a newer version and auto-installs it. No manual updates needed — just restart Pi. To disable (no network calls on startup), set `autoUpdate: false` in the config or env `ACP_AUTO_UPDATE=0`.
 
 ### Compression philosophy in system prompt
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
 
 ### Auto-update
 
-On each Pi startup, pai-acp checks npm for a newer version and auto-installs it. No manual updates needed — just restart Pi. To disable (no network calls on startup), set `autoUpdate: false` in the config or env `ACP_AUTO_UPDATE=0`.
+On each Pi startup, pai-acp checks npm for a newer version and auto-installs it. No manual updates needed — just restart Pi. To disable (no network calls on startup), set `autoUpdate: false` in the config, or set the env var `ACP_AUTO_UPDATE` to one of: `0`, `false`, `no`, or `off` (case-insensitive).
 
 ### Compression philosophy in system prompt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.0.8",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.0.8",
+      "version": "0.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "^0.0.6",
+        "acp-kernel": "0.0.6",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "^0.0.6",
+    "acp-kernel": "0.0.6",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { defaultCountTokens } from "acp-kernel";
+import { defaultCountTokens, deactivateBlock, parseBlockIdArg, buildRestoredContentPreview } from "acp-kernel";
 
 declare const CURRENT_VERSION: string;
 
@@ -25,16 +25,33 @@ export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options
     {
       name: "acp-decompress",
       options: {
-        description: "Restore a compressed block's summary. Usage: /acp-decompress b3",
+        description: "Restore a compressed block (deactivate it). Usage: /acp-decompress b3",
         handler: async (args, ctx) => {
           const id = args.trim();
           if (!id) {
             ctx.ui.notify("Usage: /acp-decompress <blockId>");
             return;
           }
-          const { state } = await runtime.stateFor(ctx);
-          const block = runtime.core.decompress(id, state);
-          ctx.ui.notify(block ? `[${id}] ${block.summary}` : `Block ${id} not found.`);
+          const blockIdNum = parseBlockIdArg(id);
+          if (blockIdNum === null) {
+            ctx.ui.notify(`Invalid blockId: ${id}. Use format like "b3".`);
+            return;
+          }
+          const { state, coreMessages } = await runtime.stateFor(ctx);
+          const block = state.blocks.find((b) => b.blockId === blockIdNum);
+          if (!block) {
+            ctx.ui.notify(`Block ${id} not found.`);
+            return;
+          }
+          if (!block.active) {
+            ctx.ui.notify(`Block ${id} is already inactive.`);
+            return;
+          }
+          const beforeIds = new Set(block.effectiveMessageIds);
+          const newState = deactivateBlock(state, [blockIdNum], { deep: false });
+          await runtime.save(newState, ctx);
+          const { restoredCount } = buildRestoredContentPreview(coreMessages, beforeIds, newState);
+          ctx.ui.notify(`Restored block ${id}: ${restoredCount} message(s) now visible.`);
         },
       },
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,31 +27,26 @@ export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options
       options: {
         description: "Restore a compressed block (deactivate it). Usage: /acp-decompress b3",
         handler: async (args, ctx) => {
-          const id = args.trim();
-          if (!id) {
-            ctx.ui.notify("Usage: /acp-decompress <blockId>");
-            return;
-          }
-          const blockIdNum = parseBlockIdArg(id);
-          if (blockIdNum === null) {
-            ctx.ui.notify(`Invalid blockId: ${id}. Use format like "b3".`);
+          const blockId = parseBlockIdArg(args);
+          if (!blockId) {
+            ctx.ui.notify('Usage: /acp-decompress <blockId> (e.g. "b3")');
             return;
           }
           const { state, coreMessages } = await runtime.stateFor(ctx);
-          const block = state.blocks.find((b) => b.blockId === blockIdNum);
+          const block = state.blocks.find((b) => b.blockId === blockId);
           if (!block) {
-            ctx.ui.notify(`Block ${id} not found.`);
+            ctx.ui.notify(`Block ${blockId} not found.`);
             return;
           }
           if (!block.active) {
-            ctx.ui.notify(`Block ${id} is already inactive.`);
+            ctx.ui.notify(`Block ${blockId} is already inactive.`);
             return;
           }
           const beforeIds = new Set(block.effectiveMessageIds);
-          const newState = deactivateBlock(state, [blockIdNum], { deep: false });
+          const newState = deactivateBlock(state, [blockId], { deep: false });
           await runtime.save(newState, ctx);
           const { restoredCount } = buildRestoredContentPreview(coreMessages, beforeIds, newState);
-          ctx.ui.notify(`Restored block ${id}: ${restoredCount} message(s) now visible.`);
+          ctx.ui.notify(`Restored block ${blockId}: ${restoredCount} message(s) now visible.`);
         },
       },
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,10 @@ export interface AdapterConfig {
   modelContextLimit?: number;
   protectedTools?: string[];
   preserveRecentMessages?: number;
+  /** Check npm for a newer pai-acp on startup and auto-install it. Default: true.
+   *  Disable via `autoUpdate: false` or env `ACP_AUTO_UPDATE=0` to avoid all
+   *  network calls on startup. */
+  autoUpdate?: boolean;
   coreOverrides?: Partial<Config>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { makeDecompressTool } from "./decompress-tool.js";
 import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
 import { makeCommands } from "./commands.js";
-import { entriesToCoreMessages, coreOutToAgentMessages } from "./messages.js";
+import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT } from "./system-prompt.js";
 import { debug } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens } from "./tokens.js";
@@ -49,7 +49,7 @@ function wireCompactionDisable(pi: ExtensionAPI): void {
 function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("session_start", (_event, ctx) => {
     runtime.store.invalidate();
-    void checkForUpdate((msg) => {
+    void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
   });
@@ -63,12 +63,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const sid = ctx.sessionManager.getSessionId();
     const release = await runtime.acquireLock(sid);
     try {
-      const entries = ctx.sessionManager.buildContextEntries();
-      const coreMessages = entriesToCoreMessages(entries);
-      const state = await runtime.store.load(
-        ctx.sessionManager.getSessionFile() ?? undefined,
-        sid,
-      );
+      const { state, coreMessages, entries } = await runtime.stateFor(ctx);
       const config = runtime.configFor(ctx);
       const coveredIds = collectCoveredMessageIds(state);
       const tokenCount = estimateTokens(coreMessages, coveredIds);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionContext, SessionEntry } from "@earendil-works/pi-coding-agent";
 import {
   createCore,
   defaultCountTokens,
@@ -16,7 +16,7 @@ export interface AcpRuntime {
   adapter: AdapterConfig;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
-  stateFor(ctx: ExtensionContext): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages> }>;
+  stateFor(ctx: ExtensionContext): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
   save(state: CompressionState, ctx: ExtensionContext): Promise<void>;
   acquireLock(sid: string): Promise<() => void>;
 }
@@ -53,7 +53,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     const sm = ctx.sessionManager;
     const state = await store.load(sm.getSessionFile() ?? undefined, sm.getSessionId());
     const entries = sm.buildContextEntries();
-    return { state, coreMessages: entriesToCoreMessages(entries) };
+    return { state, coreMessages: entriesToCoreMessages(entries), entries };
   }
 
   async function save(state: CompressionState, ctx: ExtensionContext) {

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -2,7 +2,6 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens } from "acp-kernel";
-import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -36,8 +35,6 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
 
 async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
-  const coveredIds = collectCoveredMessageIds(state);
-  void estimateTokens(coreMessages, coveredIds);
 
   return buildStatusReport(state, coreMessages, defaultCountTokens, {
     scope: args.scope,

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,7 +1,3 @@
-const LT = "\x3c";
-const GT = "\x3e";
-const ACP_TAG_EXAMPLE = LT + 'acp tokens="2.1K" type="bash"' + GT + "m00175" + LT + "/acp" + GT;
-
 export const ACP_SYSTEM_PROMPT = `
 ACP context management
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,4 @@
-import type { CoreMessage } from "acp-kernel";
+import { defaultCountTokens, type CoreMessage } from "acp-kernel";
 
 export function collectCoveredMessageIds(state: { blocks: { active: boolean; effectiveMessageIds: string[] }[] }): Set<string> {
   const ids = new Set<string>();
@@ -10,11 +10,11 @@ export function collectCoveredMessageIds(state: { blocks: { active: boolean; eff
 }
 
 export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>): number {
-  let chars = 0;
+  let tokens = 0;
   for (const m of messages) {
     if (m.toolName === "compress") continue;
     if (coveredIds?.has(m.id)) continue;
-    chars += m.text?.length ?? 0;
+    tokens += defaultCountTokens(m.text ?? "");
   }
-  return Math.ceil(chars / 4);
+  return tokens;
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,13 +1,14 @@
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { debug } from "./log.js";
 
 declare const CURRENT_VERSION: string;
 
 const PACKAGE_NAME = "pai-acp";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
 const THROTTLE_FILE = `${process.env.HOME ?? ""}/.pi/agent/.pai-acp-update-check`;
 
@@ -79,6 +80,10 @@ async function findExtensionDir(): Promise<string | undefined> {
 }
 
 async function autoInstallLatest(latest: string): Promise<boolean> {
+  // Defense against a poisoned/MITM registry: only accept a strict semver,
+  // then pass args as an array to execFile (never via a shell string) so the
+  // version can never be interpreted as a command even if it slipped through.
+  if (!SEMVER_RE.test(latest)) return false;
   const extDir = await findExtensionDir();
   if (!extDir) return false;
   const npmDir = findNpmRoot(extDir);
@@ -86,14 +91,11 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
 
   try {
     const code = await new Promise<number>((resolve) => {
-      exec(
-        `npm install ${PACKAGE_NAME}@${latest} --silent --no-audit --no-fund`,
+      execFile(
+        "npm",
+        ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
         { cwd: npmDir, timeout: 60_000 },
-        (err) => {
-          if (!err) return resolve(0);
-          const exit = (err as NodeJS.ErrnoException & { code?: number }).code;
-          resolve(typeof exit === "number" ? exit : 1);
-        },
+        (err) => resolve(err ? 1 : 0),
       );
     });
     return code === 0;
@@ -106,10 +108,13 @@ export async function checkForUpdate(
   autoUpdate: boolean,
   notify?: (msg: string) => void,
 ): Promise<void> {
+  const envFlag = process.env.ACP_AUTO_UPDATE?.toLowerCase();
   if (
     !autoUpdate ||
-    process.env.ACP_AUTO_UPDATE === "0" ||
-    process.env.ACP_AUTO_UPDATE === "false"
+    envFlag === "0" ||
+    envFlag === "false" ||
+    envFlag === "no" ||
+    envFlag === "off"
   ) {
     return;
   }

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { exec } from "node:child_process";
 import { debug } from "./log.js";
 
 declare const CURRENT_VERSION: string;
@@ -26,8 +27,7 @@ function isNewer(latest: string, current: string): boolean {
 
 async function readLastCheck(): Promise<number> {
   try {
-    const fs = await import("node:fs/promises");
-    const data = await fs.readFile(THROTTLE_FILE, "utf-8");
+    const data = await readFile(THROTTLE_FILE, "utf-8");
     return parseInt(data.trim(), 10) || 0;
   } catch {
     return 0;
@@ -36,11 +36,8 @@ async function readLastCheck(): Promise<number> {
 
 async function writeLastCheck(timestamp: number): Promise<void> {
   try {
-    const fs = await import("node:fs/promises");
-    const path = await import("node:path");
-    const dir = path.dirname(THROTTLE_FILE);
-    await fs.mkdir(dir, { recursive: true });
-    await fs.writeFile(THROTTLE_FILE, String(timestamp), "utf-8");
+    await mkdir(dirname(THROTTLE_FILE), { recursive: true });
+    await writeFile(THROTTLE_FILE, String(timestamp), "utf-8");
   } catch {
     // best-effort
   }
@@ -88,26 +85,34 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
   if (!npmDir) return false;
 
   try {
-    const npmPkgPath = join(npmDir, "package.json");
-    const npmPkg = await readPackageJson(npmPkgPath);
-    if (npmPkg?.dependencies?.[PACKAGE_NAME]) {
-      npmPkg.dependencies[PACKAGE_NAME] = latest;
-      await writeFile(npmPkgPath, JSON.stringify(npmPkg, null, 2) + "\n");
-    }
-
-    const { exec } = await import("node:child_process");
-    await new Promise<void>((resolve) => {
-      exec("npm install --silent --no-audit --no-fund", { cwd: npmDir, timeout: 30_000 }, () => resolve());
+    const code = await new Promise<number>((resolve) => {
+      exec(
+        `npm install ${PACKAGE_NAME}@${latest} --silent --no-audit --no-fund`,
+        { cwd: npmDir, timeout: 60_000 },
+        (err) => {
+          if (!err) return resolve(0);
+          const exit = (err as NodeJS.ErrnoException & { code?: number }).code;
+          resolve(typeof exit === "number" ? exit : 1);
+        },
+      );
     });
-    return true;
+    return code === 0;
   } catch {
     return false;
   }
 }
 
 export async function checkForUpdate(
+  autoUpdate: boolean,
   notify?: (msg: string) => void,
 ): Promise<void> {
+  if (
+    !autoUpdate ||
+    process.env.ACP_AUTO_UPDATE === "0" ||
+    process.env.ACP_AUTO_UPDATE === "false"
+  ) {
+    return;
+  }
   const now = Date.now();
   const lastCheck = await readLastCheck();
   if (now - lastCheck < CHECK_INTERVAL_MS) return;

--- a/tests/decompress-cmd.test.ts
+++ b/tests/decompress-cmd.test.ts
@@ -1,0 +1,122 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) {
+      this.tools.push(tool);
+    },
+    registerCommand(name: string, options: any) {
+      this.commands.set(name, options);
+    },
+  };
+  return { api, handlers };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+// State persists to <sessionFile>.acp.json; clear stale state from prior runs.
+async function cleanState(sessionFile: string) {
+  await rm(`${sessionFile}.acp.json`, { force: true });
+}
+
+function fakeCtx(entries: any[], stateFile: string, notifies: string[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: (m: string) => notifies.push(m), confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+}
+
+// Full pipeline: context handler assigns refs → compress tool creates an active
+// block → /acp-decompress deactivates it and persists state.
+test("/acp-decompress deactivates an active block and reports restored count", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  const stateFile = "/tmp/pai-acp-decompress-it.session.json";
+  await cleanState(stateFile);
+  // acp-kernel refuses to compress ranges under 5000 chars; pad the target message.
+  const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+  const entries = [userMsg("e1", longText), userMsg("e2", "second message"), userMsg("e3", "third message")];
+  const notifies: string[] = [];
+  const ctx = fakeCtx(entries, stateFile, notifies);
+
+  // 1) Run the context handler so the kernel assigns refs (m00001..) and saves state.
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+
+  // 2) Compress the first message range to create an active block (b1).
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const compressRes = await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00001", summary: "This range contained the first user message which discussed the initial detailed context for the session." }] },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const compressText = (compressRes.content[0] as any).text as string;
+  assert.match(compressText, /1 block/, "compress created a block");
+
+  // 3) Run /acp-decompress b1.
+  notifies.length = 0;
+  const decompressCmd = api.commands.get("acp-decompress");
+  await decompressCmd.handler("b1", ctx);
+  assert.equal(notifies.length, 1);
+  assert.match(notifies[0]!, /Restored block b1: \d+ message/, "notify reports restored count");
+
+  // 4) Re-running on the same id now reports it is already inactive.
+  notifies.length = 0;
+  await decompressCmd.handler("b1", ctx);
+  assert.match(notifies[0]!, /already inactive/i, "second call sees inactive block");
+});
+
+test("/acp-decompress rejects invalid input with a usage message", async () => {
+  const { api } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  const notifies: string[] = [];
+  const ctx = fakeCtx([], "/tmp/pai-acp-decompress-invalid.session.json", notifies);
+  await cleanState("/tmp/pai-acp-decompress-invalid.session.json");
+  const decompressCmd = api.commands.get("acp-decompress");
+
+  // parseBlockIdArg accepts bare numbers ("3" -> "b3") and "b<N>"; only truly
+  // malformed input returns null.
+  for (const bad of ["", "   ", "xyz", "b", "abc123", "b-"]) {
+    notifies.length = 0;
+    await decompressCmd.handler(bad, ctx);
+    assert.equal(notifies.length, 1, `notifies for input ${JSON.stringify(bad)}`);
+    assert.match(notifies[0]!, /Usage:|Invalid|format/i, `usage message for ${JSON.stringify(bad)}`);
+  }
+});
+
+test("/acp-decompress reports not-found for a valid id with no matching block", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  const notifies: string[] = [];
+  const ctx = fakeCtx([userMsg("e1", "only message")], "/tmp/pai-acp-decompress-nf.session.json", notifies);
+  await cleanState("/tmp/pai-acp-decompress-nf.session.json");
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+
+  const decompressCmd = api.commands.get("acp-decompress");
+  await decompressCmd.handler("b99", ctx);
+  assert.match(notifies[0]!, /not found/i, "reports not-found for absent block");
+});

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { estimateTokens } from "../src/tokens.js";
+
+test("estimateTokens matches kernel defaultCountTokens (word-based, not chars/4)", () => {
+  const msgs = [
+    { id: "m1", role: "user", contentType: "text", text: "hello world foo bar baz" },
+  ];
+  // defaultCountTokens counts ascii words: 5 — chars/4 would give 2
+  assert.equal(estimateTokens(msgs), 5);
+});
+
+test("estimateTokens is consistent with kernel counter for CJK (each char = 1 token)", () => {
+  const zh = "这是一个中文测试";
+  const msgs = [{ id: "m1", role: "user", contentType: "text", text: zh }];
+  // 8 CJK chars → 8 tokens under defaultCountTokens; chars/4 would give 2
+  assert.equal(estimateTokens(msgs), 8);
+});
+
+test("estimateTokens skips compress tool calls", () => {
+  const msgs = [
+    { id: "m1", role: "user", contentType: "text", text: "alpha beta gamma" },
+    { id: "m2", role: "assistant", contentType: "tool-call", toolName: "compress", text: "ignored payload here" },
+    { id: "m3", role: "user", contentType: "text", text: "delta epsilon" },
+  ];
+  // m1 (3) + skip m2 (compress) + m3 (2) = 5
+  assert.equal(estimateTokens(msgs), 5);
+});
+
+test("estimateTokens skips covered (already-compressed) message ids", () => {
+  const msgs = [
+    { id: "m1", role: "user", contentType: "text", text: "alpha beta gamma" },
+    { id: "m3", role: "user", contentType: "text", text: "delta epsilon" },
+  ];
+  const covered = new Set(["m3"]);
+  // m1 (3) + skip m3 (covered) = 3
+  assert.equal(estimateTokens(msgs, covered), 3);
+});

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { checkForUpdate } from "../src/update.js";
+
+// Opt-out must short-circuit BEFORE any network/filesystem touch. We assert this
+// by making global fetch throw if it is ever reached.
+function withFetchGuard<T>(fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (() => {
+    throw new Error("fetch must not be called when auto-update is disabled");
+  }) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test("checkForUpdate is a no-op when autoUpdate=false (no fetch)", async () => {
+  delete process.env.ACP_AUTO_UPDATE;
+  await withFetchGuard(() => checkForUpdate(false));
+});
+
+test("checkForUpdate is a no-op for every opt-out env value, case-insensitive (no fetch)", async () => {
+  const opts = ["0", "false", "no", "off", "FALSE", "No", "Off", "FALSE", "0"];
+  for (const v of opts) {
+    process.env.ACP_AUTO_UPDATE = v;
+    await withFetchGuard(() => checkForUpdate(true));
+  }
+  delete process.env.ACP_AUTO_UPDATE;
+});


### PR DESCRIPTION
Addresses all findings from the project review (including acp-kernel integration).

## Token counting (P0)
`estimateTokens` switched from `chars/4` to acp-kernel's `defaultCountTokens`. The old estimator diverged from the kernel's own counter — **Chinese under-counted 3.4×, code over-counted 2.8×** — so nudge / emergency-truncate thresholds fired on the wrong usage ratio. The kernel already calls `defaultCountTokens` internally every turn (9+ sites), so there is no new overhead.

**Performance verified** (the concern raised in review):

| input | ~tokens | `defaultCountTokens` |
|-------|---------|----------------------|
| 10 MB | 2.1M (max real window is ~2M) | 89 ms |
| 100 MB | 21M | 1.06 s |
| 500 MB | 104M | 8.4 s |

Realistic model windows (≤2M tokens ≈ 8 MB) cost ~70 ms once per turn — negligible next to the LLM call. Added `tests/tokens.test.ts` (CJK + coverage-skip cases).

## `/acp-decompress` command (P0)
Now performs a **real** decompression (`deactivateBlock` + `runtime.save` + preview), matching the decompress tool and the opencode-acp pattern. Previously it only read the summary via `core.decompress` (a pure lookup) and never mutated state.

## Auto-update opt-out (P1)
New `AdapterConfig.autoUpdate` (default `true`) and env `ACP_AUTO_UPDATE=0` disable all startup network calls.

## Safer auto-install (P1)
Dropped the silent host `package.json` rewrite; now runs scoped `npm install pai-acp@<ver>`, checks the npm exit code (only reports success on `0`), timeout 30s → 60s. No longer re-installs unrelated deps or falsely reports success on failure.

## Cleanup (P2)
- Removed dead `ACP_TAG_EXAMPLE` / `LT` / `GT` constants (system prompt content kept intact).
- Removed discarded `void estimateTokens(...)` in status-tool (`buildStatusReport` computes tokens itself).
- `update.ts`: removed redundant dynamic imports of `fs/promises` + `path`.
- `index.ts` reuses `runtime.stateFor` (now also returns `entries`).
- Pinned `acp-kernel` to exact `0.0.6` (0.x caret only locks `0.0.x`).

## Quality
typecheck ✅ · 20/20 tests ✅ · build ✅ (`dist/index.js` 126 KB)