### PR TITLE
refactor(prompt): source compression rules from acp-kernel (markers removed)

### DIFF
--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,9 +1,16 @@
+import {
+  COMPRESS_PHILOSOPHY,
+  HOW_TO_COMPRESS_RULES,
+  TIER2_DISTILL_RULES,
+  TIER3_CONDENSE_RULES,
+} from "acp-kernel";
+
 export const ACP_SYSTEM_PROMPT = `
 ACP context management
 
 ACP TAGS
 
-Each user and tool message has an \x3cacp tokens="2.1K" type="bash"\x3em00175\x3c/acp\x3e tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g., m00005) inside compress calls — never the XML wrapper.
+Each user and tool message has an \x3cacp tokens="2.1K" type="bash"\x3em00175\x3c/acp\x3e tag showing its ref (mNNNNN), approximate token size, and content type. Assistant messages are untagged — infer their refs from adjacent tagged messages. These tags are system metadata injected by the context manager. NEVER echo, repeat, or reference these XML tags in your responses. Use only the ref ID (e.g. m00005) inside compress calls — never the XML wrapper.
 
 COMPRESSION SUMMARIES IN CONTEXT
 
@@ -22,13 +29,7 @@ You have four context-management tools:
 - search_context — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: search_context({ query: "auth token refresh" }).
 - acp_status — Context status with compressible ranges. No args = overview + totals. scope:"uncompressed" for range view; add view:"messages" for per-message listing. scope:"compressed" for block details.
 
-COMPRESSION PHILOSOPHY
-
-Two failure modes to avoid:
-- Over-compression: Compressing too aggressively loses critical details, decisions, and state needed for your task. This directly harms task quality.
-- Under-compression: Failing to compress verbose outputs causes context overflow, reducing accuracy and eventually blocking your work.
-
-Balance is key. The single test for whether to compress is: "Is this content still needed by the current task step?" If yes, keep it. If no, compress it.
+${COMPRESS_PHILOSOPHY}
 
 WHEN TO COMPRESS
 
@@ -43,43 +44,20 @@ WHEN TO COMPRESS
 WHEN NOT TO COMPRESS
 
 - Content the current task step is actively reading or reasoning about.
-- Important user messages — preserve their exact intent, constraints, and acceptance criteria verbatim.
+- Important user messages — preserve their exact intent, constraints, and acceptance criteria. If a message in the range must stay verbatim, exclude it from the compress range instead of compressing it.
 - Protected tool outputs — hard-excluded from compression ranges, survive intact in visible context.
 
-HOW TO COMPRESS
-
-When you call compress, the summary you write becomes the only record of the replaced conversation. Make it self-contained and complete: every user request, experiment purpose, and work task in the range must be accurately captured. A later reader (or you, after decompressing) should be able to continue the task WITHOUT needing the original.
-
-KEEP VERBATIM — never paraphrase or abbreviate these:
-- Full file paths with line numbers on every mention (lib/hooks.ts:347, src/index.ts:12-18). Never abbreviate to a bare filename.
-- Function, class, and type signatures (exact names, params, return types) AND critical code lines that encode logic.
-- Error messages and stack traces (exact text — you need the literal string to grep for it later).
-- Decisions and their rationale ("chose X over Y because Z" — the "because" is load-bearing).
-- Constraints discovered ("must support Node 22", "no new dependencies").
-- Exact values: versions, config keys, thresholds, magic numbers.
-- User intent — quote short user messages verbatim.
-- Open questions and unresolved TODOs.
-
-DROP — extract the signal, discard the vessel:
-- Verbose logs (build/test/npm output) once you have captured the error line or the result.
-- Duplicate file reads once the needed content is recorded.
-- Consumed exploration — search hits, agent return values, successful tool outputs.
-- Dead-end exploration — but PRESERVE the lesson in one line: "tried X, failed because Y".
-
-PRIORITY — when the summary must be compact, preserve in this order:
-1. User's overall goal, intent, and hard constraints (losing these changes the task).
-2. Decisions and rationale.
-3. Exact technical artifacts: paths, signatures, errors, values.
-4. Conclusions and key findings.
-5. Lessons learned: what failed and why.
-
-Write dense, scannable bullets — not narrative prose. If the range spans distinct concerns, group bullets under short thematic headers.
+${HOW_TO_COMPRESS_RULES}
 
 MULTI-TIER COMPRESSION
 
 Summaries accumulate as the session grows. When tier-1 summaries pile up, the system injects a nudge prompting you to DISTILL old blocks into a single tier-2 summary. If tier-2 summaries also accumulate, a further nudge asks you to CONDENSE them into tier-3.
 
 To compress blocks: use block IDs as boundaries: compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] }). This deactivates the consumed blocks and creates a new higher-tier block.
+
+${TIER2_DISTILL_RULES}
+
+${TIER3_CONDENSE_RULES}
 
 THE PHILOSOPHY OF DECOMPRESS
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -87,6 +87,25 @@ test("context handler tags every message with a ref even when length matches eve
   assert.ok(firstContent.some((b: any) => b.type === "text" && b.text.includes("m0000")), "first msg ref-tagged");
 });
 
+test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension()(api as any);
+  const result = handlers.get("before_agent_start")![0]!({ systemPrompt: "" }, {});
+  const sp = result.systemPrompt;
+  // kernel constants inlined (regression guard against reverting to a hardcoded copy)
+  assert.ok(sp.includes("Work from summaries, not raw tool outputs"), "kernel COMPRESS_PHILOSOPHY inlined");
+  assert.ok(sp.includes("HOW TO COMPRESS"), "kernel HOW_TO_COMPRESS_RULES inlined");
+  assert.ok(sp.includes("TIER 2 COMPRESSION"), "kernel TIER2_DISTILL_RULES inlined");
+  assert.ok(sp.includes("TIER 3 COMPRESSION"), "kernel TIER3_CONDENSE_RULES inlined");
+  // marker system removed entirely from kernel constants
+  assert.ok(!sp.includes("[[KEEP:"), "no KEEP marker teaching");
+  assert.ok(!sp.includes("[[REF:"), "no REF marker teaching");
+  assert.ok(!sp.includes("KEEP MARKERS"), "no KEEP MARKERS section");
+  // old hardcoded copy removed
+  assert.ok(!sp.includes("Two failure modes to avoid"), "old hardcoded philosophy removed");
+  assert.ok(!sp.includes("Over-compression: Compressing too aggressively"), "old hardcoded over/under-compression section removed");
+});
+
 test("context handler persists state so a second call is idempotent on the same entries", async () => {
   const { api, handlers } = captureApi();
   createAcpExtension({ modelContextLimit: 200_000 })(api as any);


### PR DESCRIPTION
## Summary

Two coupled changes, depending on **acp-kernel PR #33** (delete KEEP/REF markers → release 0.0.15):

1. **Source compression rules from acp-kernel** instead of a hardcoded copy — `src/system-prompt.ts` imports `COMPRESS_PHILOSOPHY / HOW_TO_COMPRESS_RULES / TIER2_DISTILL_RULES / TIER3_CONDENSE_RULES`. Adapter-specific blocks (ACP TAGS, tool docs, WHEN TO/NOT TO, DECOMPRESS, BREAKDOWN) stay verbatim. Eliminates the drift hazard (issue #3).

2. **Remove the marker system** — `src/compress-tool.ts` no longer wires `resolveKeepMarkers`, and the prompt no longer teaches `[[KEEP]]/[[REF]]`.

## Why delete markers

- **KEEP is contradictory with compression.** Its job is to re-inject verbatim original content into a summary. If a message is important enough to keep verbatim, it should be **excluded from the compress range** (pai-acp supports per-message ranges), not compressed then padded back. Expanding verbatim content also risks blowing the context budget.
- **REF added nothing.** The expansion `[→ m00005: desc]` is no better than the model writing `(see m00005)`. Refs are already exposed by acp tags.

## ⛔ BLOCKED on acp-kernel 0.0.15

This PR sources constants from acp-kernel. Until kernel PR #33 lands and **0.0.15** is published, the registry 0.0.14 constants still carry marker teaching — so this PR is **red on CI** by design (the `no KEEP marker teaching` assertion fails against 0.0.14).

**Merge sequence:**
1. Review & merge acp-kernel PR #33
2. Release acp-kernel **0.0.15**
3. In THIS PR: bump `"acp-kernel": "0.0.14"` → `"0.0.15"`, run `npm install` (refresh lockfile)
4. CI goes green → merge

## Tests (`tests/integration.test.ts`)
- `system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)` — asserts the kernel constants are inlined AND that no marker teaching remains. Regression guard.
- Removed the old `[[KEEP]]` expansion end-to-end test (feature deleted).

## Test plan
- [x] typecheck + build clean (against marker-free kernel dist)
- [x] 46 tests pass against marker-free kernel
- [x] confirmed the `no markers` assertion FAILS against registry 0.0.14 (proves the dependency)
- [ ] blocked: bump pin to 0.0.15 after kernel release → full CI green