### PR TITLE
release: v0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "0.0.6",
+        "acp-kernel": "0.0.7",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.6.tgz",
-      "integrity": "sha512-KOjPLIKRRIqJgdT9trMyRDHIOYtAy+CvIRtjuoLxyEez/LRBwYsR7XTjnPYsdjCYYhGu8039UrPhcXqjt2vsJA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.7.tgz",
+      "integrity": "sha512-hhkU/1n0oHtRelSFr3FM0suu+Guo8/z+pJ0l/EPowoG58kN2vb1tk+uq8cFiVk94K8970qNsUwmrInGtwgYwLg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.6",
+    "acp-kernel": "0.0.7",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Release v0.1.5 (patch)

Picks up **acp-kernel 0.0.7**, which removes the destructive mechanical `merge-blocks` pipeline node.

### The bug this fixes
`merge-blocks` destroyed high-quality model-written T1 summaries: once N old-gen summaries exceeded `merge.maxSummaryLength`, it kept only the first line (a `## title`) of each, replacing detailed technical content with a ~100-char skeleton titled `Batch merge cleanup` + a `[merged and truncated by batch cleanup]` marker. With acp-kernel 0.0.7 the node is gone; tier promotion is left to model-driven distillation (nudge → `compress`).

### Changes
- `acp-kernel` **0.0.6 → 0.0.7** (exact pin)
- `package-lock.json` regenerated (CI `npm ci` requires sync)
- version `0.1.4 → 0.1.5`

### Verification
- typecheck ✅
- **32 tests pass** ✅
- build ✅ `dist/index.js` 122.5KB (down from 126KB)
- **dist verified clean**: `mergeMarkedBlocks` / `merge-blocks` / `Batch merge cleanup` / `merged and truncated` → **0 hits each** (down from 2/1/1/1)

### Merge → publish
CI (`release.yml`) auto-tags `v0.1.5` + publishes `pai-acp@0.1.5` to npm on merge of this `*_release-v*` branch.