### PR TITLE
release: v0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release pai-acp 0.1.7.

### Since 0.1.6
- **#30** Unify range display across acp_status, /acp, and nudge: reuse acp-kernel's exported `formatRanges` so all three render compressible + protected ranges identically — merged oldest-first list, mixed ranges show `[X compressible | Y protected: tools]` (previously protected ranges were dropped entirely in two of the three views)

Bumps acp-kernel 0.0.10 → 0.0.11 (formatRanges export).

typecheck clean; 32/32 tests pass. Merging triggers CI auto-tag + npm publish.