### PR TITLE
release: v0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "^0.0.8",
+        "acp-kernel": "0.0.10",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.8.tgz",
-      "integrity": "sha512-6XTfz5YSIAUFyCuk8uCTLc8KNVZnlIMEMLTOtzVlV4l+UqjHeXNyNi4+90YPbVdR8cnR96vmrNd3fvyh4VH/kg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.10.tgz",
+      "integrity": "sha512-3Uswl1VFB3AzvXwoR2/ZhZ4O7c/pFOE0gSyZptupA7AGQIJJtAPvIry6RPdQo+v5LslQnXc9PLJPZ27hQ2Wacg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.9",
+    "acp-kernel": "0.0.10",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Release pai-acp 0.1.6

### 修复
- **#24** compress 记录 compressCallId → 成功的 compress 可被 hideConsumedCompressCalls 识别,不再永久残留
- **#25** acp_status 跑 processTurn pipeline → 显示与模型实际收到的内容一致(之前显示未隐藏的原始消息)
- **#26** /acp 命令用真实 token (getContextUsage) → 与 footer 一致; displayTotal 对齐 footer
- **#27** framework 拆分为 SysPrompt (getSystemPrompt 精确测) + 残差 (tool schemas + 估算误差)

### 依赖
acp-kernel 0.0.9 → 0.0.10:
- orphan compress 全清 (KEEP_LAST_ORPHANED=0)
- nudge 范围 oldest-first

typecheck ✅ · 32/32 tests ✅

Merging triggers CI auto-tag + npm publish.