### PR TITLE
feat: config-file debug toggle + print nudges to terminal (model-invisible)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,13 @@ export interface AdapterConfig {
    *  Disable via `autoUpdate: false` or env `ACP_AUTO_UPDATE=0` to avoid all
    *  network calls on startup. */
   autoUpdate?: boolean;
+  /** Write ACP debug events to the debug log file (default ~/.pi/acp-debug.log).
+   *  Default: false (or env ACP_DEBUG=1/true). */
+  debug?: boolean;
+  /** Print nudge/compression notices to the user terminal via ctx.ui.notify
+   *  instead of injecting them into the model's context. Default: true.
+   *  When false, nudges are injected as a context message the model can see. */
+  terminalNudge?: boolean;
   coreOverrides?: Partial<Config>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,10 @@ import { makeStatusTool } from "./status-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT } from "./system-prompt.js";
-import { debug } from "./log.js";
+import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
+import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -47,8 +48,18 @@ function wireCompactionDisable(pi: ExtensionAPI): void {
 }
 
 function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
-  pi.on("session_start", (_event, ctx) => {
+  pi.on("session_start", async (_event, ctx) => {
     runtime.store.invalidate();
+    // Load user config (~/.pi/acp.json + project .pi/acp.json) and apply it so
+    // debug/terminalNudge/autoUpdate/modelContextLimit are runtime-configurable
+    // without env vars or reinstalling.
+    try {
+      const user = await loadUserConfig(ctx.cwd);
+      runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+      if (runtime.adapter.debug === true) setDebugEnabled(true);
+    } catch {
+      // best-effort — fall back to factory/env config
+    }
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
@@ -100,11 +111,8 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 
     const originalById = collectOriginals(entries);
     const rebuilt = coreOutToAgentMessages(turn.messages, originalById);
-    const out = turn.nudge?.shouldInject ? [...rebuilt, nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active))] : rebuilt;
+    const terminalNudge = runtime.adapter.terminalNudge ?? true;
 
-    // Always return the transformed array: every message needs its [mNNNNN] ref
-    // tag applied, so there is no meaningful "no change" case to short-circuit.
-      debug.event("context-out", { outMsgs: out.length, injected: turn.nudge?.shouldInject ?? false });
     if (turn.nudge?.shouldInject) {
       const rendered = renderNudgeText(turn.nudge);
       const lines = [rendered.text];
@@ -112,9 +120,23 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       if (top) {
         lines.push("", `Example: compress({ content: [{ startId: "${top.startRef}", endId: "${top.endRef}", summary: "..." }] })`);
       }
-      debug.event("nudge-injected", { sid: ctx.sessionManager.getSessionId(), voice: rendered.voice, text: lines.join("\n") });
+      const text = lines.join("\n");
+      if (terminalNudge) {
+        // Print to the user terminal only — the model never sees this. Mirrors
+        // opencode-acp's ignored-part injection: surface the nudge without
+        // spending model context on it.
+        if (ctx.hasUI) ctx.ui.notify(text);
+      } else {
+        // Legacy: inject as a context message the model can act on.
+        rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active)));
+      }
+      debug.event("nudge-injected", { sid: ctx.sessionManager.getSessionId(), voice: rendered.voice, channel: terminalNudge ? "terminal" : "context", text });
     }
-    return { messages: out };
+
+    // Always return the transformed array: every message needs its [mNNNNN] ref
+    // tag applied, so there is no meaningful "no change" case to short-circuit.
+    debug.event("context-out", { outMsgs: rebuilt.length, injected: turn.nudge?.shouldInject ?? false, channel: turn.nudge?.shouldInject ? (terminalNudge ? "terminal" : "context") : "none" });
+    return { messages: rebuilt };
     } finally {
       release();
     }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,13 +1,24 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
-const DEBUG = process.env.ACP_DEBUG === "1" || process.env.ACP_DEBUG === "true";
+const ENV_DEBUG = process.env.ACP_DEBUG === "1" || process.env.ACP_DEBUG === "true";
 const LOG_FILE = process.env.ACP_LOG_FILE ?? path.join(process.env.HOME ?? "/tmp", ".pi", "acp-debug.log");
 
+let runtimeDebug: boolean | null = null;
 let initialized = false;
 
+/** Toggle debug at runtime from config (config.debug takes precedence over the
+ *  env var when set). Called once during session_start. */
+export function setDebugEnabled(enabled: boolean): void {
+  runtimeDebug = enabled;
+}
+
+function debugOn(): boolean {
+  return runtimeDebug ?? ENV_DEBUG;
+}
+
 async function write(line: string): Promise<void> {
-  if (!DEBUG) return;
+  if (!debugOn()) return;
   if (!initialized) {
     initialized = true;
     await fs.mkdir(path.dirname(LOG_FILE), { recursive: true }).catch(() => {});
@@ -17,13 +28,13 @@ async function write(line: string): Promise<void> {
 
 export const debug = {
   get enabled(): boolean {
-    return DEBUG;
+    return debugOn();
   },
   get logFile(): string {
     return LOG_FILE;
   },
   event(scope: string, fields: Record<string, unknown>): void {
-    if (!DEBUG) return;
+    if (!debugOn()) return;
     const ts = new Date().toISOString();
     const body = Object.entries(fields)
       .map(([k, v]) => `${k}=${fmt(v)}`)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -14,6 +14,7 @@ export interface AcpRuntime {
   core: CompressionCore;
   store: SessionStateStore;
   adapter: AdapterConfig;
+  setAdapter(adapter: AdapterConfig): void;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
   stateFor(ctx: ExtensionContext): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
@@ -25,6 +26,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const core = createCore({ countTokens: defaultCountTokens });
   const store = new SessionStateStore();
   const locks = new Map<string, Promise<void>>();
+  let adapterRef = adapter;
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -46,7 +48,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   }
 
   function configFor(ctx: ExtensionContext): Config {
-    return resolveConfig(adapter, liveContextLimit(ctx));
+    return resolveConfig(adapterRef, liveContextLimit(ctx));
   }
 
   async function stateFor(ctx: ExtensionContext) {
@@ -61,5 +63,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, adapter, liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, adapter: adapterRef, setAdapter: (a) => { adapterRef = a; }, liveContextLimit, configFor, stateFor, save, acquireLock };
 }

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import type { AdapterConfig } from "./config.js";
+import { debug } from "./log.js";
+
+/** User-facing config keys (subset of AdapterConfig). Loaded from
+ *  ~/.<CONFIG_DIR_NAME>/acp.json (global) and <cwd>/.<CONFIG_DIR_NAME>/acp.json
+ *  (project-local overrides project-global). Project wins over global. */
+export interface UserAcpConfig {
+  debug?: boolean;
+  terminalNudge?: boolean;
+  autoUpdate?: boolean;
+  modelContextLimit?: number;
+}
+
+/** Read global + project acp.json, project overrides global. Returns {} on any
+ *  error (missing file, bad JSON) — never throws. */
+export async function loadUserConfig(cwd: string): Promise<UserAcpConfig> {
+  const home = process.env.HOME ?? "";
+  const merged: UserAcpConfig = {};
+  for (const base of [join(home, CONFIG_DIR_NAME), join(cwd, CONFIG_DIR_NAME)]) {
+    const file = join(base, "acp.json");
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        Object.assign(merged, pickKnown(parsed));
+        debug.event("config-loaded", { file });
+      }
+    } catch {
+      // missing or unreadable — skip
+    }
+  }
+  return merged;
+}
+
+function join(... parts: string[]): string {
+  return path.join(...parts);
+}
+
+const KNOWN = new Set(["debug", "terminalNudge", "autoUpdate", "modelContextLimit"]);
+
+function pickKnown(parsed: Record<string, unknown>): UserAcpConfig {
+  const out: UserAcpConfig = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (KNOWN.has(k)) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
+/** Merge user config onto an adapter config: user config wins for the keys it
+ *  sets. Used at session_start to apply runtime-discovered config. */
+export function applyUserConfig(adapter: AdapterConfig, user: UserAcpConfig): AdapterConfig {
+  return {
+    ...adapter,
+    ...user,
+    // coreOverrides / protectedTools / preserveRecentMessages are not overridable
+    // from acp.json (keep them from the factory config).
+    coreOverrides: adapter.coreOverrides,
+    protectedTools: adapter.protectedTools,
+    preserveRecentMessages: adapter.preserveRecentMessages,
+  };
+}


### PR DESCRIPTION
## 两个改动

### 1. 配置文件开 debug（不用环境变量）
- 新增 \`AdapterConfig.debug\` + \`src/user-config.ts\`：session_start 时加载 \`~/.pi/acp.json\`（全局）和 \`<cwd>/.pi/acp.json\`（项目覆盖全局）。已知键：\`debug\`、\`terminalNudge\`、\`autoUpdate\`、\`modelContextLimit\`。
- \`log.ts\`：\`setDebugEnabled()\` 运行时开关；config.debug 设了就覆盖 \`ACP_DEBUG\` 环境变量。
- \`runtime.setAdapter()\` 应用加载的配置，无需重装即生效。

### 2. nudge 默认打印到终端（模型不可见）
- \`AdapterConfig.terminalNudge\`（默认 true）：nudge 触发时通过 \`ctx.ui.notify\` 打印，**用户可见**，但**不加入 context 事件返回的 messages**——模型看不到。对齐 opencode-acp 的 ignored-part 注入（呈现提示而不消耗模型上下文）。
- 设 \`terminalNudge: false\` 恢复旧行为（注入为模型可见的 context 消息）。

### 配置示例
\`\`\`json
// ~/.pi/acp.json
{ "debug": true, "terminalNudge": true }
\`\`\`

## 任务①手动压缩验证
已在本会话验证 compress 工具正常工作（m00207-m00242 压缩成功，回收 4.2K，1 block）。

typecheck ✅ · 32/32 tests ✅

+120/-14，5 文件（新增 src/user-config.ts）。