### PR TITLE
fix(windows): resolve pi/npm via shell on win32 (ENOENT exit -4058)

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -268,6 +268,7 @@ async function runDelegate(
     cwd,
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
   }) as ChildProcess;
   // Pass the task via stdin (not argv) so tasks starting with `-` are not
   // mis-parsed as CLI options. pi reads piped stdin as the prompt in print mode.

--- a/src/update.ts
+++ b/src/update.ts
@@ -98,7 +98,7 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
       execFile(
         "npm",
         ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
-        { cwd: npmDir, timeout: 60_000 },
+        { cwd: npmDir, timeout: 60_000, shell: process.platform === "win32" },
         (err) => resolve(err ? 1 : 0),
       );
     });


### PR DESCRIPTION
## Problem

On Windows, `child_process.spawn()`/`execFile()` **do not search PATH** and cannot find the `.cmd` shims (`pi.cmd`, `npm.cmd`) that npm global installs generate. The child exits immediately with ENOENT, surfaced as **exit code -4058** (`0xFFFFF026`).

Two call sites affected:

| File | Call | Impact |
|------|------|--------|
| `src/delegate-tool.ts:267` | `spawn("pi", ...)` | **acp_delegate completely broken on Windows** (0-second failure, exit -4058) |
| `src/update.ts:98` | `execFile("npm", ...)` | **auto-update silently fails** on Windows (error swallowed by catch) |

`decompress`/`search_context`/`compress`/`acp_status` are unaffected (pure in-memory operations, no subprocess).

## Fix

Add `shell: process.platform === "win32"` to both subprocess options.

- **Windows**: the shell (`cmd.exe`) resolves the `.cmd` shim via PATH → subprocess found.
- **Linux/macOS**: spawn keeps direct exec — no shell, no `DEP0190` args-with-shell deprecation warning, and `child.pid` stays the real process pid (so `acp_delegate_cancel` keeps working).

## Security

No injection risk from enabling shell on Windows:

- **delegate**: `cliArgs` carries only static flags (`-p`, `--no-session`), a `mkdtemp` role-file path (no metachars), and `provider`/`model` from the user's own config. The free-form **task travels via stdin, never argv** — so task content can never be shell-interpreted.
- **npm**: args are fully static + a version string that passed `SEMVER_RE` (digits/dots only).

## Verification

- `npm run typecheck` ✅ clean
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅ success
- On Linux this change is a behavioral no-op (`process.platform === "win32"` is `false`) — confirmed by existing tests passing unchanged. The Windows fix is by construction (the documented fix for spawn-ENOENT-on-.cmd).