### PR TITLE
feat: use pi's real context usage instead of chars/4 estimate for nudge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,14 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const { state, coreMessages, entries } = await runtime.stateFor(ctx);
       const config = runtime.configFor(ctx);
       const coveredIds = collectCoveredMessageIds(state);
-      const tokenCount = estimateTokens(coreMessages, coveredIds);
+      // Prefer pi's real token count (anchored on provider usage) over our
+      // chars/4 estimate — it includes the system prompt, tool schemas, and
+      // trailing messages pi has not yet received a usage for. This is what the
+      // footer percentage reflects, so nudge usage/growth will match what the
+      // user sees.
+      const realUsage = ctx.getContextUsage?.();
+      const estimated = estimateTokens(coreMessages, coveredIds);
+      const tokenCount = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : estimated;
 
       debug.event("context-in", {
         sid,
@@ -85,6 +92,9 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         entries: entries.length,
         coreMsgs: coreMessages.length,
         tokenCount,
+        estimatedTokens: estimated,
+        realTokens: realUsage?.tokens ?? null,
+        realPercent: realUsage?.percent ?? null,
         limit: config.modelContextLimit,
         blocksBefore: state.blocks.length,
         activeBefore: state.blocks.filter((b) => b.active).length,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -43,6 +43,10 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   }
 
   function liveContextLimit(ctx: ExtensionContext): number {
+    // Prefer pi's reported context window (matches what the footer shows) over
+    // ctx.model.contextWindow, which can be stale or unset for some providers.
+    const usage = ctx.getContextUsage?.();
+    if (usage?.contextWindow && usage.contextWindow > 0) return usage.contextWindow;
     const m = ctx.model as { contextWindow?: number } | undefined;
     return m?.contextWindow ?? 0;
   }
@@ -63,5 +67,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, adapter: adapterRef, setAdapter: (a) => { adapterRef = a; }, liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, liveContextLimit, configFor, stateFor, save, acquireLock };
 }


### PR DESCRIPTION
## 问题
pai-acp 的 tokenCount 用 estimateTokens(可见消息 text, chars/4) 估算,漏算了 system prompt + tool schemas,且 chars/4 对代码符号低估。实测: **pai-acp 报 2% (tokenCount=22K) vs pi 实际 24% (~240K),差 10 倍** → growth 永远很小 → nudge 不触发。

## 修复
用 pi 暴露的 \`ctx.getContextUsage()\` (返回 \`{tokens, contextWindow, percent}\`,基于真实 provider usage) 替代 chars/4 估算:

- **tokenCount**: 优先 \`realUsage.tokens\`,fallback estimateTokens(usage 为 null 时,如刚 compaction 后)
- **modelContextLimit**: 优先 \`realUsage.contextWindow\`,比 \`ctx.model.contextWindow\` 更可靠(部分 provider 后者失效)

这正是 pi footer 百分比的数据源,nudge 的 usage/growth 将与用户所见一致。

## 验证
context-in debug 现在同时记录 \`tokenCount\` / \`estimatedTokens\` / \`realTokens\` / \`realPercent\`,可在 debug log 直观对比修复前后。

typecheck ✅ · 32/32 tests ✅

## 配套
依赖 acp-kernel PR#9 (defaultCountTokens 修复符号/数字低估)。两个修复叠加后,estimateTokens fallback 也会更准。