### PR TITLE
release v0.1.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.19 (patch)

Delegate batch-count visibility.

### What ships (PR #58, 2 commits)

**Remaining-running count on every completion surface.** When the model dispatches several delegates in a batch, it tends to lose count of outstanding runs — after one or two return it may assume the batch is done and stop waiting for the rest. Every completion now reports how many delegates are still running:

- **Injected notification**: `[acp_delegate completed] **oracle** (runId del_..., exit 0) 3 delegates are still running; keep doing other work and their notifications will arrive as they finish.` (or `No delegates are currently running.`)
- **acp_delegate_wait result**: `Delegate **oracle** ... completed (exit 0) 3 delegates are still running.`

**Reviewer-driven polish** (del_msdxsw7z_29q7, no CRITICAL/MAJOR found):
- Count correctness verified: atomic status flip happens before the count read (same sync tick, no drift); 5-delegate batch countdown traces correctly (4→3→2→1→0); `status==="running"` filter correctly excludes completed/failed/cancelled.
- **MINOR 2** (pre-existing, exposed here): cancelled-via-waiter was rendering a misleading "could not be persisted" (cancelled runs have no result) — now short-circuits to an honest "was cancelled" message.
- **MINOR 1**: made the cancel-then-wait and wait-then-cancel paths consistent (both show the remaining count via a shared `remainingLineForWait` helper).

### Bump
- `0.1.18` → `0.1.19` (pai-acp only; `acp-kernel` stays pinned at `0.0.16`).

### Pre-flight
- `npm run typecheck` ✅
- `npm test` ✅ 46 pass / 0 fail
- `npm run build` ✅

### Cross-repo dependency
None — `acp-kernel` unchanged at `0.0.16`.