### PR TITLE
release v0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.18 (minor)

Delegate mechanism redesign — replace polling status tool with blocking wait.

### What ships (PR #56, 4 commits)

**Replace `acp_delegate_status` with `acp_delegate_wait`.** The model kept polling the non-blocking status tool despite copy telling it not to — a status tool is structurally an invitation to poll. The only way to fetch a delegate result is now `acp_delegate_wait({ runId, timeout? })`, which BLOCKS:

- Run finishes within timeout → result returned (tool owns it, background injection suppressed via `run.consumed`)
- Timeout (default **10s**, max 300s, min 1s) → "failed, go do other work" — do not retry; a completion notification is still injected when the run finishes
- ESC abort → "aborted, still running" → injection still fires

**No status tool ⇒ no poll loop is expressible.** This unifies async + sync: `wait` with a big timeout == sync; let it lapse == async injection. The model picks per call. Default 10s keeps parallel-dispatch latency low (10 delegates × 10s = 100s worst case, not 10+ minutes).

**Reviewer-driven hardening** (del_msdaocyh_oalg):
- **M1** atomic status+result: close flipped status synchronously but set result asynchronously — a concurrent wait could observe "finished" with no result, read an empty file path, and suppress injection → silent permanent loss. Fix: flip status inside `.then`, atomically with result.
- **M2** clearTimeout: setTimeout handle now captured and cleared in finish (was leaking dead timers holding closures, delaying event-loop exit).
- **m4** spawn-error finalize: `child.on("error")` now atomically sets status + synthetic result and wakes a parked waiter (Node does not guarantee a follow-up close).
- **m5** refuse double-wait on the same run (was orphaning the first waiter's timer/listener).
- System prompt `ACP_DELEGATE NOTIFICATIONS` section teaches wait as the sole result path.
- README / README.zh-CN tool tables updated (status → wait).

### Bump
- `0.1.17` → `0.1.18` (pai-acp only; `acp-kernel` stays pinned at `0.0.16`).

### Pre-flight
- `npm run typecheck` ✅
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅

### Cross-repo dependency
None — `acp-kernel` unchanged at `0.0.16`.

### Note on version bump
Minor (0.1.17 → 0.1.18): the tool surface changes (status removed, wait added) — a public API change for any consumer scripting against the delegate tools, so a patch bump would understate it.