### PR TITLE
release: v0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release pai-acp 0.1.8.

### Since 0.1.7
- **#32** Check for updates on the context event (every LLM call), not only session_start. Resuming a long-running session never re-fires session_start, so combined with the 3-minute throttle an update could go unnoticed for days. Added `updateInFlight` guard against concurrent checks.

typecheck clean; 32/32 tests pass. Merging triggers CI auto-tag + npm publish.