### PR TITLE
release v0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pai-acp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "acp-kernel": "0.0.15",
+        "acp-kernel": "0.0.16",
         "tsup": "^8.5.1",
         "tsx": "^4.23.1",
         "typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
       }
     },
     "node_modules/acp-kernel": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.15.tgz",
-      "integrity": "sha512-Tm2Z1BH1hNHnBO4YF2tQFb2arB/wF36KagVznkAs4EbTxq9YGCaDNNOP2CwRoJrSJ5yECX4zVcUtVfCd/dxAOw==",
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.16.tgz",
+      "integrity": "sha512-fepPOzGsUaz/ilHUuhLUMd2DskL/QM8H9YXcSrlIjJYKLJgeCTLAy3BGLhqmessR6DJF9BL48PKbQ+WfCq/8XQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "acp-kernel": "0.0.15",
+    "acp-kernel": "0.0.16",
     "tsup": "^8.5.1",
     "tsx": "^4.23.1",
     "typescript": "^7.0.2"


### PR DESCRIPTION
## Release v0.1.14

Bumps `acp-kernel` to **0.0.16** (published ✅). Ships the new **acp_delegate** tool family.

### Changes since v0.1.13
- `feat: add acp_delegate — spawn clean-context sub-agents` (PR #46)
- `fix(delegate): address reviewer round 2 — stdin error guard + cleanup` (08ea487)
- `fix(delegate): drop preview from injected/sync result — title + path only` (PR #47)
  - success: header + task title + file path (zero preview)
  - failure: `stderr || "(no stderr)"` only

### Dependency
- `acp-kernel`: `0.0.15` → `0.0.16` ✅ already live on npm
  - brings `read`/`bash` excluded from the recent-zone (large tool results no longer block tail compression)

### Verification (pre-flight, matches release.yml)
- typecheck ✅
- test ✅ 46 pass / 0 fail
- build ✅

> Merge this PR to trigger CI auto-publish to npm.