### PR TITLE
feat: acp_status lists protected ranges

### DIFF
--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -89,5 +89,14 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
       extra.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
     }
   }
+  const protectedRanges = nudge?.protectedRanges ?? [];
+  if (protectedRanges.length > 0) {
+    extra.push("");
+    extra.push(`Protected Ranges (${protectedRanges.length}, do not compress):`);
+    for (const r of protectedRanges) {
+      const tools = r.tools.length > 0 ? ` [${r.tools.join(", ")}]` : "";
+      extra.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
+    }
+  }
   return extra.length > 0 ? `${base}\n${extra.join("\n")}` : base;
 }


### PR DESCRIPTION
status-tool overview 只显示 Compressible Ranges, 从不显示 protectedRanges。用户看不到哪些范围含 protected 工具调用 (不能压缩)。加 Protected Ranges 段 (与 acp-kernel #21 nudge 列表一致)。typecheck ✅ 32/32 tests ✅