### PR TITLE
release: v0.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "^0.0.12",
+        "acp-kernel": "^0.0.13",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.12.tgz",
-      "integrity": "sha512-863na901y13tNZHShVn7aZsZ7UWdtWQwJFLNcQUBNthwLyNToP7fUMNpIjkSC2curLQ3yIvZGYxzjISg1viQwA==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.13.tgz",
+      "integrity": "sha512-UDSq4goivtSoL23lLn1WHDLKBN496w7rL/QtzN5tBkbFvpScBnRrT6t+nU46QYZajnqnEVgyfrLXcukHeyJxwQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "^0.0.12",
+    "acp-kernel": "^0.0.13",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Release v0.1.10

Patch release — bundles **acp-kernel@0.0.13** and includes **#38** (decompress defaults to file).

### Changes since v0.1.9

**#38** `feat: decompress defaults to file — prevent context bloat`
- decompress 默认**写文件**到 `~/.cache/pi/acp-decompress/b<id>-<ts>.txt`，工具结果只返回路径 + ~600 字符预览，不再膨胀 context
- `inline: true` 需模型显式 opt-in 才返回完整内容
- `toFile` 支持自定义路径；`ALLOWED_DIRS` 新增 `~/.cache/pi`
- 新增 `tests/decompress-tool.test.ts`（5 用例）

**acp-kernel 0.0.12 → 0.0.13**（bundled inline）
- 含 #28：`NEVER_PRESERVE_RECENT_TOOLS=["decompress"]` + 保护区改为过滤而非整体失败

### Verification
- typecheck ✓ / 37 tests pass ✓ / build ✓
- dist 确认含 `NEVER_PRESERVE_RECENT_TOOLS`（bundle 了 kernel 修复）

> Human merge only — Agent MUST NOT merge. CI auto-tags + publishes on merge.