### PR TITLE
fix: gate tier/growth nudges to once per turn (stop terminal spam)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT } from "./system-prompt.js";
 import { debug, setDebugEnabled } from "./log.js";
-import { collectCoveredMessageIds, estimateTokens } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
@@ -124,23 +124,36 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const terminalNudge = runtime.adapter.terminalNudge ?? true;
 
     if (turn.nudge?.shouldInject) {
-      const rendered = renderNudgeText(turn.nudge);
-      const lines = [rendered.text];
-      const top = [...turn.nudge.compressibleRanges].sort((a, b) => b.tokens - a.tokens)[0];
-      if (top) {
-        lines.push("", `Example: compress({ content: [{ startId: "${top.startRef}", endId: "${top.endRef}", summary: "..." }] })`);
-      }
-      const text = lines.join("\n");
-      if (terminalNudge) {
-        // Print to the user terminal only — the model never sees this. Mirrors
-        // opencode-acp's ignored-part injection: surface the nudge without
-        // spending model context on it.
-        if (ctx.hasUI) ctx.ui.notify(text);
+      // Emergency nudges (usage >= 80%) print every time — they are overflow
+      // warnings the user must always see. Other nudges (tier distillation,
+      // growth) print at most once per turn: pi fires the context event
+      // multiple times per assistant reply (streaming/tool loop), and without
+      // this gate a tier-2 nudge would spam the terminal on every event.
+      const emergency = turn.nudge.breakdown?.emergencyOverride === 1;
+      const turnKey = lastUserMessageId(entries) ?? sid;
+      const alreadyShown = !emergency && runtime.nudgeShownFor(turnKey);
+      if (!alreadyShown) {
+        const rendered = renderNudgeText(turn.nudge);
+        const lines = [rendered.text];
+        const top = [...turn.nudge.compressibleRanges].sort((a, b) => b.tokens - a.tokens)[0];
+        if (top) {
+          lines.push("", `Example: compress({ content: [{ startId: "${top.startRef}", endId: "${top.endRef}", summary: "..." }] })`);
+        }
+        const text = lines.join("\n");
+        if (terminalNudge) {
+          // Print to the user terminal only — the model never sees this. Mirrors
+          // opencode-acp's ignored-part injection: surface the nudge without
+          // spending model context on it.
+          if (ctx.hasUI) ctx.ui.notify(text);
+        } else {
+          // Legacy: inject as a context message the model can act on.
+          rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active)));
+        }
+        if (!emergency) runtime.markNudgeShown(turnKey);
+        debug.event("nudge-injected", { sid: ctx.sessionManager.getSessionId(), voice: rendered.voice, channel: terminalNudge ? "terminal" : "context", emergency, turnKey, text });
       } else {
-        // Legacy: inject as a context message the model can act on.
-        rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active)));
+        debug.event("nudge-suppressed", { sid: ctx.sessionManager.getSessionId(), turnKey, reason: turn.nudge.reason });
       }
-      debug.event("nudge-injected", { sid: ctx.sessionManager.getSessionId(), voice: rendered.voice, channel: terminalNudge ? "terminal" : "context", text });
     }
 
     // Always return the transformed array: every message needs its [mNNNNN] ref

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,6 +15,11 @@ export interface AcpRuntime {
   store: SessionStateStore;
   adapter: AdapterConfig;
   setAdapter(adapter: AdapterConfig): void;
+  /** Record that a nudge was already shown for the turn keyed by last user msg
+   *  id, so a tier/growth nudge prints at most once per turn instead of on
+   *  every context event (pi fires multiple per assistant reply). */
+  markNudgeShown(turnKey: string): void;
+  nudgeShownFor(turnKey: string): boolean;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
   stateFor(ctx: ExtensionContext): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
@@ -27,6 +32,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const store = new SessionStateStore();
   const locks = new Map<string, Promise<void>>();
   let adapterRef = adapter;
+  const nudgeShownTurns = new Set<string>();
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -67,5 +73,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), liveContextLimit, configFor, stateFor, save, acquireLock };
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -18,3 +18,13 @@ export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>
   }
   return tokens;
 }
+
+/** Id of the last user-role entry — used as a per-turn key so a nudge prints at
+ *  most once per turn. Returns undefined if there is no user message yet. */
+export function lastUserMessageId(entries: { id: string; message?: { role?: string } }[]): string | undefined {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]!;
+    if (e.message?.role === "user") return e.id;
+  }
+  return undefined;
+}

--- a/tests/tokens.test.ts
+++ b/tests/tokens.test.ts
@@ -2,12 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { estimateTokens } from "../src/tokens.js";
 
-test("estimateTokens matches kernel defaultCountTokens (word-based, not chars/4)", () => {
+test("estimateTokens matches kernel defaultCountTokens (CJK 1:1 + chars/4)", () => {
   const msgs = [
     { id: "m1", role: "user", contentType: "text", text: "hello world foo bar baz" },
   ];
-  // defaultCountTokens counts ascii words: 5 — chars/4 would give 2
-  assert.equal(estimateTokens(msgs), 5);
+  // defaultCountTokens (acp-kernel 0.0.7+): CJK 1:1 + non-CJK chars/4.
+  // 24 non-CJK chars → ceil(24/4) = 6
+  assert.equal(estimateTokens(msgs), 6);
 });
 
 test("estimateTokens is consistent with kernel counter for CJK (each char = 1 token)", () => {
@@ -23,8 +24,8 @@ test("estimateTokens skips compress tool calls", () => {
     { id: "m2", role: "assistant", contentType: "tool-call", toolName: "compress", text: "ignored payload here" },
     { id: "m3", role: "user", contentType: "text", text: "delta epsilon" },
   ];
-  // m1 (3) + skip m2 (compress) + m3 (2) = 5
-  assert.equal(estimateTokens(msgs), 5);
+  // m1 (4) + skip m2 (compress) + m3 (4) = 8
+  assert.equal(estimateTokens(msgs), 8);
 });
 
 test("estimateTokens skips covered (already-compressed) message ids", () => {
@@ -33,6 +34,6 @@ test("estimateTokens skips covered (already-compressed) message ids", () => {
     { id: "m3", role: "user", contentType: "text", text: "delta epsilon" },
   ];
   const covered = new Set(["m3"]);
-  // m1 (3) + skip m3 (covered) = 3
-  assert.equal(estimateTokens(msgs, covered), 3);
+  // m1 (4) + skip m3 (covered) = 4
+  assert.equal(estimateTokens(msgs, covered), 4);
 });


### PR DESCRIPTION
This is the per-turn dedup commit (35e2704) that was pushed to PR#21's branch *after* #21 was already merged, so it never landed on master. Re-submitting as its own PR.

pi fires the context event multiple times per assistant reply; a tier-2 nudge triggers every event (tier ignores lastNudgeShownTokens), spamming the terminal ~10x in 85s. Gate non-emergency nudges to once per turn via last-user-message-id; emergency (usage>=80%) still prints every event.

typecheck ✅ 32/32 tests ✅