### PR TITLE
chore: gitignore acp state files + minor review polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+*.acp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ pi-acp/
 │   ├── update.ts             # Auto-update: checks npm, auto-installs latest
 │   ├── tokens.ts             # Token estimation utilities
 │   └── log.ts                # Debug logging
-├── tests/                    # 16 tests
+├── tests/                    # 32 tests
 ├── tsup.config.ts
 └── package.json
 ```

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -3,7 +3,7 @@ ACP context management
 
 ACP TAGS
 
-Each user and tool message has an <acp tokens="2.1K" type="bash">m00175</acp> tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g., m00005) inside compress calls — never the XML wrapper.
+Each user and tool message has an \x3cacp tokens="2.1K" type="bash"\x3em00175\x3c/acp\x3e tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g., m00005) inside compress calls — never the XML wrapper.
 
 COMPRESSION SUMMARIES IN CONTEXT
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -108,7 +108,7 @@ export async function checkForUpdate(
   autoUpdate: boolean,
   notify?: (msg: string) => void,
 ): Promise<void> {
-  const envFlag = process.env.ACP_AUTO_UPDATE?.toLowerCase();
+  const envFlag = process.env.ACP_AUTO_UPDATE?.trim().toLowerCase();
   if (
     !autoUpdate ||
     envFlag === "0" ||

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -20,8 +20,16 @@ test("checkForUpdate is a no-op when autoUpdate=false (no fetch)", async () => {
 });
 
 test("checkForUpdate is a no-op for every opt-out env value, case-insensitive (no fetch)", async () => {
-  const opts = ["0", "false", "no", "off", "FALSE", "No", "Off", "FALSE", "0"];
+  const opts = ["0", "false", "no", "off", "FALSE", "No", "Off"];
   for (const v of opts) {
+    process.env.ACP_AUTO_UPDATE = v;
+    await withFetchGuard(() => checkForUpdate(true));
+  }
+  delete process.env.ACP_AUTO_UPDATE;
+});
+
+test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matching (no fetch)", async () => {
+  for (const v of [" false ", "\t no\t", "  off "]) {
     process.env.ACP_AUTO_UPDATE = v;
     await withFetchGuard(() => checkForUpdate(true));
   }


### PR DESCRIPTION
> **Stacked PR** — based on #12 (`2026-08-02_review-fixes`). After #12 merges, rebase this onto `master` (or change the base here to `master`).

Follow-up to the second review round: the `.gitignore` root-cause fix plus the Minor/Nit items that touch code introduced by #12.

## Changes

- **`.gitignore`**: ignore `*.acp.json` — runtime session-state files (`{"blocks":[],"messageRefs":{...}}`) were showing as untracked in every working tree. This is the root-cause fix for the "uncommitted files" question.
- **`src/update.ts`**: `trim()` `ACP_AUTO_UPDATE` before matching, so surrounding whitespace (`"false "`, `" off "`) no longer silently defeats opt-out (which would still send a network request and may auto-install).
- **`tests/update.test.ts`**: dedup the opt-out array (had repeated `"FALSE"`/`"0"`); add a case covering surrounding-whitespace values.
- **`src/system-prompt.ts`**: hex-escape the literal `<acp>` example tag (`\x3c`/`\x3e`) to comply with AGENTS.md ("hex escapes for any `<acp>` XML in source files"). Runtime output is unchanged (verified: the prompt string still renders `<acp tokens="2.1K" type="bash">m00175</acp>`).
- **`AGENTS.md`**: tests count `16` → `32`.

## Verification

- typecheck ✅
- **32 tests pass** (added one covering whitespace trimming)
- build ✅