### PR TITLE
fix: nudge rendered blockId with double prefix (bb3, not b3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ function nudgeMessage(nudge: NudgeDecision, blocks: CompressionBlock[]): AgentMe
       tierCounts[t] = (tierCounts[t] || 0) + 1;
     }
     const tierStr = Object.keys(tierCounts).map(Number).sort().map((t) => `T${t}:${tierCounts[t]}`).join(" ");
-    const ids = blocks.slice(0, 10).map((b) => `b${b.blockId}`).join(", ");
+    const ids = blocks.slice(0, 10).map((b) => b.blockId).join(", ");
     const extra = blocks.length > 10 ? ` (+${blocks.length - 10} more)` : "";
     lines.push("");
     lines.push(`Compressed blocks: ${blocks.length} active (${tierStr}) — ${fmt(totalSummary)} summary, ${fmt(totalCompressed)} original compressed. Blocks: ${ids}${extra}.`);


### PR DESCRIPTION
## 问题

\`nudgeMessage\`（\`src/index.ts:152\`）渲染 \`\\\`b\\\${b.blockId}\\\`\`，但 acp-kernel 的 \`allocateBlockId\` 返回值**已含 "b" 前缀**（blockId === \`"b3"\`），结果 tier-nudge 显示：

\`\`\`
Blocks: bb1, bb2, bb3, ...
\`\`\`

模型若照抄调用 \`decompress({blockId: "bb3"})\` → \`parseBlockIdArg("bb3")\` 两个正则都不匹配 → 返回 \`null\` → "Invalid blockId"。nudge 给的示例 id 直接不可用。

## 修复

去掉多余前缀，直接渲染 \`b.blockId\`：

\`\`\`diff
- const ids = blocks.slice(0, 10).map((b) => `b${b.blockId}`).join(", ");
+ const ids = blocks.slice(0, 10).map((b) => b.blockId).join(", ");
\`\`\`

一行改动。

## 测试说明

typecheck ✅，但 32 测试里 1 个失败（\`tests/decompress-cmd.test.ts\` 的 "deactivates an active block"）。**该失败与本修复无关**：是 acp-kernel PR#5（硬保护最近 N 条）让这个 3 消息的测试场景里 m00001 落入最后 5 条保护区，compress 被正确拒绝。需要单独更新该测试场景（构造 >5 条消息），会在另一个 PR 处理。

-1/+1，单文件。