### PR TITLE
fix: inline typebox into dist (ACP tags/nudge silently disappeared)

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
     "@earendil-works/pi-coding-agent",
     "@earendil-works/pi-ai",
     "@earendil-works/pi-agent-core",
-    "typebox",
   ],
+  noExternal: ["typebox"],
 });


### PR DESCRIPTION
## 问题（Blocker）

ACP 的标签注入和 nudge 静默消失了——本会话从头到尾没有任何 \`<acp>\` 标签、没有 nudge，但 \`acp_status\` 工具照常工作。

## 根因

\`tsup.config.ts\` 把 \`typebox\` 列在 \`external\`，导致 \`dist/index.js\` 保留了 4 处运行时 \`import { Type } from \"typebox\"\`。但：

1. pai-acp 的 \`package.json\` **没有任何 dependencies**（typebox 是 \`@earendil-works/pi-coding-agent\` 的间接依赖）
2. pi 的安装布局（\`~/.pi/agent/npm/node_modules/\`）**任何层级都没有 typebox**

结果：session 启动时 \`import \"typebox\"\` 抛 \`ERR_MODULE_NOT_FOUND\`，扩展的模块求值崩溃，pi 静默丢弃它 → \`context\` 事件 handler 没注册 → **无标签注入、无 nudge**。\`acp_status\` 工具通过另一条加载路径侥幸能用，造成\"扩展加载了但功能没了\"的迷惑表象。

## 修复

从 \`external\` 移除 \`typebox\`，加入 \`noExternal\` 强制 esbuild 内联（typebox 是 ESM-only 且无 \`main\`，这是 tsup 默认不当 external 的原因）。

dist 从 123KB → 330KB（内联了 typebox 运行时）。验证：dist 里 \`from \"typebox\"\` **0 残留**，且在**完全没有 typebox** 的环境下能干净加载（context handler 注册、4 工具 + 4 命令）。

## 影响

Blocker 级回归：每个在 typebox 不可解析的 pi 布局下运行的 pai-acp 安装都有静默的 context-management 失效。很可能在工具 schema 开始 import Type 时引入。

typecheck ✅ · 32/32 tests ✅

-1/+1，单文件。