### PR TITLE
fix: record compressCallId so consumed compress calls get hidden

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "0.0.7",
+        "acp-kernel": "^0.0.8",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.7.tgz",
-      "integrity": "sha512-hhkU/1n0oHtRelSFr3FM0suu+Guo8/z+pJ0l/EPowoG58kN2vb1tk+uq8cFiVk94K8970qNsUwmrInGtwgYwLg==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.8.tgz",
+      "integrity": "sha512-6XTfz5YSIAUFyCuk8uCTLc8KNVZnlIMEMLTOtzVlV4l+UqjHeXNyNi4+90YPbVdR8cnR96vmrNd3fvyh4VH/kg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.7",
+    "acp-kernel": "0.0.9",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -41,14 +41,14 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
       "Never compress content the current step is actively using.",
     ],
     parameters: CompressParams,
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-      const result = await handleCompress(params as CompressArgs, runtime, ctx);
+    async execute(toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      const result = await handleCompress(params as CompressArgs, runtime, ctx, toolCallId);
       return { details: undefined, content: [{ type: "text", text: result }] };
     },
   };
 }
 
-async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
+async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {
   const ranges = args.content ?? [];
   if (ranges.length === 0) return "No ranges provided.";
   const { state, coreMessages } = await runtime.stateFor(ctx);
@@ -69,7 +69,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   });
 
   const applied = runtime.core.applyCompression({
-    ranges: ranges.map((r) => ({ startRef: r.startId, endRef: r.endId, summary: r.summary, topic: r.topic ?? topLevelTopic, summaryMaxChars })),
+    ranges: ranges.map((r) => ({ startRef: r.startId, endRef: r.endId, summary: r.summary, topic: r.topic ?? topLevelTopic, summaryMaxChars, compressCallId: toolCallId })),
     messages: coreMessages,
     state,
     config,


### PR DESCRIPTION
## Bug
compress-tool 忽略了 execute() 的 toolCallId 参数 (下划线前缀)。applyCompression 从不接收 compressCallId → 每个 block 的 compressCallId 都是 undefined → hideConsumedCompressCalls 的 allBlockCallIds 是空集 → 成功的 compress 调用无法和失败的区分, 全当 orphan, 只留最后 2 个, 其余(含失败的 error 消息)永久残留。

实测: 本会话 12 个 compress 调用残留(应≤2), blockCallIds=0。

## Fix
toolCallId 传透: execute → handleCompress → applyCompression.ranges[].compressCallId。成功的 compress 把 toolCallId 记到 block 上, hideConsumedCompressCalls 即可匹配隐藏已消费的 tool-call+tool-result 对。

同时 bump acp-kernel 0.0.7 → 0.0.9。

typecheck ✅ · 32/32 tests ✅

## 注意
已存在的历史 block 仍无 compressCallId (无法回填), 需新 compress 才生效。