### PR TITLE
fix: review findings — nudge tracking leak + debug toggle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,13 +50,14 @@ function wireCompactionDisable(pi: ExtensionAPI): void {
 function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("session_start", async (_event, ctx) => {
     runtime.store.invalidate();
+    runtime.clearNudgeTracking();
     // Load user config (~/.pi/acp.json + project .pi/acp.json) and apply it so
     // debug/terminalNudge/autoUpdate/modelContextLimit are runtime-configurable
     // without env vars or reinstalling.
     try {
       const user = await loadUserConfig(ctx.cwd);
       runtime.setAdapter(applyUserConfig(runtime.adapter, user));
-      if (runtime.adapter.debug === true) setDebugEnabled(true);
+      if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
     } catch {
       // best-effort — fall back to factory/env config
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,6 +20,9 @@ export interface AcpRuntime {
    *  every context event (pi fires multiple per assistant reply). */
   markNudgeShown(turnKey: string): void;
   nudgeShownFor(turnKey: string): boolean;
+  /** Clear per-turn nudge tracking. Called on session_start so the Set does not
+   *  grow unbounded across sessions in a long-lived Pi process. */
+  clearNudgeTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
   stateFor(ctx: ExtensionContext): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
@@ -73,5 +76,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };
 }


### PR DESCRIPTION
## Review 发现 (low severity)
1. **nudgeShownTurns 内存泄漏**: Set 永不清理。加 clearNudgeTracking() 在 session_start 调用。
2. **debug 配置只能开不能关**: ===true 改 !==undefined。

typecheck ✅ · 32/32 tests ✅