### PR TITLE
feat: unify range display across acp_status, /acp, and nudge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "0.0.10",
+        "acp-kernel": "0.0.11",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.10.tgz",
-      "integrity": "sha512-3Uswl1VFB3AzvXwoR2/ZhZ4O7c/pFOE0gSyZptupA7AGQIJJtAPvIry6RPdQo+v5LslQnXc9PLJPZ27hQ2Wacg==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.11.tgz",
+      "integrity": "sha512-g8iz0yfdnvJAhaUZxppQYPmnJTKoJub96JejHwTM42iJ8eq4TggBgGhiFI/5OQcEGPc0DQKcOS9g2FsK0hGF1A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.10",
+    "acp-kernel": "0.0.11",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
 import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { defaultCountTokens, deactivateBlock, parseBlockIdArg, buildRestoredContentPreview } from "acp-kernel";
+import { defaultCountTokens, deactivateBlock, parseBlockIdArg, buildRestoredContentPreview, formatRanges } from "acp-kernel";
 
 declare const CURRENT_VERSION: string;
 
@@ -164,13 +164,10 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   }
 
   const ranges = nudge?.compressibleRanges ?? [];
-  if (ranges.length > 0) {
+  const protectedRanges = nudge?.protectedRanges ?? [];
+  if (ranges.length > 0 || protectedRanges.length > 0) {
     lines.push("");
-    lines.push(`Compressible Ranges (${ranges.length}):`);
-    for (const r of ranges) {
-      const tools = r.toolPct > 0 ? ` (${Math.round(r.toolPct)}% tools)` : "";
-      lines.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
-    }
+    lines.push(formatRanges(ranges, protectedRanges));
   }
 
   if (activeBlocksList.length > 0) {

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -1,12 +1,8 @@
 import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { buildStatusReport, defaultCountTokens } from "acp-kernel";
+import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
-
-function fmtTokens(n: number): string {
-  return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
-}
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -71,6 +67,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
 
   const nudge = turn.nudge;
   const ranges = nudge?.compressibleRanges ?? [];
+  const protectedRanges = nudge?.protectedRanges ?? [];
 
   const extra: string[] = [];
   if (nudge) {
@@ -81,13 +78,12 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
         : `Nudge: idle — ${nudge.reason}`,
     );
   }
-  if (ranges.length > 0) {
+  if (ranges.length > 0 || protectedRanges.length > 0) {
     extra.push("");
-    extra.push(`Compressible Ranges (${ranges.length}):`);
-    for (const r of ranges) {
-      const tools = r.toolPct > 0 ? ` (${Math.round(r.toolPct)}% tools)` : "";
-      extra.push(`  ${r.startRef}\u2013${r.endRef}  (${r.count} msgs, ${fmtTokens(r.tokens)}${tools})`);
-    }
+    // Reuse the kernel's merged range formatter so acp_status, the nudge,
+    // and /acp all render compressible+protected ranges identically
+    // (merged oldest-first, with mixed-range breakdowns).
+    extra.push(formatRanges(ranges, protectedRanges));
   }
   return extra.length > 0 ? `${base}\n${extra.join("\n")}` : base;
 }


### PR DESCRIPTION
status-tool 和 /acp 各自实现范围显示且忽略 protectedRanges, 与 nudge 不一致。复用 acp-kernel 导出的 formatRanges (#22), 三个视图字节一致。依赖 acp-kernel #22。typecheck ✅ 32/32 tests ✅