### PR TITLE
feat: auto-inject ACP tools into builtin subagents' allowlists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { ACP_SYSTEM_PROMPT } from "./system-prompt.js";
 import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
+import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
 type AgentMessage = SessionMessageEntry["message"];
@@ -64,6 +65,10 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
+    // Idempotently ensure all builtin pi-subagents have ACP context tools
+    // (compress/decompress/search_context/acp_status) in their allowlists.
+    // Settings.json is patched safely (backup + optimistic mtime lock + verify).
+    void runSetupAndNotify(ctx.hasUI ? (m) => ctx.ui.notify(m) : undefined);
   });
 }
 

--- a/src/setup-subagent-tools.ts
+++ b/src/setup-subagent-tools.ts
@@ -1,0 +1,149 @@
+import { readFile, writeFile, stat, copyFile, rename } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { debug } from "./log.js";
+
+const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
+
+const BUILTIN_DEFAULT_TOOLS: Record<string, string[]> = {
+  advisor: ["read", "grep", "find", "ls", "bash", "intercom"],
+  "context-builder": ["read", "grep", "find", "ls", "bash", "write", "web_search", "intercom"],
+  delegate: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+  oracle: ["read", "grep", "find", "ls", "bash", "intercom"],
+  planner: ["read", "grep", "find", "ls", "intercom"],
+  researcher: ["read", "write", "web_search", "fetch_content", "get_search_content", "intercom"],
+  reviewer: ["read", "grep", "find", "ls", "bash", "edit", "write", "intercom"],
+  scout: ["read", "grep", "find", "ls", "bash", "write", "intercom"],
+  worker: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
+};
+
+export function resolveAgentDir(): string {
+  const configured = process.env.PI_CODING_AGENT_DIR;
+  if (configured === "~") return homedir();
+  if (configured?.startsWith("~/")) return join(homedir(), configured.slice(2));
+  return configured || join(homedir(), ".pi", "agent");
+}
+
+export interface SetupResult {
+  path: string;
+  action: "skipped" | "updated" | "failed";
+  reason?: string;
+}
+
+type OverrideEntry = { tools?: string[]; [k: string]: unknown };
+
+function desiredTools(existing: OverrideEntry | undefined, name: string): { tools: string[]; changed: boolean } {
+  const base = Array.isArray(existing?.tools) && existing!.tools!.length > 0
+    ? [...(existing!.tools as string[])]
+    : [...(BUILTIN_DEFAULT_TOOLS[name] ?? [])];
+  const hasAll = ACP_TOOLS.every((t) => base.includes(t));
+  if (hasAll) return { tools: base, changed: false };
+  for (const t of ACP_TOOLS) if (!base.includes(t)) base.push(t);
+  return { tools: base, changed: true };
+}
+
+export async function ensureSubagentAcpTools(settingsPath?: string): Promise<SetupResult> {
+  const path = settingsPath ?? join(resolveAgentDir(), "settings.json");
+
+  let raw: string;
+  let mtimeMs: number;
+  try {
+    raw = await readFile(path, "utf-8");
+    mtimeMs = (await stat(path)).mtimeMs;
+  } catch {
+    return { path, action: "skipped", reason: "settings.json not found; will retry next session" };
+  }
+
+  let settings: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return { path, action: "failed", reason: "settings.json root is not a JSON object" };
+    }
+    settings = parsed as Record<string, unknown>;
+  } catch (e) {
+    return { path, action: "failed", reason: `settings.json is not valid JSON: ${(e as Error).message}` };
+  }
+
+  const subagents = (typeof settings.subagents === "object" && settings.subagents !== null && !Array.isArray(settings.subagents))
+    ? { ...(settings.subagents as Record<string, unknown>) }
+    : {};
+  const overridesRaw = (typeof subagents.agentOverrides === "object" && subagents.agentOverrides !== null && !Array.isArray(subagents.agentOverrides))
+    ? { ...(subagents.agentOverrides as Record<string, unknown>) }
+    : {};
+
+  const updatedOverrides: Record<string, unknown> = { ...overridesRaw };
+  let anyChanged = false;
+  for (const name of Object.keys(BUILTIN_DEFAULT_TOOLS)) {
+    const existing = (overridesRaw[name] ?? undefined) as OverrideEntry | undefined;
+    const { tools, changed } = desiredTools(existing, name);
+    if (changed) {
+      updatedOverrides[name] = { ...(existing ?? {}), tools };
+      anyChanged = true;
+    }
+  }
+
+  if (!anyChanged) {
+    return { path, action: "skipped", reason: "all builtin agents already have ACP tools" };
+  }
+
+  const backupPath = `${path}.acp-bak`;
+  if (!existsSync(backupPath)) {
+    try { await copyFile(path, backupPath); } catch { /* best effort */ }
+  }
+
+  // Optimistic concurrency guard: bail if the file changed since we read it.
+  try {
+    if ((await stat(path)).mtimeMs !== mtimeMs) {
+      return { path, action: "skipped", reason: "settings.json changed during setup (concurrent write); will retry next session" };
+    }
+  } catch {
+    return { path, action: "failed", reason: "settings.json disappeared during setup" };
+  }
+
+  const next: Record<string, unknown> = {
+    ...settings,
+    subagents: { ...subagents, agentOverrides: updatedOverrides },
+  };
+
+  const tmpPath = `${path}.tmp-${process.pid}`;
+  try {
+    await writeFile(tmpPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
+    await rename(tmpPath, path);
+  } catch (e) {
+    return { path, action: "failed", reason: `write failed: ${(e as Error).message}` };
+  }
+
+  try {
+    const verify = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
+    const sub = verify.subagents as Record<string, unknown> | undefined;
+    const v = sub?.agentOverrides;
+    if (typeof v !== "object" || v === null) throw new Error("agentOverrides missing after write");
+    for (const name of Object.keys(BUILTIN_DEFAULT_TOOLS)) {
+      const tools = (v as Record<string, OverrideEntry>)[name]?.tools;
+      if (!Array.isArray(tools) || !ACP_TOOLS.every((t) => tools.includes(t))) {
+        throw new Error(`${name} missing ACP tools after write`);
+      }
+    }
+  } catch (e) {
+    try { await copyFile(backupPath, path); } catch { /* leave as-is */ }
+    return { path, action: "failed", reason: `verification failed; restored backup: ${(e as Error).message}` };
+  }
+
+  return { path, action: "updated" };
+}
+
+export async function runSetupAndNotify(notify?: (msg: string) => void): Promise<SetupResult> {
+  try {
+    const result = await ensureSubagentAcpTools();
+    debug.event("setup-subagent-tools", { action: result.action, reason: result.reason });
+    if (result.action === "updated" && notify) {
+      notify(`ACP: enabled context tools (compress/decompress/search_context/acp_status) for subagents`);
+    }
+    return result;
+  } catch (e) {
+    debug.event("setup-subagent-tools-error", { msg: String(e) });
+    return { path: "", action: "failed", reason: String(e) };
+  }
+}

--- a/tests/setup-subagent-tools.test.ts
+++ b/tests/setup-subagent-tools.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureSubagentAcpTools } from "../src/setup-subagent-tools.js";
+
+const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"];
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "acp-setup-"));
+}
+
+function writeSettings(dir: string, obj: unknown): string {
+  const p = join(dir, "settings.json");
+  writeFileSync(p, JSON.stringify(obj, null, 2));
+  return p;
+}
+
+function readSettings(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function allAgentsHaveAcp(path: string): boolean {
+  const s = readSettings(path);
+  const o = (s.subagents as Record<string, unknown> | undefined)?.agentOverrides as Record<string, { tools?: string[] }> | undefined;
+  if (!o) return false;
+  const names = ["advisor", "context-builder", "delegate", "oracle", "planner", "researcher", "reviewer", "scout", "worker"];
+  return names.every((n) => Array.isArray(o[n]?.tools) && ACP_TOOLS.every((t) => o[n]!.tools!.includes(t)));
+}
+
+test("creates overrides for all builtin agents when settings has no subagents", async () => {
+  const dir = tmpDir();
+  const path = writeSettings(dir, { theme: "dark", defaultModel: "gpt-4" });
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "updated");
+  assert.ok(allAgentsHaveAcp(path), "all agents should have ACP tools");
+  const s = readSettings(path);
+  assert.equal(s.theme, "dark", "preserves existing fields");
+  assert.equal(s.defaultModel, "gpt-4", "preserves existing fields");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("is idempotent — second run skips and does not rewrite file", async () => {
+  const dir = tmpDir();
+  const path = writeSettings(dir, { theme: "dark" });
+  const first = await ensureSubagentAcpTools(path);
+  assert.equal(first.action, "updated");
+  const firstMtime = statSync(path).mtimeMs;
+  const second = await ensureSubagentAcpTools(path);
+  assert.equal(second.action, "skipped");
+  assert.match(second.reason!, /already have ACP tools/);
+  assert.equal(statSync(path).mtimeMs, firstMtime, "file not rewritten on skip");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("preserves user-customized override tools and appends ACP", async () => {
+  const dir = tmpDir();
+  const path = writeSettings(dir, {
+    subagents: {
+      agentOverrides: {
+        delegate: { tools: ["read", "bash", "myCustomTool"] },
+      },
+    },
+  });
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "updated");
+  const s = readSettings(path);
+  const tools = (s.subagents as Record<string, unknown>).agentOverrides.delegate.tools as string[];
+  assert.ok(tools.includes("myCustomTool"), "preserves user custom tool");
+  assert.ok(ACP_TOOLS.every((t) => tools.includes(t)), "has ACP tools");
+  assert.ok(tools.includes("read") && tools.includes("bash"), "preserves original tools");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("does not duplicate ACP tools when already partially present", async () => {
+  const dir = tmpDir();
+  const path = writeSettings(dir, {
+    subagents: {
+      agentOverrides: {
+        delegate: { tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor", ...ACP_TOOLS] },
+      },
+    },
+  });
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "updated");
+  const s = readSettings(path);
+  const delegateTools = (s.subagents as Record<string, unknown>).agentOverrides.delegate.tools as string[];
+  assert.equal(delegateTools.length, 12, "delegate unchanged (no duplicate added)");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("preserves other override fields (model, thinking)", async () => {
+  const dir = tmpDir();
+  const path = writeSettings(dir, {
+    subagents: {
+      agentOverrides: {
+        delegate: { model: "custom-model", thinking: "high", tools: ["read", "bash"] },
+      },
+    },
+  });
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "updated");
+  const s = readSettings(path);
+  const delegate = (s.subagents as Record<string, unknown>).agentOverrides.delegate as Record<string, unknown>;
+  assert.equal(delegate.model, "custom-model", "preserves model override");
+  assert.equal(delegate.thinking, "high", "preserves thinking override");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("returns failed on invalid JSON without modifying file", async () => {
+  const dir = tmpDir();
+  const path = join(dir, "settings.json");
+  writeFileSync(path, "{ not valid json");
+  const before = statSync(path).mtimeMs;
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "failed");
+  assert.match(result.reason!, /not valid JSON/);
+  assert.equal(statSync(path).mtimeMs, before, "file untouched on parse failure");
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("returns skipped when settings.json does not exist", async () => {
+  const dir = tmpDir();
+  const path = join(dir, "settings.json");
+  const result = await ensureSubagentAcpTools(path);
+  assert.equal(result.action, "skipped");
+  assert.match(result.reason!, /not found/);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("creates backup on first write, not on subsequent skips", async () => {
+  const dir = tmpDir();
+  const original = { theme: "light", customField: 42 };
+  const path = writeSettings(dir, original);
+  const backupPath = `${path}.acp-bak`;
+
+  const first = await ensureSubagentAcpTools(path);
+  assert.equal(first.action, "updated");
+
+  const backupContent = readSettings(backupPath);
+  assert.deepEqual(backupContent, original, "backup contains pre-edit content");
+
+  const backupMtime = statSync(backupPath).mtimeMs;
+  const second = await ensureSubagentAcpTools(path);
+  assert.equal(second.action, "skipped");
+  assert.equal(statSync(backupPath).mtimeMs, backupMtime, "backup not rewritten");
+  rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## 问题

Builtin pi-subagents（delegate / reviewer / worker 等 9 个）用**严格工具白名单**，不继承父会话的 ambient extension 工具。所以即使装了 pai-acp，子 agent 也看不到 \`compress\` / \`decompress\` / \`search_context\` / \`acp_status\`——ACP 对委托出去的工作完全不可见。

## 方案

pi-subagents 的 \`settings.json\` 支持 \`subagents.agentOverrides.<name>.tools\`（完整替换 builtin 列表）。pai-acp 在 \`session_start\` 钩子里**幂等**地把 4 个 ACP 工具追加到全部 9 个 builtin agent 的白名单。

用户**零配置**——装 pai-acp 即生效，一次写入永久有效。

## 安全性（回应"settings.json 很重要"的顾虑）

| 措施 | 做法 |
|------|------|
| **幂等** | 所有 agent 已含全部 ACP 工具 → \`skipped\`，不重写文件（重跑免费） |
| **备份** | 首次写前 \`copyFile → settings.json.acp-bak\`，**不覆盖**已存在的备份 |
| **原子写** | 写 tmp 文件 + \`rename\`（POSIX 原子，防读到半写状态） |
| **乐观 mtime 锁** | 读时记 \`mtimeMs\`，写前再 \`stat\` 比对；变了就放弃（并发安全） |
| **验证** | 写后读回 \`JSON.parse\` + 断言所有 agent 含 ACP 工具；失败从备份恢复 |
| **保留** | 只动 \`subagents.agentOverrides\`，保留 \`packages\`/\`theme\`/\`defaultModel\` 等所有字段，保留每个 agent 已有的 \`model\`/\`thinking\`/自定义 tools |
| **失败安全** | 全程 try/catch 静默，**绝不影响 pi 启动** |

### 并发场景
- 两个 pi 同时启动 → 都读干净 settings → 都算出相同结果 → 一个原子 rename 成功，另一个 mtime 锁检测到变化放弃；即使都写了，内容相同幂等无破坏。
- session_start 期间用户手动改 settings → mtime 锁放弃，下次 session 重试。

## 实测

\`\`\`
还原 settings.json → 调 ensureSubagentAcpTools
→ action: \"updated\"
→ settings.json 正确注入 9 个 agent override（每个含 4 个 ACP 工具）
→ backup = 原始干净配置 ✓

再跑一次 → action: \"skipped\", reason: \"all builtin agents already have ACP tools\" ✓

subagent action:get reviewer（从未手动配过的 agent）
→ Tools: ..., compress, decompress, search_context, acp_status ✓
\`\`\`

## 测试

新增 \`tests/setup-subagent-tools.test.ts\`（8 用例）：创建/幂等/保留自定义 tools/不重复/保留其他字段/无效 JSON/文件不存在/备份行为。

**typecheck ✓ / 45 tests pass（原 37 + 新 8）/ build ✓**

> Human merge only — Agent MUST NOT merge.