### PR TITLE
search: historical message search + message-ref decompress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .DS_Store
 *.acp.json
 .pi-subagents/
+tmp-debug.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,14 @@ pi-acp/
 │   ├── compress-tool.ts      # compress tool handler
 │   ├── decompress-tool.ts    # decompress tool handler
 │   ├── search-tool.ts        # search_context tool (delegates to kernel.searchBlocks)
+│   ├── search-index.ts       # Builds SearchDoc[] from session log + ACP blocks
 │   ├── status-tool.ts        # acp_status tool (delegates to kernel.buildStatusReport)
 │   ├── commands.ts           # /acp slash command
 │   ├── system-prompt.ts      # System prompt with compression philosophy
 │   ├── update.ts             # Auto-update: checks npm, auto-installs latest
 │   ├── tokens.ts             # Token estimation utilities
 │   └── log.ts                # Debug logging
-├── tests/                    # 32 tests
+├── tests/                    # 45 tests
 ├── tsup.config.ts
 └── package.json
 ```
@@ -57,6 +58,7 @@ pi-acp/
 3. **Assistant messages skip tag injection** — prevents model echo of XML tags
 4. **Tags appended to END of text** — matches opencode-acp pattern
 5. **Auto-update on session_start** — checks npm registry (6h throttle), auto-installs if newer
+6. **acp-kernel MUST be pinned to an exact version** (e.g. `"acp-kernel": "0.0.14"`, NEVER `"^0.0.14"`). Because acp-kernel is a build-time dependency that tsup bundles inline into `dist`, a caret range makes the resolved version drift if `package-lock.json` is regenerated or absent, breaking reproducible builds. When bumping acp-kernel: set the exact version in `package.json`, run `npm install` to refresh the lockfile, then rebuild. The `package-lock.json` is committed and kept in sync.
 
 ## 3. Development Standards
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "^0.0.13",
+        "acp-kernel": "^0.0.14",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.13.tgz",
-      "integrity": "sha512-UDSq4goivtSoL23lLn1WHDLKBN496w7rL/QtzN5tBkbFvpScBnRrT6t+nU46QYZajnqnEVgyfrLXcukHeyJxwQ==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.14.tgz",
+      "integrity": "sha512-vQIJ/NSxgvK218z9CmmHLdCrOBy9TLvYd1v+Inkr0nbgjtQppN5EfyEMei9tMCJQPS1RY/5kvuciXk7jXrEkAg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "^0.0.14",
+        "acp-kernel": "0.0.14",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "^0.0.14",
+    "acp-kernel": "0.0.14",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "^0.0.13",
+    "acp-kernel": "^0.0.14",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -14,7 +14,7 @@ const AUTO_DIR = join(process.env.HOME ?? tmpdir(), ".cache", "pi", "acp-decompr
 const PREVIEW_CHARS = 600;
 
 const DecompressParams = Type.Object({
-  blockId: Type.String({ description: 'Block id to restore, e.g. "b5".' }),
+  blockId: Type.String({ description: 'Block id to restore, e.g. "b5". Also accepts a message ref (UUID) from search_context results — resolves to the owning block automatically.' }),
   full: Type.Optional(Type.Boolean({ description: "If true, recurse through all nested blocks to original messages. Default: false (restores one tier up — nested block summaries shown, direct messages in full)." })),
   toFile: Type.Optional(Type.String({ description: "Write restored content to this file path (must be under /tmp, ~/.cache/opencode, or ~/.cache/pi) instead of the default auto-generated path. Block stays compressed." })),
   inline: Type.Optional(Type.Boolean({ description: "If true, return content inline as this tool's result (appends to context). Default: false — content is written to an auto-generated file to avoid context bloat. Only set true when the content is small or you accept the context cost." })),
@@ -27,10 +27,11 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     name: "decompress",
     label: "Decompress",
     description:
-      "Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By default writes content to an auto-generated file (avoids context bloat) and returns the path; use the read tool to access it. Pass inline:true to return content in the tool result instead. full:true recurses to original messages.",
-    promptSnippet: 'decompress({ blockId: "b5" }) — writes to file by default; decompress({ blockId: "b5", inline: true }) to return inline',
+      "Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By default writes content to an auto-generated file (avoids context bloat) and returns the path; use the read tool to access it. Pass inline:true to return content in the tool result instead. full:true recurses to original messages. Accepts a block id (b5) or a message ref (UUID) from search_context results.",
+    promptSnippet: 'decompress({ blockId: "b5" }) or decompress({ blockId: "d51b6f94" }) (message ref from search) — writes to file by default; add inline: true to return inline',
     promptGuidelines: [
       "Decompress when you need exact details lost in compression (file contents, error messages, signatures).",
+      "You can pass a block id (b5) OR a message ref (UUID) from search_context results — it resolves to the owning block.",
       "By default content is written to an auto-generated file — use the read tool to view it. This keeps context small.",
       "Pass inline:true ONLY when content is small or you accept the context cost.",
       "Use full:true to recurse through all nested tiers to original messages.",
@@ -80,10 +81,17 @@ function headPreview(text: string): string {
 }
 
 async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
-  const blockId = parseBlockIdArg(args.blockId);
-  if (!blockId) return `Invalid blockId: ${args.blockId}. Expected format like "b5" or "5".`;
-
   const { state, coreMessages } = await runtime.stateFor(ctx);
+
+  let blockId = parseBlockIdArg(args.blockId);
+  // If not a valid blockId format, try resolving as a message ref (UUID from
+  // search_context results) → the owning block.
+  if (!blockId) {
+    const msgRef = args.blockId.trim();
+    const owner = state.blocks.find((b) => b.effectiveMessageIds.includes(msgRef));
+    if (owner) blockId = owner.blockId;
+  }
+  if (!blockId) return `Invalid blockId: ${args.blockId}. Expected format like "b5", "5", or a message ref (UUID) from search_context results.`;
   const block = state.blocks.find((b) => b.blockId === blockId);
   if (!block) {
     const active = state.blocks.filter((b) => b.active).map((b) => b.blockId).join(", ");

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendi
 import type { AcpRuntime } from "./runtime.js";
 import { debug } from "./log.js";
 import { parseBlockIdArg, collectBlockContent } from "acp-kernel";
+import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
 import { resolve, relative, isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
@@ -12,6 +13,12 @@ const AUTO_DIR = join(process.env.HOME ?? tmpdir(), ".cache", "pi", "acp-decompr
 
 /** Maximum chars of a head preview included in the tool result for file mode. */
 const PREVIEW_CHARS = 600;
+
+/** For message-ref decompression: a single message at or above this size is
+ *  written to a file instead of returned inline, to avoid context bloat.
+ *  Single messages are usually small, so the default for messages is inline
+ *  (unlike block decompression, which defaults to file). */
+const MESSAGE_INLINE_THRESHOLD = 2000;
 
 const DecompressParams = Type.Object({
   blockId: Type.String({ description: 'Block id to restore, e.g. "b5". Also accepts a message ref (UUID) from search_context results — resolves to the owning block automatically.' }),
@@ -27,13 +34,12 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     name: "decompress",
     label: "Decompress",
     description:
-      "Restore a previously compressed block's content. The block stays compressed — context and cache prefix are not disrupted. By default writes content to an auto-generated file (avoids context bloat) and returns the path; use the read tool to access it. Pass inline:true to return content in the tool result instead. full:true recurses to original messages. Accepts a block id (b5) or a message ref (UUID) from search_context results.",
+      "Restore a previously compressed block's content, or a single message by its ref. The block/message stays compressed — context and cache prefix are not disrupted. BLOCK decompress (blockId b5) defaults to writing a file (blocks can be large); use the read tool to access it, or inline:true to return inline. MESSAGE decompress (blockId = a message UUID from search_context) returns that ONE message's original text — defaults to inline since a single message is usually small; oversized messages go to a file. full:true recurses through nested block tiers (block mode only). You can pass a block id (b5) OR a message ref (UUID) from search_context results.",
     promptSnippet: 'decompress({ blockId: "b5" }) or decompress({ blockId: "d51b6f94" }) (message ref from search) — writes to file by default; add inline: true to return inline',
     promptGuidelines: [
       "Decompress when you need exact details lost in compression (file contents, error messages, signatures).",
-      "You can pass a block id (b5) OR a message ref (UUID) from search_context results — it resolves to the owning block.",
-      "By default content is written to an auto-generated file — use the read tool to view it. This keeps context small.",
-      "Pass inline:true ONLY when content is small or you accept the context cost.",
+      "Message ref (UUID) returns ONLY that one message's original text, default inline (small). Block id (b5) returns the whole block, default file.",
+      "Pass inline:true ONLY when content is small or you accept the context cost (block mode).",
       "Use full:true to recurse through all nested tiers to original messages.",
     ],
     parameters: DecompressParams,
@@ -80,17 +86,76 @@ function headPreview(text: string): string {
   return text.slice(0, PREVIEW_CHARS) + "\n\n... (truncated; use read tool for full content)";
 }
 
+/** Locate a single message's original text by its ref (CoreMessage.id). Scans
+ *  session entries since the raw text lives in pi's append-only session log,
+ *  NOT in the block (blocks store only a summary + the ref pointer). Returns
+ *  the text and role, or null if the ref is not found. */
+function findMessageContent(ref: string, ctx: ExtensionContext): { text: string; role: string } | null {
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type !== "message") continue;
+    for (const cm of entriesToCoreMessages([entry])) {
+      if (cm.id === ref) {
+        return { text: cm.text ?? "", role: cm.role };
+      }
+    }
+  }
+  return null;
+}
+
+/** Decompress a single message by its ref. Unlike block decompression (which
+ *  defaults to file — blocks can be huge), a single message is usually small,
+ *  so it defaults to inline. Oversized messages still go to a file. */
+async function handleMessageRef(
+  ref: string,
+  ownerBlockId: string,
+  args: DecompressArgs,
+  ctx: ExtensionContext,
+): Promise<string> {
+  const found = findMessageContent(ref, ctx);
+  if (!found || !found.text) {
+    return `Message ${ref} (in block ${ownerBlockId}) has no restorable text content in the session log.`;
+  }
+  const { text, role } = found;
+
+  // Decide inline vs file. Default inline (messages are small); file when the
+  // message is large, or toFile/inline:false is set explicitly.
+  const wantFile = args.toFile !== undefined || args.inline === false || text.length >= MESSAGE_INLINE_THRESHOLD;
+
+  if (!wantFile) {
+    debug.event("decompress-message", { ref, ownerBlockId, mode: "inline", chars: text.length });
+    return `Message ${ref} (${role}, block ${ownerBlockId}, ${text.length} chars) restored inline:\n\n${text}`;
+  }
+
+  const targetPath = args.toFile ? resolveToFilePath(args.toFile) : autoFilePath(`msg-${ref}`);
+  if (typeof targetPath === "object" && "error" in targetPath) return targetPath.error;
+
+  await mkdir(AUTO_DIR, { recursive: true }).catch(() => {});
+  await writeFile(targetPath, text, "utf8");
+
+  debug.event("decompress-message", { ref, ownerBlockId, mode: "file", path: targetPath, chars: text.length });
+
+  return [
+    `Message ${ref} (${role}, block ${ownerBlockId}, ${text.length} chars) written to ${targetPath}.`,
+    "Block stays compressed — context unchanged. Use the read tool to access the content.",
+    "", "Preview:", headPreview(text),
+  ].join("\n");
+}
+
 async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
+  const arg = args.blockId.trim();
 
-  let blockId = parseBlockIdArg(args.blockId);
-  // If not a valid blockId format, try resolving as a message ref (UUID from
-  // search_context results) → the owning block.
-  if (!blockId) {
-    const msgRef = args.blockId.trim();
-    const owner = state.blocks.find((b) => b.effectiveMessageIds.includes(msgRef));
-    if (owner) blockId = owner.blockId;
+  // Resolve what `arg` refers to. Check message-ref FIRST (data-driven: a ref
+  // exists in some block's effectiveMessageIds). This must precede block-id
+  // parsing because pure-digit hex refs (e.g. 51102431) would otherwise be
+  // misread as a block number by parseBlockIdArg.
+  const owner = state.blocks.find((b) => b.effectiveMessageIds.includes(arg));
+  if (owner) {
+    return handleMessageRef(arg, owner.blockId, args, ctx);
   }
+
+  // Otherwise treat as a block id.
+  const blockId = parseBlockIdArg(arg);
   if (!blockId) return `Invalid blockId: ${args.blockId}. Expected format like "b5", "5", or a message ref (UUID) from search_context results.`;
   const block = state.blocks.find((b) => b.blockId === blockId);
   if (!block) {

--- a/src/search-index.ts
+++ b/src/search-index.ts
@@ -1,0 +1,94 @@
+/**
+ * Search index — bridges pi's session log into acp-kernel's search.
+ *
+ * Builds SearchDoc[] from:
+ *  1. All compression blocks (active AND inactive) — via blockDocs()
+ *  2. All historical messages from the append-only session log — via getEntries()
+ *
+ * Each historical message is mapped to the block that compressed it (if any),
+ * so a message hit tells the model exactly which block to decompress for the
+ * surrounding detail. Messages still visible in context have no owning block.
+ *
+ * Token estimates use the same chars/4 + CJK heuristic as the kernel.
+ */
+
+import type { ExtensionContext, SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
+import { blockDocs, messageDocs, type SearchDoc, type MessageInput, type MessageRole } from "acp-kernel";
+import { entriesToCoreMessages } from "./messages.js";
+import type { CompressionState } from "acp-kernel";
+
+/** ref prefix → owning blockId, built from every block's effectiveMessageIds. */
+function buildMessageOwnerMap(state: CompressionState): Map<string, string> {
+    const m = new Map<string, string>();
+    for (const b of state.blocks) {
+        for (const id of b.effectiveMessageIds) {
+            // first block (lowest tier, earliest) wins — outermost summary owns it
+            if (!m.has(id)) m.set(id, b.blockId);
+        }
+    }
+    return m;
+}
+
+/** Estimate tokens with CJK awareness (matches kernel defaultCountTokens). */
+function estimateTokens(text: string): number {
+    if (!text) return 0;
+    const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g);
+    const cjkCount = cjk?.length ?? 0;
+    return cjkCount + Math.ceil((text.length - cjkCount) / 4);
+}
+
+/** Map pi message role → acp-kernel MessageRole. Tool calls count as assistant. */
+function toRole(entry: SessionMessageEntry): MessageRole | null {
+    const role = entry.message.role;
+    if (role === "user") return "user";
+    if (role === "assistant") return "assistant";
+    if (role === "toolResult") return "tool";
+    return null;
+}
+
+/**
+ * Build the full searchable document set for one session.
+ * Called per searchBlocks invocation. Reads are cheap (in-memory entry tree).
+ */
+export function buildSearchDocs(ctx: ExtensionContext, state: CompressionState): SearchDoc[] {
+    const sm = ctx.sessionManager;
+    const allEntries: SessionEntry[] = sm.getEntries();
+    const ownerMap = buildMessageOwnerMap(state);
+
+    // which message refs are still visible? buildContextEntries gives the live set.
+    const liveEntries = sm.buildContextEntries();
+    const liveIds = new Set(liveEntries.map((e) => e.id));
+    // also include ids of currently-in-context messages (sub-refs like "id#callId")
+    const coreMsgs = entriesToCoreMessages(liveEntries);
+    for (const m of coreMsgs) if (m.id) liveIds.add(m.id);
+
+    const blockTier = new Map<string, number>();
+    for (const b of state.blocks) blockTier.set(b.blockId, b.tier ?? 1);
+
+    const msgs: MessageInput[] = [];
+    for (const entry of allEntries) {
+        if (entry.type !== "message") continue;
+        const role = toRole(entry);
+        if (!role) continue;
+
+        const cores = entriesToCoreMessages([entry]);
+        for (const cm of cores) {
+            if (!cm.id) continue;
+            // skip messages still visible in context — model can already see them
+            if (liveIds.has(cm.id)) continue;
+            const text = cm.text ?? "";
+            if (!text || text.length < 2) continue;
+            const ownerBlock = ownerMap.get(cm.id);
+            msgs.push({
+                ref: cm.id,
+                role,
+                text,
+                tokens: estimateTokens(text),
+                blockId: ownerBlock,
+                tier: ownerBlock ? blockTier.get(ownerBlock) : undefined,
+            });
+        }
+    }
+
+    return [...blockDocs(state), ...messageDocs(msgs)];
+}

--- a/src/search-index.ts
+++ b/src/search-index.ts
@@ -3,13 +3,16 @@
  *
  * Builds SearchDoc[] from:
  *  1. All compression blocks (active AND inactive) — via blockDocs()
- *  2. All historical messages from the append-only session log — via getEntries()
+ *  2. Historical messages that compression folded into a block summary.
  *
- * Each historical message is mapped to the block that compressed it (if any),
- * so a message hit tells the model exactly which block to decompress for the
- * surrounding detail. Messages still visible in context have no owning block.
+ * Which messages are searchable? Those covered by SOME block's
+ * effectiveMessageIds — i.e. messages that were compressed into a summary and
+ * are no longer individually visible. Messages still live in context (not in
+ * any block) are skipped: the model can already see them.
  *
- * Token estimates use the same chars/4 + CJK heuristic as the kernel.
+ * We deliberately do NOT use pi's buildContextEntries for the visible check:
+ * ACP prunes messages itself (no pi `compaction` entry is written), so pi
+ * reports ALL entries as in-context. The ACP state is the source of truth.
  */
 
 import type { ExtensionContext, SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
@@ -17,19 +20,26 @@ import { blockDocs, messageDocs, type SearchDoc, type MessageInput, type Message
 import { entriesToCoreMessages } from "./messages.js";
 import type { CompressionState } from "acp-kernel";
 
-/** ref prefix → owning blockId, built from every block's effectiveMessageIds. */
+/** All message refs covered by any block (active or inactive). */
+function buildCoveredRefs(state: CompressionState): Set<string> {
+    const s = new Set<string>();
+    for (const b of state.blocks) {
+        for (const id of b.effectiveMessageIds) s.add(id);
+    }
+    return s;
+}
+
+/** ref → owning blockId (first/earliest block wins — outermost summary). */
 function buildMessageOwnerMap(state: CompressionState): Map<string, string> {
     const m = new Map<string, string>();
     for (const b of state.blocks) {
         for (const id of b.effectiveMessageIds) {
-            // first block (lowest tier, earliest) wins — outermost summary owns it
             if (!m.has(id)) m.set(id, b.blockId);
         }
     }
     return m;
 }
 
-/** Estimate tokens with CJK awareness (matches kernel defaultCountTokens). */
 function estimateTokens(text: string): number {
     if (!text) return 0;
     const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g);
@@ -37,7 +47,6 @@ function estimateTokens(text: string): number {
     return cjkCount + Math.ceil((text.length - cjkCount) / 4);
 }
 
-/** Map pi message role → acp-kernel MessageRole. Tool calls count as assistant. */
 function toRole(entry: SessionMessageEntry): MessageRole | null {
     const role = entry.message.role;
     if (role === "user") return "user";
@@ -46,26 +55,11 @@ function toRole(entry: SessionMessageEntry): MessageRole | null {
     return null;
 }
 
-/**
- * Build the full searchable document set for one session.
- * Called per searchBlocks invocation. Reads are cheap (in-memory entry tree).
- *
- * Visibility check: ACP does NOT write pi `compaction` entries (it prunes
- * messages itself in processTurn), so pi's buildContextEntries returns ALL
- * entries. The real visible set is the post-prune coreMessages from stateFor.
- */
-export function buildSearchDocs(
-    ctx: ExtensionContext,
-    state: CompressionState,
-    visibleCoreMessages: { id?: string }[],
-): SearchDoc[] {
+export function buildSearchDocs(ctx: ExtensionContext, state: CompressionState): SearchDoc[] {
     const sm = ctx.sessionManager;
     const allEntries: SessionEntry[] = sm.getEntries();
+    const covered = buildCoveredRefs(state);
     const ownerMap = buildMessageOwnerMap(state);
-
-    // Visible = the post-prune messages ACP actually keeps in context.
-    const liveIds = new Set<string>();
-    for (const m of visibleCoreMessages) if (m.id) liveIds.add(m.id);
 
     const blockTier = new Map<string, number>();
     for (const b of state.blocks) blockTier.set(b.blockId, b.tier ?? 1);
@@ -79,8 +73,9 @@ export function buildSearchDocs(
         const cores = entriesToCoreMessages([entry]);
         for (const cm of cores) {
             if (!cm.id) continue;
-            // skip messages still visible in context — model can already see them
-            if (liveIds.has(cm.id)) continue;
+            // Only include messages that were compressed into a block.
+            // Still-live messages are visible to the model — no need to search them.
+            if (!covered.has(cm.id)) continue;
             const text = cm.text ?? "";
             if (!text || text.length < 2) continue;
             const ownerBlock = ownerMap.get(cm.id);

--- a/src/search-index.ts
+++ b/src/search-index.ts
@@ -49,18 +49,23 @@ function toRole(entry: SessionMessageEntry): MessageRole | null {
 /**
  * Build the full searchable document set for one session.
  * Called per searchBlocks invocation. Reads are cheap (in-memory entry tree).
+ *
+ * Visibility check: ACP does NOT write pi `compaction` entries (it prunes
+ * messages itself in processTurn), so pi's buildContextEntries returns ALL
+ * entries. The real visible set is the post-prune coreMessages from stateFor.
  */
-export function buildSearchDocs(ctx: ExtensionContext, state: CompressionState): SearchDoc[] {
+export function buildSearchDocs(
+    ctx: ExtensionContext,
+    state: CompressionState,
+    visibleCoreMessages: { id?: string }[],
+): SearchDoc[] {
     const sm = ctx.sessionManager;
     const allEntries: SessionEntry[] = sm.getEntries();
     const ownerMap = buildMessageOwnerMap(state);
 
-    // which message refs are still visible? buildContextEntries gives the live set.
-    const liveEntries = sm.buildContextEntries();
-    const liveIds = new Set(liveEntries.map((e) => e.id));
-    // also include ids of currently-in-context messages (sub-refs like "id#callId")
-    const coreMsgs = entriesToCoreMessages(liveEntries);
-    for (const m of coreMsgs) if (m.id) liveIds.add(m.id);
+    // Visible = the post-prune messages ACP actually keeps in context.
+    const liveIds = new Set<string>();
+    for (const m of visibleCoreMessages) if (m.id) liveIds.add(m.id);
 
     const blockTier = new Map<string, number>();
     for (const b of state.blocks) blockTier.set(b.blockId, b.tier ?? 1);

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -32,8 +32,8 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
 }
 
 async function handleSearch(args: SearchArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
-    const { state, coreMessages } = await runtime.stateFor(ctx);
-    const docs = buildSearchDocs(ctx, state, coreMessages);
+    const { state } = await runtime.stateFor(ctx);
+    const docs = buildSearchDocs(ctx, state);
     const msgCount = docs.filter((d) => d.kind === "message").length;
     const blockCount = docs.filter((d) => d.kind === "block").length;
     const results = searchBlocks(docs, args.query, { limit: args.limit });

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -1,11 +1,12 @@
 import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { searchBlocks } from "acp-kernel";
+import { searchBlocks, type SearchResult } from "acp-kernel";
 import type { AcpRuntime } from "./runtime.js";
+import { buildSearchDocs } from "./search-index.js";
 
 const SearchParams = Type.Object({
-    query: Type.String({ description: "Search query — keywords to match in compressed block summaries." }),
-    limit: Type.Optional(Type.Number({ description: "Max results to return (default: 10)." })),
+    query: Type.String({ description: "Keywords to locate detail folded into compressed summaries or historical messages." }),
+    limit: Type.Optional(Type.Number({ description: "Max results (default 10)." })),
 });
 
 type SearchArgs = Static<typeof SearchParams>;
@@ -15,11 +16,12 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
         name: "search_context",
         label: "Search Context",
         description:
-            "Search compressed block summaries by keyword. Use BEFORE decompressing to find the right block. Returns matching blocks with relevance scores and previews.",
+            "Search compressed blocks AND historical messages by keyword. Use to cheaply locate detail before decompressing. Returns ranked results with ref, size, preview, and the decompress command to retrieve full content.",
         promptSnippet: 'search_context({ query: "auth token" })',
         promptGuidelines: [
-            "Search to find which block contains information you need before decompressing.",
-            "Results show block ID, tier, topic, and a preview of the summary.",
+            "Search locates detail folded into summaries or past messages — cheaper than decompressing blind.",
+            "Each result shows a ref (b3 block / m00350 message), size, and the exact decompress command for full content.",
+            "Message hits link to the owning block — decompress that block to recover surrounding detail.",
         ],
         parameters: SearchParams,
         async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
@@ -31,18 +33,47 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
 
 async function handleSearch(args: SearchArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
     const { state } = await runtime.stateFor(ctx);
-    const results = searchBlocks(state, args.query, { limit: args.limit });
+    const docs = buildSearchDocs(ctx, state);
+    const results = searchBlocks(docs, args.query, { limit: args.limit });
 
     if (results.length === 0) {
-        const count = state.blocks.filter((b) => b.active).length;
-        return `No matches for "${args.query}" in ${count} block(s).`;
+        const blocks = state.blocks.length;
+        return `No matches for "${args.query}" across ${blocks} block(s) and ${docs.filter((d) => d.kind === "message").length} historical message(s).`;
     }
 
     const lines = [`Found ${results.length} match(es) for "${args.query}":`];
-    for (const r of results) {
-        lines.push("", `${r.blockId} (T${r.tier}, score:${r.score}) "${r.topic}"`);
-        const ellipsis = r.block.summary.length > r.preview.length ? "..." : "";
-        lines.push(`  ${r.preview}${ellipsis}`);
-    }
+    for (const r of results) lines.push("", formatResult(r));
     return lines.join("\n");
+}
+
+function formatResult(r: SearchResult): string {
+    const sizeStr = r.tokens != null ? formatSize(r.tokens) : "";
+    const meta = [
+        r.kind === "message" ? `message ${r.ref}` : `block ${r.ref}`,
+        r.role ? `(${r.role})` : "",
+        `T${r.tier}`,
+        `score:${r.score.toFixed(2)}`,
+        sizeStr,
+    ].filter(Boolean).join(" ");
+
+    const header = `${meta}  "${truncate(r.title, 50)}"`;
+
+    const decompressHint = r.kind === "block"
+        ? `→ decompress({ blockId: "${r.ref}" })`
+        : r.blockId
+          ? `→ decompress({ blockId: "${r.blockId}" })  (block containing message ${r.ref})`
+          : `(message ${r.ref} is still visible in context)`;
+
+    return `${header}\n  ${r.preview}\n  ${decompressHint}`;
+}
+
+function truncate(s: string, n: number): string {
+    if (s.length <= n) return s;
+    return s.slice(0, n - 1) + "…";
+}
+
+function formatSize(tokens: number): string {
+    if (tokens < 1000) return `${tokens}tok`;
+    if (tokens < 1_000_000) return `${(tokens / 1000).toFixed(1)}K`;
+    return `${(tokens / 1_000_000).toFixed(1)}M`;
 }

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -32,16 +32,18 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
 }
 
 async function handleSearch(args: SearchArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
-    const { state } = await runtime.stateFor(ctx);
-    const docs = buildSearchDocs(ctx, state);
+    const { state, coreMessages } = await runtime.stateFor(ctx);
+    const docs = buildSearchDocs(ctx, state, coreMessages);
+    const msgCount = docs.filter((d) => d.kind === "message").length;
+    const blockCount = docs.filter((d) => d.kind === "block").length;
     const results = searchBlocks(docs, args.query, { limit: args.limit });
 
     if (results.length === 0) {
         const blocks = state.blocks.length;
-        return `No matches for "${args.query}" across ${blocks} block(s) and ${docs.filter((d) => d.kind === "message").length} historical message(s).`;
+        return `No matches for "${args.query}" across ${blocks} block(s) and ${msgCount} historical message(s).`;
     }
 
-    const lines = [`Found ${results.length} match(es) for "${args.query}":`];
+    const lines = [`Found ${results.length} match(es) for "${args.query}" (searched ${blockCount} blocks + ${msgCount} messages):`];
     for (const r of results) lines.push("", formatResult(r));
     return lines.join("\n");
 }


### PR DESCRIPTION
## Summary

Historical message search + message-ref decompress, built on acp-kernel 0.0.14's unified search API.

## Changes

### 1. Historical message search (`search-index.ts`, `search-tool.ts`)
- `buildSearchDocs(ctx, state)` reads pi's full session log and indexes messages that were compressed into a block (those are the ones worth searching — still-live messages are already visible)
- Google-style results: `message <ref> (role) T<tier> score size` + preview + `→ decompress({blockId})` hint
- Result header shows `searched X blocks + Y messages`

### 2. Message-ref decompress (`decompress-tool.ts`)
- `decompress({ blockId: "d51b6f94" })` now works — resolves a message UUID from search results
- Message ref returns ONLY that one message's original text (not the whole owning block)
- **Message defaults to inline** (single messages are usually small); block defaults to file
- Oversized messages (≥2000 chars) still go to a file
- Data-driven ref resolution first (fixes pure-digit hex refs like `51102431` being misread as block numbers)

### 3. Deps
- Bump `acp-kernel` to `^0.0.14`

## Key design point
Original message text lives in pi's append-only session log (NOT in blocks — blocks store only summary + ref pointers). Search reads that log; message-ref decompress recovers the single message's raw text from it.

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm test` — 45 pass, 0 fail
- [x] `npm run build` — success (dist bundles acp-kernel 0.0.14)
- [x] Manual: CJK queries + role weighting verified
- [x] Manual: message-ref decompress returns single message inline (small) / file (large)
- [x] Manual: block-id decompress unchanged (file default)
