### PR TITLE
chore: gitignore acp state files + minor review polish (into master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.log
 .DS_Store
+*.acp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ pi-acp/
 │   ├── update.ts             # Auto-update: checks npm, auto-installs latest
 │   ├── tokens.ts             # Token estimation utilities
 │   └── log.ts                # Debug logging
-├── tests/                    # 16 tests
+├── tests/                    # 32 tests
 ├── tsup.config.ts
 └── package.json
 ```

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -3,7 +3,7 @@ ACP context management
 
 ACP TAGS
 
-Each user and tool message has an <acp tokens="2.1K" type="bash">m00175</acp> tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g., m00005) inside compress calls — never the XML wrapper.
+Each user and tool message has an \x3cacp tokens="2.1K" type="bash"\x3em00175\x3c/acp\x3e tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g., m00005) inside compress calls — never the XML wrapper.
 
 COMPRESSION SUMMARIES IN CONTEXT
 

--- a/src/update.ts
+++ b/src/update.ts
@@ -108,7 +108,7 @@ export async function checkForUpdate(
   autoUpdate: boolean,
   notify?: (msg: string) => void,
 ): Promise<void> {
-  const envFlag = process.env.ACP_AUTO_UPDATE?.toLowerCase();
+  const envFlag = process.env.ACP_AUTO_UPDATE?.trim().toLowerCase();
   if (
     !autoUpdate ||
     envFlag === "0" ||

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -20,8 +20,16 @@ test("checkForUpdate is a no-op when autoUpdate=false (no fetch)", async () => {
 });
 
 test("checkForUpdate is a no-op for every opt-out env value, case-insensitive (no fetch)", async () => {
-  const opts = ["0", "false", "no", "off", "FALSE", "No", "Off", "FALSE", "0"];
+  const opts = ["0", "false", "no", "off", "FALSE", "No", "Off"];
   for (const v of opts) {
+    process.env.ACP_AUTO_UPDATE = v;
+    await withFetchGuard(() => checkForUpdate(true));
+  }
+  delete process.env.ACP_AUTO_UPDATE;
+});
+
+test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matching (no fetch)", async () => {
+  for (const v of [" false ", "\t no\t", "  off "]) {
     process.env.ACP_AUTO_UPDATE = v;
     await withFetchGuard(() => checkForUpdate(true));
   }


### PR DESCRIPTION
> Follow-up to #12. Carries the chore/nit changes from #13 onto `master`.

#13 was merged into the intermediate branch `2026-08-02_review-fixes` (it was a stacked PR on top of #12). After #12 landed on `master`, this intermediate branch never got re-merged into `master` — so #13's changes are currently sitting on the branch, not on `master`.

This PR closes that gap. The diff vs `master` is exactly the 5 chore files (no logic changes):

- `.gitignore`: ignore `*.acp.json` (runtime session-state files were showing as untracked in every worktree — root-cause fix).
- `src/update.ts`: `trim()` `ACP_AUTO_UPDATE` so surrounding whitespace (`"false "`) doesn't silently defeat opt-out.
- `tests/update.test.ts`: dedup the opt-out array + add a whitespace-trim case.
- `src/system-prompt.ts`: hex-escape the literal `<acp>` example tag (`\x3c`/`\x3e`) per AGENTS.md; runtime output unchanged.
- `AGENTS.md`: tests count `16` → `32`.

Verified: typecheck ✅ · 32/32 tests pass ✅ · build ✅