### PR TITLE
release v0.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release with delegate fixes from #64.

## Changes
- fix: delegate spawn breaks under renamed forks (pi-stable) — use process.execPath + process.argv[1] instead of hardcoded "pi"
- fix: state file pollutes parent working directory — no longer persist state for --no-session ephemeral sessions

## Bundled
- acp-kernel pinned at 0.0.16 (unchanged from 0.1.20)

## Pre-flight
- typecheck ✅
- 47 tests pass ✅
- build ✅