### PR TITLE
release v0.1.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "0.0.14",
+        "acp-kernel": "0.0.15",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.14.tgz",
-      "integrity": "sha512-vQIJ/NSxgvK218z9CmmHLdCrOBy9TLvYd1v+Inkr0nbgjtQppN5EfyEMei9tMCJQPS1RY/5kvuciXk7jXrEkAg==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.15.tgz",
+      "integrity": "sha512-Tm2Z1BH1hNHnBO4YF2tQFb2arB/wF36KagVznkAs4EbTxq9YGCaDNNOP2CwRoJrSJ5yECX4zVcUtVfCd/dxAOw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.14",
+    "acp-kernel": "0.0.15",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Release v0.1.13

Bumps `acp-kernel` dependency to **0.0.15** (marker removal, published).

### Changes since v0.1.12
- `refactor(prompt): source compression rules from acp-kernel (markers removed)` (4e37625, PR #44)
- `docs: expand §5 release workflow with cross-repo dependency rules` (1ef16b5)

### Dependency
- `acp-kernel`: `0.0.14` → `0.0.15` ✅ already live on npm

### Verification (pre-flight, matches release.yml)
- typecheck ✅
- test ✅ 46 pass / 0 fail
- build ✅

> Merge this PR to trigger CI auto-publish to npm.