### PR TITLE
release v0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.15 (patch)

Documentation-only patch release — propagates the README rewrite (PR #49) to the npm package.

### Changes
- Bump `0.1.14` → `0.1.15` (pai-acp version only; `acp-kernel` stays pinned at `0.0.16`).
- Refreshes `package-lock.json`.

### What this release ships
The README rewrite from #49 (merged to master but not yet on npm):
- Fixed the **Configuration** section (was entirely wrong — showed a non-existent factory config). Now documents the real `~/.pi/acp.json` mechanism (3 keys: `debug` / `autoUpdate` / `modelContextLimit`) and the env vars (`ACP_AUTO_UPDATE` / `ACP_MODEL_CONTEXT_LIMIT` / `ACP_DEBUG`).
- Added **Chinese README** (`README.zh-CN.md`), aligned with opencode-acp.
- Centered header block (badges + install command), value-proposition section.
- Fixed test count (208), pipeline stages (8), documented `acp_delegate` tool family.

### Pre-flight
- `npm run typecheck` ✅ clean
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅ 374 KB

No functional changes — `dist/index.js` is byte-identical to 0.1.14. This release only updates the bundled README that npm displays.