### PR TITLE
feat: show nudge + full compressible ranges in acp_status / /acp

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -153,12 +153,9 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   if (ranges.length > 0) {
     lines.push("");
     lines.push(`Compressible Ranges (${ranges.length}):`);
-    for (const r of ranges.slice(0, 8)) {
+    for (const r of ranges) {
       const tools = r.toolPct > 0 ? ` (${Math.round(r.toolPct)}% tools)` : "";
       lines.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
-    }
-    if (ranges.length > 8) {
-      lines.push(`  ...and ${ranges.length - 8} more`);
     }
   }
 
@@ -167,7 +164,9 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
     lines.push(`Blocks: ${activeBlocksList.length} active / ${totalBlocksList.length} total (${fmtTokens(state.stats.tokensCompressed)} tokens compressed)`);
     for (const b of activeBlocksList) {
       const topic = b.topic ? `: ${b.topic}` : "";
-      lines.push(`  [${b.blockId}] T${b.tier} ${fmtTokens(Math.ceil((b.summary || "").length / 4))}tok${topic}`);
+      const summaryTok = defaultCountTokens(b.summary || "");
+      const origTok = b.compressedTokens > 0 ? b.compressedTokens : summaryTok;
+      lines.push(`  [${b.blockId}] T${b.tier} ${fmtTokens(origTok)}\u2192${fmtTokens(summaryTok)}${topic}`);
     }
   } else if (totalBlocksList.length > 0) {
     lines.push("");

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -2,6 +2,11 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens } from "acp-kernel";
+import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
+
+function fmtTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
+}
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -36,11 +41,42 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
 async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
 
-  return buildStatusReport(state, coreMessages, defaultCountTokens, {
+  const base = buildStatusReport(state, coreMessages, defaultCountTokens, {
     scope: args.scope,
     view: args.view,
     tool: args.tool,
     sort: args.sort,
     limit: args.limit,
   });
+
+  // Overview mode additionally surfaces the nudge decision and compressible
+  // ranges — the same info the /acp slash command shows. Drill-down modes
+  // (scope: compressed/uncompressed) return the base report as-is.
+  if (args.scope) return base;
+
+  const config = runtime.configFor(ctx);
+  const coveredIds = collectCoveredMessageIds(state);
+  const tokenCount = estimateTokens(coreMessages, coveredIds);
+  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
+  const nudge = turn.nudge;
+  const ranges = nudge?.compressibleRanges ?? [];
+
+  const extra: string[] = [];
+  if (nudge) {
+    extra.push("");
+    extra.push(
+      nudge.shouldInject
+        ? `Nudge: ACTIVE — ${nudge.reason}`
+        : `Nudge: idle — ${nudge.reason}`,
+    );
+  }
+  if (ranges.length > 0) {
+    extra.push("");
+    extra.push(`Compressible Ranges (${ranges.length}):`);
+    for (const r of ranges) {
+      const tools = r.toolPct > 0 ? ` (${Math.round(r.toolPct)}% tools)` : "";
+      extra.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
+    }
+  }
+  return extra.length > 0 ? `${base}\n${extra.join("\n")}` : base;
 }


### PR DESCRIPTION
## 背景

\`acp_status\` 工具的 overview 模式只调了 \`buildStatusReport\`（token 占比 + 已压缩块），**没调 processTurn**，所以漏掉了它自己 prompt 描述和系统提示承诺的 nudge 决策与 compressible ranges。\`/acp\` slash 命令显示这些，但模型可见的工具不显示——两个视图不一致。

另外 \`/acp\` 命令有两个显示问题：compressible ranges 截断到 8 条（"...and N more"）；block 只显示 summary 大小（用 chars/4 旧估算），看不出压缩收益。

## 修复

- **status-tool.ts**：overview 模式额外跑 \`processTurn\`，追加 \`Nudge: ACTIVE|idle — <reason>\` 行和完整 \`Compressible Ranges\` 列表。drill-down 模式（scope: compressed/uncompressed）不变。
- **commands.ts**：显示**全部** compressible ranges（不 slice/截断）；block 渲染为 \`compressedTokens→summaryTokens\`（用 defaultCountTokens，不再 chars/4）。

typecheck ✅ · 32/32 tests ✅

+41/-6，2 文件。