### PR TITLE
release v0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.17 (patch)

Delegate messaging fix release.

### What ships
- **Delegate messaging fix (PR #54)** — three fixes driven by observed model behavior:
  1. **Stop polling** — async result no longer suggests `acp_delegate_status`; says "the result will find you". Description narrows status/cancel to genuine use cases.
  2. **Injection is system, not user** — injected header now self-identifies as an automated system notification; new `ACP_DELEGATE NOTIFICATIONS` section in the system prompt teaches the model to recognize `[acp_delegate ...]` headers and not treat them as new user requests (pi injects all custom messages as role:user to the LLM — no API to avoid, so wording carries the disambiguation).
  3. **Stale copy** — dropped leftover `preview` mentions (PR #47 already removed previews).

### Bump
- `0.1.16` → `0.1.17` (pai-acp only; `acp-kernel` stays pinned at `0.0.16`).

### Pre-flight
- `npm run typecheck` ✅
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅

### Cross-repo dependency
None — `acp-kernel` unchanged at `0.0.16`.