### PR TITLE
release v0.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.16 (patch)

Windows compat fix release.

### What ships
- **Windows spawn fix (PR #52)** — On Windows, `child_process.spawn()`/`execFile()` do not search PATH and cannot find the `.cmd` shims (`pi.cmd`, `npm.cmd`) npm global installs generate, causing ENOENT (exit -4058 / 0xFFFFF026). Two call sites fixed via `shell: process.platform === "win32"`:
  - `src/delegate-tool.ts` — **acp_delegate was completely broken on Windows** (0-second failure)
  - `src/update.ts` — **auto-update silently failed** on Windows
  - No-op on Linux/macOS (direct exec preserved, no DEP0190 warning, real pid for cancel). No injection risk (task via stdin, static argv).

### Bump
- `0.1.15` → `0.1.16` (pai-acp only; `acp-kernel` stays pinned at `0.0.16`).
- Refreshes `package-lock.json`.

### Pre-flight
- `npm run typecheck` ✅ clean
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅ success

### Cross-repo dependency
None — `acp-kernel` is unchanged at `0.0.16` (no kernel release needed).