### PR TITLE
feat: decompress defaults to file — prevent context bloat

### DIFF
--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -3,14 +3,21 @@ import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendi
 import type { AcpRuntime } from "./runtime.js";
 import { debug } from "./log.js";
 import { parseBlockIdArg, collectBlockContent } from "acp-kernel";
-import { writeFile } from "node:fs/promises";
+import { writeFile, mkdir } from "node:fs/promises";
 import { resolve, relative, isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
+
+/** Directory for auto-generated decompress output files. */
+const AUTO_DIR = join(process.env.HOME ?? tmpdir(), ".cache", "pi", "acp-decompress");
+
+/** Maximum chars of a head preview included in the tool result for file mode. */
+const PREVIEW_CHARS = 600;
 
 const DecompressParams = Type.Object({
   blockId: Type.String({ description: 'Block id to restore, e.g. "b5".' }),
   full: Type.Optional(Type.Boolean({ description: "If true, recurse through all nested blocks to original messages. Default: false (restores one tier up — nested block summaries shown, direct messages in full)." })),
-  toFile: Type.Optional(Type.String({ description: "If provided, write the restored content to this file path (must be under /tmp or ~/.cache/opencode) instead of returning it inline." })),
+  toFile: Type.Optional(Type.String({ description: "Write restored content to this file path (must be under /tmp, ~/.cache/opencode, or ~/.cache/pi) instead of the default auto-generated path. Block stays compressed." })),
+  inline: Type.Optional(Type.Boolean({ description: "If true, return content inline as this tool's result (appends to context). Default: false — content is written to an auto-generated file to avoid context bloat. Only set true when the content is small or you accept the context cost." })),
 });
 
 type DecompressArgs = Static<typeof DecompressParams>;
@@ -20,12 +27,12 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     name: "decompress",
     label: "Decompress",
     description:
-      "Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By default returns content as this tool's result (appended to the conversation). Use toFile to write to a file instead. full:true recurses to original messages.",
-    promptSnippet: 'decompress({ blockId: "b5" }) or decompress({ blockId: "b5", full: true }) or decompress({ blockId: "b5", toFile: "/tmp/restore.txt" })',
+      "Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By default writes content to an auto-generated file (avoids context bloat) and returns the path; use the read tool to access it. Pass inline:true to return content in the tool result instead. full:true recurses to original messages.",
+    promptSnippet: 'decompress({ blockId: "b5" }) — writes to file by default; decompress({ blockId: "b5", inline: true }) to return inline',
     promptGuidelines: [
       "Decompress when you need exact details lost in compression (file contents, error messages, signatures).",
-      "Content is returned as the tool result — the compressed block stays folded, so context is not disrupted.",
-      "Use toFile to write large restorations to a file (e.g. for reading back via read tool) instead of returning inline.",
+      "By default content is written to an auto-generated file — use the read tool to view it. This keeps context small.",
+      "Pass inline:true ONLY when content is small or you accept the context cost.",
       "Use full:true to recurse through all nested tiers to original messages.",
     ],
     parameters: DecompressParams,
@@ -36,24 +43,40 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
   };
 }
 
+/** Allowed roots for toFile paths. Keeps user-supplied paths from escaping to
+ *  arbitrary filesystem locations. */
+const ALLOWED_DIRS = [
+  tmpdir(),
+  join(process.env.HOME ?? "", ".cache", "opencode"),
+  join(process.env.HOME ?? "", ".cache", "pi"),
+];
+
 function resolveToFilePath(targetPath: string): string | { error: string } {
-  // Expand a leading ~ to the home dir so users can pass ~/.cache/...
   const expanded = targetPath.startsWith("~/")
     ? join(process.env.HOME ?? "", targetPath.slice(2))
     : targetPath;
   const resolved = resolve(expanded);
-  const allowedDirs = [
-    tmpdir(),
-    join(process.env.HOME ?? "", ".cache", "opencode"),
-  ];
-  const isAllowed = allowedDirs.some((dir) => {
+  const isAllowed = ALLOWED_DIRS.some((dir) => {
     const rel = relative(dir, resolved);
     return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
   });
   if (!isAllowed) {
-    return { error: `Error: toFile path must be under ${tmpdir()} or ~/.cache/opencode/. Got: ${targetPath}` };
+    return { error: `Error: toFile path must be under ${tmpdir()}, ~/.cache/opencode, or ~/.cache/pi. Got: ${targetPath}` };
   }
   return resolved;
+}
+
+/** Generate a unique auto file path for a block. Uses a timestamp so repeated
+ *  decompressions of the same block never overwrite each other. */
+function autoFilePath(blockId: string): string {
+  // blockId already carries the "b" prefix (e.g. "b5"); use it as-is so the
+  // filename reads "b5-<ts>.txt" rather than "bb5-<ts>.txt".
+  return join(AUTO_DIR, `${blockId}-${Date.now()}.txt`);
+}
+
+function headPreview(text: string): string {
+  if (text.length <= PREVIEW_CHARS) return text;
+  return text.slice(0, PREVIEW_CHARS) + "\n\n... (truncated; use read tool for full content)";
 }
 
 async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
@@ -72,16 +95,33 @@ async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: 
 
   if (count === 0) return `Block ${blockId} has no restorable message content.`;
 
-  debug.event("decompress", { blockId, full, count, toFile: Boolean(args.toFile) });
-
-  // toFile: write the collected content to a file. The block stays compressed;
-  // nothing is appended to the conversation beyond a short confirmation.
-  if (args.toFile) {
-    const resolved = resolveToFilePath(args.toFile);
-    if (typeof resolved === "object" && "error" in resolved) return resolved.error;
-    await writeFile(resolved, text, "utf8");
-    return `Wrote block ${blockId} (${count} item${count === 1 ? "" : "s"}) to ${resolved}`;
+  // inline mode: return content directly. Model explicitly accepts the context
+  // cost (e.g. small restorations or when it must reason over exact text).
+  if (args.inline === true && !args.toFile) {
+    debug.event("decompress", { blockId, full, count, mode: "inline" });
+    return `Restored block ${blockId} (${count} item${count === 1 ? "" : "s"}) inline:\n\n${text}`;
   }
 
-  return `Restored block ${blockId} (${count} item${count === 1 ? "" : "s"}):\n\n${text}`;
+  // file mode (default): write to disk. Determined path is either the explicit
+  // toFile or an auto-generated location. The block stays compressed; only a
+  // short path + preview is added to the conversation.
+  const targetPath = args.toFile
+    ? resolveToFilePath(args.toFile)
+    : autoFilePath(blockId);
+  if (typeof targetPath === "object" && "error" in targetPath) return targetPath.error;
+
+  await mkdir(AUTO_DIR, { recursive: true }).catch(() => {});
+  await writeFile(targetPath, text, "utf8");
+
+  debug.event("decompress", { blockId, full, count, mode: "file", path: targetPath, chars: text.length });
+
+  const itemWord = count === 1 ? "item" : "items";
+  const lines = [
+    `Block ${blockId} (${count} ${itemWord}, ${text.length} chars) written to ${targetPath}.`,
+    "Block stays compressed — context unchanged. Use the read tool to access the content.",
+  ];
+  // A short head preview lets the model decide whether the content is worth
+  // reading without forcing a second round-trip for small restorations.
+  lines.push("", "Preview:", headPreview(text));
+  return lines.join("\n");
 }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -18,7 +18,7 @@ TOOLS
 You have four context-management tools:
 
 - compress — Replace a contiguous range of older conversation with a single detailed summary you write. Use when content is genuinely consumed (no longer needed for the current task step). Single range: compress({ content: [{ startId: "m00150", endId: "m00220", summary: "..." }] }). Batch (multiple unrelated ranges, each with its own topic): compress({ content: [{ topic: "Auth", startId: "m00150", endId: "m00220", summary: "..." }, { topic: "Deploy", startId: "m00300", endId: "m00350", summary: "..." }] }).
-- decompress — Restore a previously compressed block's content. Content is returned as the tool result (appended to the conversation); the block stays compressed, so context and cache prefix are not disrupted. By default restores one tier up (T2 shows T1 summaries). Use full: true to recurse all the way to original messages. Use toFile to write restored content to a file (under /tmp or ~/.cache/opencode) instead of returning it inline. Example: decompress({ blockId: "b5" }) or decompress({ blockId: "b5", full: true }) or decompress({ blockId: "b5", toFile: "/tmp/b5.txt" }).
+- decompress — Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By DEFAULT content is written to an auto-generated file (avoids context bloat); use the read tool to view it. Pass inline:true to return content in the tool result instead (appends to context). full:true recurses to original messages. Example: decompress({ blockId: "b5" }) or decompress({ blockId: "b5", full: true }) or decompress({ blockId: "b5", inline: true }).
 - search_context — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: search_context({ query: "auth token refresh" }).
 - acp_status — Context status with compressible ranges. No args = overview + totals. scope:"uncompressed" for range view; add view:"messages" for per-message listing. scope:"compressed" for block details.
 
@@ -83,7 +83,7 @@ To compress blocks: use block IDs as boundaries: compress({ content: [{ startId:
 
 THE PHILOSOPHY OF DECOMPRESS
 
-decompress restores previously compressed content as a tool result appended to the conversation. The compressed block stays folded (its summary remains in place), so the cache prefix is preserved and context is minimally disrupted — only the tool result adds to it. Use decompress when you need exact details lost in compression. Before decompressing, use search_context to find the right block.
+decompress restores previously compressed content and writes it to a file by default (use inline:true to return it in the tool result instead). The compressed block stays folded (its summary remains in place), so the cache prefix is preserved and context is minimally disrupted. Use decompress when you need exact details lost in compression. Before decompressing, use search_context to find the right block.
 
 CONTEXT BREAKDOWN
 

--- a/tests/decompress-tool.test.ts
+++ b/tests/decompress-tool.test.ts
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm, readFile, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAcpExtension } from "../src/index.js";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+async function cleanState(sessionFile: string) {
+  await rm(`${sessionFile}.acp.json`, { force: true });
+}
+
+function fakeCtx(entries: any[], stateFile: string) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+}
+
+// Shared setup: assign refs + compress m00001 into block b1, return the tool
+// handles + ctx so each test can drive the decompress tool.
+async function setupWithCompressedBlock() {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  const stateFile = "/tmp/pai-acp-decompress-tool-it.session.json";
+  await cleanState(stateFile);
+  const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+  const entries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+  const ctx = fakeCtx(entries, stateFile);
+
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00001", summary: "Detailed initial context message for the decompress-tool tests." }] },
+    undefined, undefined, ctx,
+  );
+
+  const decompressTool = api.tools.find((t: any) => t.name === "decompress")!;
+  return { decompressTool, ctx };
+}
+
+test("decompress default writes content to an auto-generated file (no context bloat)", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const res = await decompressTool.execute("tc2", { blockId: "b1" }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.match(text, /written to/, "result reports a file path");
+  assert.match(text, /acp-decompress\/b1-\d+\.txt/, "auto-generated path under ~/.cache/pi/acp-decompress");
+  assert.match(text, /stays compressed/, "tells model the block stays compressed");
+  assert.match(text, /Preview:/, "includes a head preview");
+  // Crucially: the full long content is NOT in the tool result (it's in the file).
+  // The result carries only a short head preview + boilerplate, so it must be
+  // far smaller than the restored content (which the result itself reports as
+  // ~7287 chars).
+  assert.ok(text.length < 2000,
+    `inline content must NOT be the full restored text (result was ${text.length} chars)`);
+});
+
+test("decompress inline:true returns the full content in the tool result", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const res = await decompressTool.execute("tc3", { blockId: "b1", inline: true }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.match(text, /inline:/, "result signals inline mode");
+  assert.ok(text.includes("This is a detailed message that needs to be compressed."),
+    "full restored content present in the tool result");
+});
+
+test("decompress toFile writes to the specified path", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const dir = await mkdtemp(join(tmpdir(), "pai-acp-decompress-"));
+  const target = join(dir, "custom.txt");
+  const res = await decompressTool.execute("tc4", { blockId: "b1", toFile: target }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.match(text, new RegExp(target.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), "result mentions the custom path");
+  const written = await readFile(target, "utf8");
+  assert.ok(written.includes("This is a detailed message that needs to be compressed."),
+    "file contains the full restored content");
+});
+
+test("decompress toFile rejects paths outside allowed roots", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const res = await decompressTool.execute("tc5", { blockId: "b1", toFile: "/etc/passwd" }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+  assert.match(text, /must be under/i, "rejects arbitrary filesystem path");
+});
+
+test("decompress keeps the block active after a file-mode call", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  await decompressTool.execute("tc6", { blockId: "b1" }, undefined, undefined, ctx);
+  // Run the status tool to confirm b1 is still folded (active).
+  const { api } = captureApi();
+  // re-query via the same ctx's persisted state: simpler to just call decompress
+  // again — a second file-mode call should succeed identically (block still there).
+  const res2 = await decompressTool.execute("tc7", { blockId: "b1" }, undefined, undefined, ctx);
+  const text2 = (res2.content[0] as any).text as string;
+  assert.doesNotMatch(text2, /not found/i, "block still present after first decompress");
+});


### PR DESCRIPTION
## 问题

decompress 默认把恢复内容 inline 返回。对大 block 这会瞬间灌入几十 KB context，且因为结果落入 preserveRecent 保护区，变得**不可压缩**——模型无法回收。

这正是 #9 审查时发现的 P0 token 口径问题的另一面：解压结果膨胀 + 保护规则 = context 只进不出。

## 修复

**默认改为写文件**，block 保持压缩。工具结果只返回路径 + 简短 head 预览（~600 字符），模型按需用 read 工具读取。inline 模式需模型**显式 opt-in**。

### API

\`\`\`
decompress({ blockId })                       → 写文件（自动路径）  [默认]
decompress({ blockId, toFile: "/tmp/x.txt" }) → 写文件（自定义路径）
decompress({ blockId, inline: true })         → inline 返回（模型承担 context 成本）
decompress({ blockId, full: true })           → 递归（与上述任意组合）
\`\`\`

### 细节
- 自动路径：\`~/.cache/pi/acp-decompress/b<id>-<timestamp>.txt\`（timestamp 避免重复解压冲突）
- \`ALLOWED_DIRS\` 新增 \`~/.cache/pi\`（兼容已有 \`/tmp\`、\`~/.cache/opencode\`）
- head 预览让小恢复无需第二次 read 往返即可使用

## 与 acp-kernel#28 的关系

本 PR 独立可用（基于现有 collectBlockContent）。默认写文件后，解压结果不再是大 inline blob，**保护规则的误伤问题在实践中基本消失**。

acp-kernel#28（decompress 不进保护区 + 保护过滤改 warning）是互补的健壮性增强：覆盖 \`inline:true\` 场景，以及任何工具结果落在最后 N 条的边界情况。建议两个都合并。

## 测试

新增 \`tests/decompress-tool.test.ts\`（5 用例）：默认写文件、inline、自定义 toFile、路径拒绝、block 保持 active。

**37/37 通过**（原 32 + 新 5），typecheck / build 通过。

> 本 PR 不合并，等人工 review。