### PR TITLE
fix: check for updates on context event, not only session_start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,13 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     // Always return the transformed array: every message needs its [mNNNNN] ref
     // tag applied, so there is no meaningful "no change" case to short-circuit.
     debug.event("context-out", { outMsgs: rebuilt.length, injected: turn.nudge?.shouldInject ?? false, emergency: turn.nudge?.breakdown?.emergencyOverride === 1 });
+    // Also check for updates here (not only on session_start): resuming a
+    // long-running session never re-fires session_start, so an update could
+    // go unnoticed for days. checkForUpdate throttles internally (3 min) and
+    // is guarded against concurrent calls, so firing it per LLM call is safe.
+    void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
+      if (ctx.hasUI) ctx.ui.notify(msg);
+    });
     return { messages: rebuilt };
     } finally {
       release();

--- a/src/update.ts
+++ b/src/update.ts
@@ -12,6 +12,10 @@ const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
 const THROTTLE_FILE = `${process.env.HOME ?? ""}/.pi/agent/.pai-acp-update-check`;
 
+// Guards against concurrent checks: the context event fires on every LLM call,
+// so several can race past the throttle read before any writes the timestamp.
+let updateInFlight = false;
+
 function parseVersion(v: string): number[] {
   return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
 }
@@ -118,15 +122,17 @@ export async function checkForUpdate(
   ) {
     return;
   }
-  const now = Date.now();
-  const lastCheck = await readLastCheck();
-  if (now - lastCheck < CHECK_INTERVAL_MS) return;
-
-  await writeLastCheck(now);
-
-  const runtimeVersion = await getRuntimeVersion();
-
+  if (updateInFlight) return;
+  updateInFlight = true;
   try {
+    const now = Date.now();
+    const lastCheck = await readLastCheck();
+    if (now - lastCheck < CHECK_INTERVAL_MS) return;
+
+    await writeLastCheck(now);
+
+    const runtimeVersion = await getRuntimeVersion();
+
     const res = await fetch(REGISTRY_URL, {
       signal: AbortSignal.timeout(5000),
       headers: { Accept: "application/json" },
@@ -157,6 +163,8 @@ export async function checkForUpdate(
     }
   } catch {
     // network error, registry down, timeout — silent
+  } finally {
+    updateInFlight = false;
   }
 }
 


### PR DESCRIPTION
## Bug
checkForUpdate 只在 session_start 触发。resume 长期运行的 session 不会重新触发 session_start, 加上 3 分钟节流, 更新可能好几天甚至永远不被发现。

## Fix
在 context 事件 (每次 LLM 调用) 也触发 checkForUpdate。内部已有 3 分钟节流, 新增 updateInFlight flag 防并发, 不会刷 registry。

typecheck ✅ · 32/32 tests ✅