### PR TITLE
release v0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.12.

Includes (from PR #42):
- Historical message search (Google-style results: ref/role/size/preview + decompress hint)
- Message-ref decompress (returns single message, inline default)
- Pins acp-kernel to exact 0.0.14 (AGENTS.md decision #6)

Merge to trigger CI publish to npm.