### PR TITLE
fix: delegate spawn breaks under pi-stable fork + state pollutes cwd

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -344,7 +344,12 @@ async function runDelegate(
   }
   debug.event("delegate-spawn", { agent: args.agent, cwd, async: isAsync, cliArgs });
 
-  const child = spawn("pi", cliArgs, {
+  // Spawn a child pi process using the SAME binary that is currently running.
+  // Hardcoding "pi" breaks under renamed forks (e.g. pi-stable whose bin is
+  // "pi-stable"). process.execPath is the Node binary, process.argv[1] is the
+  // cli.js entrypoint of the currently running pi — together they always point
+  // at the right executable regardless of how it was installed.
+  const child = spawn(process.execPath, [process.argv[1]!, ...cliArgs], {
     cwd,
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],

--- a/src/state.ts
+++ b/src/state.ts
@@ -4,9 +4,11 @@ import { createInitialState, type CompressionState } from "acp-kernel";
 
 const STATE_SUFFIX = ".acp.json";
 
-function stateFileFor(sessionFile: string | undefined, sessionId: string): string | null {
+function stateFileFor(sessionFile: string | undefined): string | null {
   if (sessionFile) return sessionFile + STATE_SUFFIX;
-  if (sessionId) return path.join(process.cwd(), `.acp-${sessionId}${STATE_SUFFIX}`);
+  // No session file (--no-session, e.g. delegate children): state is ephemeral,
+  // do NOT persist. Previously this fell back to process.cwd() and polluted
+  // the parent's working directory with .acp-<sid>.json litter.
   return null;
 }
 
@@ -14,8 +16,8 @@ export class SessionStateStore {
   private cache: CompressionState | null = null;
   private loadedKey: string | null = null;
 
-  async load(sessionFile: string | undefined, sessionId: string): Promise<CompressionState> {
-    const file = stateFileFor(sessionFile, sessionId);
+  async load(sessionFile: string | undefined, _sessionId: string): Promise<CompressionState> {
+    const file = stateFileFor(sessionFile);
     if (file && this.loadedKey === file && this.cache) return this.cache;
     let state = createInitialState();
     if (file) {
@@ -32,9 +34,9 @@ export class SessionStateStore {
     return state;
   }
 
-  async save(state: CompressionState, sessionFile: string | undefined, sessionId: string): Promise<void> {
-    const file = stateFileFor(sessionFile, sessionId);
-    if (!file) return;
+  async save(state: CompressionState, sessionFile: string | undefined, _sessionId: string): Promise<void> {
+    const file = stateFileFor(sessionFile);
+    if (!file) return; // ephemeral session: don't persist
     this.cache = state;
     this.loadedKey = file;
     const dir = path.dirname(file);


### PR DESCRIPTION
## Two bugs

### Bug 1: delegate cannot start under pi-stable fork
`delegate-tool.ts` hardcoded `spawn("pi", ...)`. Under a renamed fork (e.g. `pi-stable` whose bin is `pi-stable`), the `pi` command does not exist in PATH → every delegate exits with code -2 (command not found).

**Fix:** use `process.execPath` (current Node binary) + `process.argv[1]` (current cli.js entrypoint). Always points at the currently-running pi regardless of how it was installed or named.

### Bug 2: state file pollutes parent working directory
`state.ts` `stateFileFor()` fell back to `path.join(process.cwd(), `.acp-${sessionId}.json`)` when `sessionFile` was undefined. Delegate children run with `--no-session`, so every delegate wrote a `.acp-<sid>.json` state file into the parent's working directory. Found 32 stale litter files.

**Fix:** return `null` when no session file — ephemeral sessions are not persisted (correct because `--no-session` processes are one-shot).

## Verification
- typecheck ✅
- 47 tests pass ✅
- build ✅
- Cleaned 32 stale `.acp-*.json` files from project root
- Delegate tested live: pwd=/tmp, exit 0, no litter