### PR TITLE
release: v0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.11

Patch release — includes **#40** (auto-inject ACP tools into builtin subagents).

### Changes since v0.1.10

**#40** \`feat: auto-inject ACP tools into builtin subagents' allowlists\`
- session_start 时幂等地把 \`compress\`/\`decompress\`/\`search_context\`/\`acp_status\` 追加到全部 9 个 builtin pi-subagents（delegate/reviewer/worker 等）的工具白名单
- **用户零配置**——装即生效
- 安全：备份 (\`settings.json.acp-bak\`) + 原子写 + mtime 乐观锁 + 写后验证 + 失败回滚
- 只追加不删除：保留用户已有的自定义工具、model、thinking 等所有字段
- 幂等：已配齐则 \`skipped\` 不重写文件；绝不重复追加

### Verification
- typecheck ✓ / 45 tests pass ✓ / build ✓
- 实测：还原干净 settings → 注入 9 agent + 备份 = 原始内容；再跑 → skipped；reviewer（从未手动配过）拿到全部 ACP 工具

> Human merge only — Agent MUST NOT merge. CI auto-tags + publishes on merge.