### PR TITLE
fix: /acp slash command uses real context usage

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -89,7 +89,11 @@ function bar(value: number, total: number, width: number = 20): string {
 async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
-  const tokenCount = defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n"));
+  // Use pi's real context usage (anchored on provider usage) instead of a
+  // chars/4 estimate — matches the footer percentage and the nudge decision
+  // the context transform computes.
+  const realUsage = ctx.getContextUsage?.();
+  const tokenCount = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n"));
 
   const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
   const nudge = turn.nudge;


### PR DESCRIPTION
## Bug
\`/acp\` 命令的 statusReport 用 defaultCountTokens (chars/4) 估算 tokenCount, 忽略 pi 的 getContextUsage()。

growth 基于这个错误基线算: /acp 报 Growth +390K + Nudge ACTIVE, 但 acp_status (已修) 显示 growth 11.5K + idle。同一会话, 结论相反。

## Fix
优先用 ctx.getContextUsage().tokens (fallback 到 estimate 当 usage 为 null), 让 /acp 报告与 footer 和 nudge 决策一致。

typecheck ✅ · 32/32 tests ✅