### PR TITLE
fix: acp_status reports what the model actually receives

### DIFF
--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -40,8 +40,23 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
 
 async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
+  const config = runtime.configFor(ctx);
+  // Run the same pipeline (assign-refs → prune → hide-compress-calls → ...) that
+  // the context transform runs, so what acp_status reports matches what the
+  // model actually receives. Without this, consumed/hidden compress calls and
+  // pruned messages showed up in acp_status even though they never reached
+  // the model.
+  const tokenCount = estimateTokens(coreMessages, collectCoveredMessageIds(state));
+  const realUsage = ctx.getContextUsage?.();
+  const turn = runtime.core.processTurn({
+    messages: coreMessages,
+    state,
+    config,
+    tokenCount: realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : tokenCount,
+  });
+  const processed = turn.messages;
 
-  const base = buildStatusReport(state, coreMessages, defaultCountTokens, {
+  const base = buildStatusReport(turn.state, processed, defaultCountTokens, {
     scope: args.scope,
     view: args.view,
     tool: args.tool,
@@ -54,10 +69,6 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   // (scope: compressed/uncompressed) return the base report as-is.
   if (args.scope) return base;
 
-  const config = runtime.configFor(ctx);
-  const coveredIds = collectCoveredMessageIds(state);
-  const tokenCount = estimateTokens(coreMessages, coveredIds);
-  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
   const nudge = turn.nudge;
   const ranges = nudge?.compressibleRanges ?? [];
 


### PR DESCRIPTION
## Bug
handleStatus 用 stateFor() 的原始 coreMessages 直接生成报告, 不经过 processTurn。所以已消费/隐藏的 compress 调用、已 prune 的消息都显示在 acp_status 里, 但模型实际没收到。

实测: acp_status 显示 12 个 compress, 但模型实际上下文只有 ~2 个。

## Fix
acp_status 先跑和 context transform 一样的 pipeline (assign-refs → prune → hide-compress-calls → ...), 用 pi 真实 token (getContextUsage)。overview 路径原本也调了 processTurn 取 nudge, 现在去重只跑一次。

修复后 acp_status 反映模型真实收到的内容。

typecheck ✅ · 32/32 tests ✅