### PR TITLE
feat: add rename notice (pai-acp → billion-context-pi)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,8 +1,31 @@
 import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent, formatRanges } from "acp-kernel";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 declare const CURRENT_VERSION: string;
+
+/** The running package name, resolved from the extension's own package.json.
+ *  Same source works under both names (pai-acp and billion-context-pi). */
+function getDisplayName(): string {
+  try {
+    let dir = dirname(fileURLToPath(import.meta.url));
+    for (;;) {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+      if (pkg?.name === "pai-acp" || pkg?.name === "billion-context-pi") {
+        return pkg.name;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    // best-effort
+  }
+  return "pai-acp";
+}
 
 type CommandOptions = Omit<RegisteredCommand, "name" | "sourceInfo">;
 
@@ -113,7 +136,7 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
 
   const lines: string[] = [];
 
-  const versionStr = CURRENT_VERSION ? `pai-acp@${CURRENT_VERSION}` : "";
+  const versionStr = CURRENT_VERSION ? `${getDisplayName()}@${CURRENT_VERSION}` : "";
 
   lines.push("╭─────────────────────────────────────────────╮");
   lines.push("│           ACP Context Analysis              │");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { delegateStatusWidget } from "./fleet-widget.js";
 import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
-import { getRenameNotice } from "./rename-notice.js";
+import { checkRename } from "./rename-notice.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
@@ -77,13 +77,12 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
-    // Rename notice: pai-acp → billion-context-pi. No throttle — show every
-    // launch until the user migrates. Self-detects the running package name,
-    // so it stays silent once renamed.
+    // Rename: pai-acp → billion-context-pi. Auto-migrates (install new +
+    // rewrite settings + uninstall old) once a real version of the new
+    // package is published; until then shows a friendly notice. Self-detects
+    // the running package name, so it stays silent once renamed.
     if (ctx.hasUI) {
-      void getRenameNotice().then((msg) => {
-        if (msg) ctx.ui.notify(msg);
-      });
+      void checkRename((msg) => ctx.ui.notify(msg));
     }
     // Idempotently ensure all builtin pi-subagents have ACP context tools
     // (compress/decompress/search_context/acp_status) in their allowlists.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { delegateStatusWidget } from "./fleet-widget.js";
 import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
-import { checkRename } from "./rename-notice.js";
+import { checkRename, isLegacyPackage, isNewPackageInstalled } from "./rename-notice.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
@@ -28,6 +28,26 @@ type AgentMessage = SessionMessageEntry["message"];
 
 export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactory {
   return (pi: ExtensionAPI) => {
+    // Self-disable: if this is the legacy pai-acp package AND the new
+    // billion-context-pi is already installed in node_modules, register
+    // nothing (no tools, no context hooks) so both packages can coexist in
+    // settings.json without double-registering compress/decompress or running
+    // context transforms twice. The new package takes over entirely; the
+    // legacy one is inert and just nudges the user to uninstall it.
+    if (isLegacyPackage() && isNewPackageInstalled()) {
+      pi.on("session_start", async (_event, ctx) => {
+        if (ctx.hasUI) {
+          try {
+            const { checkRename } = await import("./rename-notice.js");
+            checkRename((m) => ctx.ui.notify(m));
+          } catch {
+            // best-effort
+          }
+        }
+      });
+      return;
+    }
+
     const runtime = createRuntime(adapter);
     wireCompactionDisable(pi);
     wireSessionLifecycle(pi, runtime);
@@ -77,11 +97,11 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
-    // Rename: pai-acp → billion-context-pi. Auto-migrates (install new +
-    // rewrite settings + uninstall old) once a real version of the new
-    // package is published; until then shows a friendly notice. Self-detects
-    // the running package name, so it stays silent once renamed.
-    if (ctx.hasUI) {
+    // Rename: pai-acp → billion-context-pi. Once a real version of the new
+    // package is published, installs it (additive — does NOT uninstall the
+    // legacy package). On next launch the factory self-disables the legacy
+    // copy when it detects the new package in node_modules.
+    if (isLegacyPackage() && ctx.hasUI) {
       void checkRename((msg) => ctx.ui.notify(msg));
     }
     // Idempotently ensure all builtin pi-subagents have ACP context tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { delegateStatusWidget } from "./fleet-widget.js";
 import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
+import { getRenameNotice } from "./rename-notice.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
@@ -76,6 +77,14 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
+    // Rename notice: pai-acp → billion-context-pi. No throttle — show every
+    // launch until the user migrates. Self-detects the running package name,
+    // so it stays silent once renamed.
+    if (ctx.hasUI) {
+      void getRenameNotice().then((msg) => {
+        if (msg) ctx.ui.notify(msg);
+      });
+    }
     // Idempotently ensure all builtin pi-subagents have ACP context tools
     // (compress/decompress/search_context/acp_status) in their allowlists.
     // Settings.json is patched safely (backup + optimistic mtime lock + verify).

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     if (isLegacyPackage() && isNewPackageInstalled()) {
       pi.on("session_start", async (_event, ctx) => {
         if (ctx.hasUI) {
-          try {
-            const { checkRename } = await import("./rename-notice.js");
-            checkRename((m) => ctx.ui.notify(m));
-          } catch {
-            // best-effort
-          }
+          checkRename((m) => ctx.ui.notify(m));
         }
       });
       return;

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -1,23 +1,25 @@
-import { readFile, writeFile, rename } from "node:fs/promises";
+import { readFileSync, existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
 
 const LEGACY_NAME = "pai-acp";
 const NEW_NAME = "billion-context-pi";
-const LEGACY_REF = `npm:${LEGACY_NAME}`;
 const NEW_REF = `npm:${NEW_NAME}`;
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_NAME}/latest`;
 
 type PackageJson = { name?: string };
 
 /** Walk up from this module to find the extension's package.json (matching
- *  either the legacy or new name). Returns the directory or undefined. */
-async function findExtensionDir(): Promise<string | undefined> {
+ *  either name). SYNC version for use in the synchronous factory function.
+ *  Uses the `parent === dir` stabilization guard so it terminates on Windows
+ *  drive roots (e.g. `C:\`) where `dirname("C:\\") === "C:\\"`. */
+function findExtensionDirSync(): string | undefined {
   let dir = dirname(fileURLToPath(import.meta.url));
   for (;;) {
     try {
-      const data = JSON.parse(await readFile(join(dir, "package.json"), "utf-8"));
+      const data = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
       if (data?.name === LEGACY_NAME || data?.name === NEW_NAME) return dir;
     } catch {
       // not found / bad json — keep walking
@@ -28,39 +30,53 @@ async function findExtensionDir(): Promise<string | undefined> {
   }
 }
 
-/** Returns the running package name (pai-acp or billion-context-pi), or
- *  undefined if it cannot be determined. */
-async function getPackageName(): Promise<string | undefined> {
-  const dir = await findExtensionDir();
-  if (!dir) return undefined;
-  try {
-    const data = JSON.parse(await readFile(join(dir, "package.json"), "utf-8"));
-    return data?.name;
-  } catch {
-    return undefined;
-  }
-}
-
-function findNpmRoot(extDir: string): string | undefined {
+/** Walk up to the npm root (first ancestor ending in `node_modules`, return
+ *  its parent). SYNC. Same stabilization guard as findExtensionDirSync. */
+function findNpmRootSync(extDir: string): string | undefined {
   let dir = dirname(extDir);
-  while (dir !== "/" && dir !== ".") {
+  for (;;) {
     if (dir.endsWith("node_modules")) return dirname(dir);
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
   }
-  return undefined;
 }
 
-/** Resolve settings.json location. pai-acp lives in
- *  <agentDir>/npm/node_modules/pai-acp, so the npm root is <agentDir>/npm
- *  and its parent is agentDir. Works for any pi fork's configDir. */
-function resolveSettingsPath(npmDir: string): string {
-  return join(dirname(npmDir), "settings.json");
+/** SYNC: is the running package the legacy pai-acp? Used by the factory to
+ *  decide whether self-disable logic applies. */
+export function isLegacyPackage(): boolean {
+  const dir = findExtensionDirSync();
+  if (!dir) return false;
+  try {
+    const data = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+    return data?.name === LEGACY_NAME;
+  } catch {
+    return false;
+  }
+}
+
+/** SYNC: has billion-context-pi been installed in the shared node_modules?
+ *  Used by the legacy factory to self-disable when the new package takes over.
+ *  Checks the physical node_modules directory (not settings.json), so it is
+ *  unaffected by settings scope (user vs project). */
+export function isNewPackageInstalled(): boolean {
+  const extDir = findExtensionDirSync();
+  if (!extDir) return false;
+  const npmDir = findNpmRootSync(extDir);
+  if (!npmDir) return false;
+  try {
+    const data = JSON.parse(
+      readFileSync(join(npmDir, "node_modules", NEW_NAME, "package.json"), "utf-8"),
+    );
+    return data?.name === NEW_NAME;
+  } catch {
+    return false;
+  }
 }
 
 /** Returns true if billion-context-pi has a real release (version > 0.0.1
  *  placeholder) published to npm. Migration only fires once a real version
- *  exists — otherwise it would install the empty placeholder and the user
- *  would lose all ACP functionality. */
+ *  exists — otherwise it would install the empty placeholder. */
 async function newPackageReady(): Promise<boolean> {
   try {
     const res = await fetch(REGISTRY_URL, {
@@ -77,57 +93,21 @@ async function newPackageReady(): Promise<boolean> {
 }
 
 /** Run a pi subcommand using the CURRENT pi process (node + cli.js), so the
- *  migration follows whatever pi fork the user is running (pi / pi-stable /
- *  any other). stdin is ignored to avoid hanging on unexpected prompts. */
+ *  install follows whatever pi fork the user is running. stdin is ignored to
+ *  avoid hanging on unexpected prompts. */
 function runPi(args: string[]): Promise<number> {
   const cliEntry = process.argv[1];
-  if (!cliEntry) return Promise.resolve(1);
+  if (!cliEntry || !existsSync(cliEntry)) return Promise.resolve(1);
   return new Promise((resolve) => {
-    execFile(
+    const child = execFile(
       process.execPath,
       [cliEntry, ...args],
       { timeout: 120_000, shell: false },
-      (err) => resolve(err ? 1 : 0),
+      (err: NodeJS.ErrnoException | null) => resolve(err ? 1 : 0),
     );
+    // Ignore stdin so an unexpected prompt cannot hang the child.
+    child.stdin?.end();
   });
-}
-
-/** Backup settings.json for restore-on-failure. Returns the backup path or
- *  undefined if backup failed (caller falls back to manual notice). */
-async function backupSettings(settingsPath: string): Promise<string | undefined> {
-  try {
-    const bak = `${settingsPath}.migrate.bak`;
-    const raw = await readFile(settingsPath, "utf-8");
-    await writeFile(bak, raw, "utf-8");
-    return bak;
-  } catch {
-    return undefined;
-  }
-}
-
-async function restoreSettings(settingsPath: string, bak: string): Promise<void> {
-  try {
-    const raw = await readFile(bak, "utf-8");
-    const tmp = `${settingsPath}.tmp`;
-    await writeFile(tmp, raw, "utf-8");
-    await rename(tmp, settingsPath);
-  } catch {
-    // best-effort restore; if this fails the user is in an unknown state,
-    // but pi's own install/uninstall failures leave settings in a consistent
-    // shape (they use the SettingsManager which is transactional).
-  }
-}
-
-/** Verify migration outcome: settings.json should reference the new package
- *  and not the legacy one. */
-async function verifyMigrated(settingsPath: string): Promise<boolean> {
-  try {
-    const data = JSON.parse(await readFile(settingsPath, "utf-8"));
-    const pkgs: string[] = Array.isArray(data.packages) ? data.packages : [];
-    return pkgs.includes(NEW_REF) && !pkgs.includes(LEGACY_REF);
-  } catch {
-    return false;
-  }
 }
 
 const GREEN = "\x1b[32m";
@@ -135,94 +115,79 @@ const CYAN = "\x1b[36m";
 const RESET = "\x1b[0m";
 
 function manualNotice(): string {
-  // NB: wrap the whole block in a single color span (no per-line resets).
-  // pi's showStatus wraps the message in theme.fg("dim", ...) — a per-line
-  // reset would clear that dim and leave subsequent lines colorless.
   const body = [
     "\u2192 pai-acp is now billion-context-pi",
     "Your context tools are unchanged — same package, new name.",
     "To switch:",
-    "  pi uninstall pai-acp",
     "  pi install billion-context-pi",
+    "  pi uninstall pai-acp",
     "(Your ~/.pi/acp.json config carries over.)",
   ].join("\n");
   return `${CYAN}${body}${RESET}`;
 }
 
+function installingNotice(): string {
+  return `${CYAN}Installing billion-context-pi\u2026${RESET}`;
+}
+
 function successNotice(): string {
-  const body = `✔ Auto-migrated to billion-context-pi — restart Pi to finish.`;
-  return `${GREEN}${body}${RESET}`;
+  return `${GREEN}\u2714 billion-context-pi installed — restart Pi to switch.${RESET}`;
 }
 
-function rollbackNotice(): string {
+/** Notice shown when self-disabled (new package is active, legacy is inert). */
+function canUninstallNotice(): string {
   const body = [
-    "\u2192 pai-acp → billion-context-pi migration was rolled back.",
-    "Settings restored. You can migrate manually:",
-    "  pi uninstall pai-acp",
-    "  pi install billion-context-pi",
+    `${GREEN}\u2714 billion-context-pi is active.${RESET}`,
+    `${CYAN}pai-acp is now inert. To clean up:${RESET}`,
+    `  ${CYAN}pi uninstall pai-acp${RESET}`,
   ].join("\n");
-  return `${CYAN}${body}${RESET}`;
+  return body;
 }
 
-/** Auto-migrate using the running pi's own package manager (pi install /
- *  pi uninstall), not raw npm — so location, lockfile and settings.json are
- *  all handled correctly by pi itself. Order: backup → install new →
- *  uninstall old → verify. Any failure restores the backup and falls back
- *  to the manual notice. The current process keeps running from in-memory
- *  code, so uninstalling the legacy package on disk is safe. */
-async function autoMigrate(): Promise<string> {
-  const extDir = await findExtensionDir();
-  if (!extDir) return manualNotice();
-  const npmDir = findNpmRoot(extDir);
-  if (!npmDir) return manualNotice();
-  const settingsPath = resolveSettingsPath(npmDir);
-
-  // 1. Backup settings.json (atomic-ish: we read then write a sibling file).
-  const bak = await backupSettings(settingsPath);
-
-  // 2. Install the new package first. If this fails, nothing changed
-  //    (pi install is transactional) — settings still has pai-acp only.
-  if ((await runPi(["install", NEW_REF])) !== 0) {
-    return manualNotice();
-  }
-
-  // 3. Uninstall the legacy package. If this fails, settings may now have
-  //    both packages — restore the backup so the user boots into pai-acp
-  //    (not a double-loaded state). The newly installed billion-context-pi
-  //    on disk is harmless (unused until referenced).
-  if ((await runPi(["uninstall", LEGACY_REF])) !== 0) {
-    if (bak) await restoreSettings(settingsPath, bak);
-    return bak ? rollbackNotice() : manualNotice();
-  }
-
-  // 4. Verify the final settings state.
-  if (!(await verifyMigrated(settingsPath))) {
-    if (bak) await restoreSettings(settingsPath, bak);
-    return bak ? rollbackNotice() : manualNotice();
-  }
-
-  return successNotice();
+/** Install the new package alongside the legacy one (does NOT uninstall the
+ *  legacy package). Safe because install is additive and idempotent: a
+ *  failure leaves settings.json unchanged, and two concurrent sessions both
+ *  installing the same package is harmless. Returns true on success. */
+async function installNewPackage(): Promise<boolean> {
+  return (await runPi(["install", NEW_REF])) === 0;
 }
 
 let migrateInFlight = false;
 
-/** Checks if the extension is running under the legacy name (pai-acp) and
- *  migrates to billion-context-pi. If a real version of the new package is
- *  published, performs the migration automatically (backup → install new →
- *  uninstall old → verify, with rollback on any failure). Otherwise, shows a
- *  friendly notice with manual steps. Stays silent once renamed. */
+/** Called from session_start of the LEGACY package (only). If the new package
+ *  has a real release on npm, installs it and notifies the user to restart.
+ *  The legacy package then self-disables on the next launch (factory detects
+ *  the new package in node_modules and registers nothing). Until a real
+ *  release exists, shows a friendly manual notice. */
 export async function checkRename(notify: (msg: string) => void): Promise<void> {
-  const name = await getPackageName();
-  if (name !== LEGACY_NAME) return;
+  const safeNotify = (msg: string) => {
+    try {
+      notify(msg);
+    } catch {
+      // notification must never crash the host
+    }
+  };
   if (migrateInFlight) return;
   migrateInFlight = true;
   try {
+    // If the new package is already installed, this session is the inert
+    // legacy copy (the factory already self-disabled the active logic).
+    // Just nudge the user to uninstall.
+    if (isNewPackageInstalled()) {
+      safeNotify(canUninstallNotice());
+      return;
+    }
     const ready = await newPackageReady();
-    const msg = ready ? await autoMigrate() : manualNotice();
-    notify(msg);
+    if (!ready) {
+      safeNotify(manualNotice());
+      return;
+    }
+    // Real version exists — install it (additive, safe).
+    safeNotify(installingNotice());
+    const ok = await installNewPackage();
+    safeNotify(ok ? successNotice() : manualNotice());
   } catch {
-    // any unexpected error — fall back to manual notice, don't crash
-    notify(manualNotice());
+    safeNotify(manualNotice());
   } finally {
     migrateInFlight = false;
   }

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -5,6 +5,8 @@ import { execFile } from "node:child_process";
 
 const LEGACY_NAME = "pai-acp";
 const NEW_NAME = "billion-context-pi";
+const LEGACY_REF = `npm:${LEGACY_NAME}`;
+const NEW_REF = `npm:${NEW_NAME}`;
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_NAME}/latest`;
 
 type PackageJson = { name?: string };
@@ -39,15 +41,6 @@ async function getPackageName(): Promise<string | undefined> {
   }
 }
 
-/** Resolve settings.json location. Prefer inferring from the extension's
- *  install location (works for any pi fork's configDir: the npm root is
- *  always <agentDir>/npm, so its parent is agentDir). Fall back to the
- *  standard ~/.pi/agent path if the structure is unexpected. */
-function resolveSettingsPath(npmDir: string): string {
-  const inferred = join(dirname(npmDir), "settings.json");
-  return inferred;
-}
-
 function findNpmRoot(extDir: string): string | undefined {
   let dir = dirname(extDir);
   while (dir !== "/" && dir !== ".") {
@@ -55,6 +48,13 @@ function findNpmRoot(extDir: string): string | undefined {
     dir = dirname(dir);
   }
   return undefined;
+}
+
+/** Resolve settings.json location. pai-acp lives in
+ *  <agentDir>/npm/node_modules/pai-acp, so the npm root is <agentDir>/npm
+ *  and its parent is agentDir. Works for any pi fork's configDir. */
+function resolveSettingsPath(npmDir: string): string {
+  return join(dirname(npmDir), "settings.json");
 }
 
 /** Returns true if billion-context-pi has a real release (version > 0.0.1
@@ -76,41 +76,55 @@ async function newPackageReady(): Promise<boolean> {
   }
 }
 
-function runNpm(args: string[], cwd: string): Promise<number> {
+/** Run a pi subcommand using the CURRENT pi process (node + cli.js), so the
+ *  migration follows whatever pi fork the user is running (pi / pi-stable /
+ *  any other). stdin is ignored to avoid hanging on unexpected prompts. */
+function runPi(args: string[]): Promise<number> {
+  const cliEntry = process.argv[1];
+  if (!cliEntry) return Promise.resolve(1);
   return new Promise((resolve) => {
-    execFile("npm", args, { cwd, timeout: 60_000, shell: process.platform === "win32" }, (err) =>
-      resolve(err ? 1 : 0),
+    execFile(
+      process.execPath,
+      [cliEntry, ...args],
+      { timeout: 120_000, shell: false },
+      (err) => resolve(err ? 1 : 0),
     );
   });
 }
 
-/** Atomically rewrite settings.json: replace "npm:pai-acp" with
- *  "npm:billion-context-pi" in the packages array. Returns false if the
- *  file is missing, unparseable, or doesn't reference pai-acp. */
-async function updateSettingsPackages(npmDir: string): Promise<boolean> {
-  const settingsPath = resolveSettingsPath(npmDir);
-  let raw: string;
+/** Backup settings.json for restore-on-failure. Returns the backup path or
+ *  undefined if backup failed (caller falls back to manual notice). */
+async function backupSettings(settingsPath: string): Promise<string | undefined> {
   try {
-    raw = await readFile(settingsPath, "utf-8");
+    const bak = `${settingsPath}.migrate.bak`;
+    const raw = await readFile(settingsPath, "utf-8");
+    await writeFile(bak, raw, "utf-8");
+    return bak;
   } catch {
-    return false;
+    return undefined;
   }
-  let data: { packages?: string[] };
+}
+
+async function restoreSettings(settingsPath: string, bak: string): Promise<void> {
   try {
-    data = JSON.parse(raw);
-  } catch {
-    return false;
-  }
-  if (!Array.isArray(data.packages)) return false;
-  const oldRef = `npm:${LEGACY_NAME}`;
-  const newRef = `npm:${NEW_NAME}`;
-  if (!data.packages.includes(oldRef)) return false;
-  data.packages = data.packages.map((p) => (p === oldRef ? newRef : p));
-  const tmp = `${settingsPath}.tmp`;
-  try {
-    await writeFile(tmp, JSON.stringify(data, null, "\t"), "utf-8");
+    const raw = await readFile(bak, "utf-8");
+    const tmp = `${settingsPath}.tmp`;
+    await writeFile(tmp, raw, "utf-8");
     await rename(tmp, settingsPath);
-    return true;
+  } catch {
+    // best-effort restore; if this fails the user is in an unknown state,
+    // but pi's own install/uninstall failures leave settings in a consistent
+    // shape (they use the SettingsManager which is transactional).
+  }
+}
+
+/** Verify migration outcome: settings.json should reference the new package
+ *  and not the legacy one. */
+async function verifyMigrated(settingsPath: string): Promise<boolean> {
+  try {
+    const data = JSON.parse(await readFile(settingsPath, "utf-8"));
+    const pkgs: string[] = Array.isArray(data.packages) ? data.packages : [];
+    return pkgs.includes(NEW_REF) && !pkgs.includes(LEGACY_REF);
   } catch {
     return false;
   }
@@ -118,7 +132,6 @@ async function updateSettingsPackages(npmDir: string): Promise<boolean> {
 
 const GREEN = "\x1b[32m";
 const CYAN = "\x1b[36m";
-const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 
 function manualNotice(): string {
@@ -141,27 +154,52 @@ function successNotice(): string {
   return `${GREEN}${body}${RESET}`;
 }
 
-/** Auto-migrate: install the new package, rewrite settings.json, uninstall
- *  the legacy package. The current process keeps running from in-memory
- *  code, so deleting the on-disk package is safe. Returns a notice string. */
+function rollbackNotice(): string {
+  const body = [
+    "\u2192 pai-acp → billion-context-pi migration was rolled back.",
+    "Settings restored. You can migrate manually:",
+    "  pi uninstall pai-acp",
+    "  pi install billion-context-pi",
+  ].join("\n");
+  return `${CYAN}${body}${RESET}`;
+}
+
+/** Auto-migrate using the running pi's own package manager (pi install /
+ *  pi uninstall), not raw npm — so location, lockfile and settings.json are
+ *  all handled correctly by pi itself. Order: backup → install new →
+ *  uninstall old → verify. Any failure restores the backup and falls back
+ *  to the manual notice. The current process keeps running from in-memory
+ *  code, so uninstalling the legacy package on disk is safe. */
 async function autoMigrate(): Promise<string> {
   const extDir = await findExtensionDir();
   if (!extDir) return manualNotice();
   const npmDir = findNpmRoot(extDir);
   if (!npmDir) return manualNotice();
+  const settingsPath = resolveSettingsPath(npmDir);
 
-  // 1. Install the new package.
-  if ((await runNpm(["install", `${NEW_NAME}@latest`, "--silent", "--no-audit", "--no-fund"], npmDir)) !== 0) {
+  // 1. Backup settings.json (atomic-ish: we read then write a sibling file).
+  const bak = await backupSettings(settingsPath);
+
+  // 2. Install the new package first. If this fails, nothing changed
+  //    (pi install is transactional) — settings still has pai-acp only.
+  if ((await runPi(["install", NEW_REF])) !== 0) {
     return manualNotice();
   }
-  // 2. Rewrite settings.json. If this fails, don't uninstall — leave both
-  //    packages present so the user can fix it manually.
-  if (!(await updateSettingsPackages(npmDir))) {
-    return manualNotice();
+
+  // 3. Uninstall the legacy package. If this fails, settings may now have
+  //    both packages — restore the backup so the user boots into pai-acp
+  //    (not a double-loaded state). The newly installed billion-context-pi
+  //    on disk is harmless (unused until referenced).
+  if ((await runPi(["uninstall", LEGACY_REF])) !== 0) {
+    if (bak) await restoreSettings(settingsPath, bak);
+    return bak ? rollbackNotice() : manualNotice();
   }
-  // 3. Uninstall the legacy package. Current process is unaffected (ESM
-  //    modules are loaded into memory; deleting the directory is safe).
-  await runNpm(["uninstall", LEGACY_NAME, "--silent"], npmDir);
+
+  // 4. Verify the final settings state.
+  if (!(await verifyMigrated(settingsPath))) {
+    if (bak) await restoreSettings(settingsPath, bak);
+    return bak ? rollbackNotice() : manualNotice();
+  }
 
   return successNotice();
 }
@@ -170,9 +208,9 @@ let migrateInFlight = false;
 
 /** Checks if the extension is running under the legacy name (pai-acp) and
  *  migrates to billion-context-pi. If a real version of the new package is
- *  published, performs the migration automatically (install + config update
- *  + uninstall). Otherwise, shows a friendly notice with manual steps.
- *  Stays silent once renamed. */
+ *  published, performs the migration automatically (backup → install new →
+ *  uninstall old → verify, with rollback on any failure). Otherwise, shows a
+ *  friendly notice with manual steps. Stays silent once renamed. */
 export async function checkRename(notify: (msg: string) => void): Promise<void> {
   const name = await getPackageName();
   if (name !== LEGACY_NAME) return;

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const LEGACY_NAME = "pai-acp";
+const NEW_NAME = "billion-context-pi";
+
+type PackageJson = { name?: string };
+
+/** Walk up from this module to find the extension's package.json (matching
+ *  either the legacy or new name). Returns the directory or undefined. */
+async function findExtensionDir(): Promise<string | undefined> {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (;;) {
+    try {
+      const data = JSON.parse(await readFile(join(dir, "package.json"), "utf-8"));
+      if (data?.name === LEGACY_NAME || data?.name === NEW_NAME) return dir;
+    } catch {
+      // not found / bad json — keep walking
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/** Returns the running package name (pai-acp or billion-context-pi), or
+ *  undefined if it cannot be determined. */
+async function getPackageName(): Promise<string | undefined> {
+  const dir = await findExtensionDir();
+  if (!dir) return undefined;
+  try {
+    const data = JSON.parse(await readFile(join(dir, "package.json"), "utf-8"));
+    return data?.name;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Returns a rename notice if running under the legacy package name (pai-acp),
+ *  or undefined if already renamed (billion-context-pi) or unknown.
+ *
+ *  Shown on every session_start (no throttle) so users who haven't migrated
+ *  keep seeing the prompt until they switch. */
+export async function getRenameNotice(): Promise<string | undefined> {
+  const name = await getPackageName();
+  if (name !== LEGACY_NAME) return undefined;
+  return [
+    "\x1b[33m\u26A0 pai-acp has been renamed to billion-context-pi\x1b[0m",
+    "This package is deprecated. To migrate:",
+    "  1. pi uninstall pai-acp",
+    "  2. pi install billion-context-pi",
+    "Config (~/.pi/acp.json) is preserved automatically.",
+  ].join("\n");
+}

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -113,12 +113,10 @@ const RESET = "\x1b[0m";
 
 function manualNotice(): string {
   const body = [
-    "\u2192 pai-acp is now billion-context-pi",
+    "\u2192 pai-acp has been renamed to billion-context-pi",
     "Your context tools are unchanged — same package, new name.",
-    "To switch:",
-    "  pi install billion-context-pi",
-    "  pi uninstall pai-acp",
-    "(Your ~/.pi/acp.json config carries over.)",
+    "Once billion-context-pi is published, it will install automatically.",
+    "Your ~/.pi/acp.json config carries over.",
   ].join("\n");
   return `${CYAN}${body}${RESET}`;
 }
@@ -128,17 +126,22 @@ function installingNotice(): string {
 }
 
 function successNotice(): string {
-  return `${GREEN}\u2714 billion-context-pi installed — restart Pi to switch.${RESET}`;
+  const body = [
+    "\u2714 pai-acp \u2192 billion-context-pi (renamed, same tools).",
+    "billion-context-pi has been installed. Restart Pi to switch over.",
+    "Do NOT uninstall billion-context-pi — it is the replacement for pai-acp.",
+  ].join("\n");
+  return `${GREEN}${body}${RESET}`;
 }
 
 /** Notice shown when self-disabled (new package is active, legacy is inert). */
 function canUninstallNotice(): string {
   const body = [
-    `${GREEN}\u2714 billion-context-pi is active.${RESET}`,
-    `${CYAN}pai-acp is now inert. To clean up:${RESET}`,
-    `  ${CYAN}pi uninstall pai-acp${RESET}`,
+    "\u2714 You are now running billion-context-pi (formerly pai-acp).",
+    "All your context tools (compress / decompress / search / delegate) are intact.",
+    "pai-acp is now inert and safe to remove:  pi uninstall pai-acp",
   ].join("\n");
-  return body;
+  return `${GREEN}${body}${RESET}`;
 }
 
 /** Install the new package alongside the legacy one (does NOT uninstall the

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -1,9 +1,13 @@
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile, rename } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import { homedir } from "node:os";
 
 const LEGACY_NAME = "pai-acp";
 const NEW_NAME = "billion-context-pi";
+const REGISTRY_URL = `https://registry.npmjs.org/${NEW_NAME}/latest`;
+const SETTINGS_PATH = join(homedir(), ".pi", "agent", "settings.json");
 
 type PackageJson = { name?: string };
 
@@ -37,19 +41,138 @@ async function getPackageName(): Promise<string | undefined> {
   }
 }
 
-/** Returns a rename notice if running under the legacy package name (pai-acp),
- *  or undefined if already renamed (billion-context-pi) or unknown.
- *
- *  Shown on every session_start (no throttle) so users who haven't migrated
- *  keep seeing the prompt until they switch. */
-export async function getRenameNotice(): Promise<string | undefined> {
-  const name = await getPackageName();
-  if (name !== LEGACY_NAME) return undefined;
+function findNpmRoot(extDir: string): string | undefined {
+  let dir = dirname(extDir);
+  while (dir !== "/" && dir !== ".") {
+    if (dir.endsWith("node_modules")) return dirname(dir);
+    dir = dirname(dir);
+  }
+  return undefined;
+}
+
+/** Returns true if billion-context-pi has a real release (version > 0.0.1
+ *  placeholder) published to npm. Migration only fires once a real version
+ *  exists — otherwise it would install the empty placeholder and the user
+ *  would lose all ACP functionality. */
+async function newPackageReady(): Promise<boolean> {
+  try {
+    const res = await fetch(REGISTRY_URL, {
+      signal: AbortSignal.timeout(5000),
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as { version?: string };
+    const v = (data.version ?? "0.0.0").split(".").map((n) => parseInt(n, 10) || 0);
+    return (v[0] ?? 0) > 0 || (v[1] ?? 0) > 0 || (v[2] ?? 0) > 1;
+  } catch {
+    return false;
+  }
+}
+
+function runNpm(args: string[], cwd: string): Promise<number> {
+  return new Promise((resolve) => {
+    execFile("npm", args, { cwd, timeout: 60_000, shell: process.platform === "win32" }, (err) =>
+      resolve(err ? 1 : 0),
+    );
+  });
+}
+
+/** Atomically rewrite settings.json: replace "npm:pai-acp" with
+ *  "npm:billion-context-pi" in the packages array. Returns false if the
+ *  file is missing, unparseable, or doesn't reference pai-acp. */
+async function updateSettingsPackages(): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await readFile(SETTINGS_PATH, "utf-8");
+  } catch {
+    return false;
+  }
+  let data: { packages?: string[] };
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(data.packages)) return false;
+  const oldRef = `npm:${LEGACY_NAME}`;
+  const newRef = `npm:${NEW_NAME}`;
+  if (!data.packages.includes(oldRef)) return false;
+  data.packages = data.packages.map((p) => (p === oldRef ? newRef : p));
+  const tmp = `${SETTINGS_PATH}.tmp`;
+  try {
+    await writeFile(tmp, JSON.stringify(data, null, "\t"), "utf-8");
+    await rename(tmp, SETTINGS_PATH);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const GREEN = "\x1b[32m";
+const CYAN = "\x1b[36m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+function manualNotice(): string {
   return [
-    "\x1b[33m\u26A0 pai-acp has been renamed to billion-context-pi\x1b[0m",
-    "This package is deprecated. To migrate:",
-    "  1. pi uninstall pai-acp",
-    "  2. pi install billion-context-pi",
-    "Config (~/.pi/acp.json) is preserved automatically.",
+    `${CYAN}\u2192 pai-acp is now billion-context-pi${RESET}`,
+    `${DIM}Your context tools are unchanged — same package, new name.${RESET}`,
+    `To switch:`,
+    `  ${DIM}pi uninstall pai-acp${RESET}`,
+    `  ${DIM}pi install billion-context-pi${RESET}`,
+    `${DIM}(Your ~/.pi/acp.json config carries over.)${RESET}`,
   ].join("\n");
+}
+
+function successNotice(): string {
+  return `${GREEN}\u2714 Auto-migrated to billion-context-pi${RESET} — ${DIM}restart Pi to finish.${RESET}`;
+}
+
+/** Auto-migrate: install the new package, rewrite settings.json, uninstall
+ *  the legacy package. The current process keeps running from in-memory
+ *  code, so deleting the on-disk package is safe. Returns a notice string. */
+async function autoMigrate(): Promise<string> {
+  const extDir = await findExtensionDir();
+  if (!extDir) return manualNotice();
+  const npmDir = findNpmRoot(extDir);
+  if (!npmDir) return manualNotice();
+
+  // 1. Install the new package.
+  if ((await runNpm(["install", `${NEW_NAME}@latest`, "--silent", "--no-audit", "--no-fund"], npmDir)) !== 0) {
+    return manualNotice();
+  }
+  // 2. Rewrite settings.json. If this fails, don't uninstall — leave both
+  //    packages present so the user can fix it manually.
+  if (!(await updateSettingsPackages())) {
+    return manualNotice();
+  }
+  // 3. Uninstall the legacy package. Current process is unaffected (ESM
+  //    modules are loaded into memory; deleting the directory is safe).
+  await runNpm(["uninstall", LEGACY_NAME, "--silent"], npmDir);
+
+  return successNotice();
+}
+
+let migrateInFlight = false;
+
+/** Checks if the extension is running under the legacy name (pai-acp) and
+ *  migrates to billion-context-pi. If a real version of the new package is
+ *  published, performs the migration automatically (install + config update
+ *  + uninstall). Otherwise, shows a friendly notice with manual steps.
+ *  Stays silent once renamed. */
+export async function checkRename(notify: (msg: string) => void): Promise<void> {
+  const name = await getPackageName();
+  if (name !== LEGACY_NAME) return;
+  if (migrateInFlight) return;
+  migrateInFlight = true;
+  try {
+    const ready = await newPackageReady();
+    const msg = ready ? await autoMigrate() : manualNotice();
+    notify(msg);
+  } catch {
+    // any unexpected error — fall back to manual notice, don't crash
+    notify(manualNotice());
+  } finally {
+    migrateInFlight = false;
+  }
 }

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -1,5 +1,4 @@
 import { readFileSync, existsSync } from "node:fs";
-import { readFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
@@ -8,8 +7,6 @@ const LEGACY_NAME = "pai-acp";
 const NEW_NAME = "billion-context-pi";
 const NEW_REF = `npm:${NEW_NAME}`;
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_NAME}/latest`;
-
-type PackageJson = { name?: string };
 
 /** Walk up from this module to find the extension's package.json (matching
  *  either name). SYNC version for use in the synchronous factory function.
@@ -55,10 +52,10 @@ export function isLegacyPackage(): boolean {
   }
 }
 
-/** SYNC: has billion-context-pi been installed in the shared node_modules?
- *  Used by the legacy factory to self-disable when the new package takes over.
- *  Checks the physical node_modules directory (not settings.json), so it is
- *  unaffected by settings scope (user vs project). */
+/** SYNC: has billion-context-pi been installed AND is it loadable?
+ *  Checks both package.json AND dist/index.js to avoid a partial install
+ *  (package.json written but dist missing) self-disabling the legacy package
+ *  before the new one can load — which would leave the user with no ACP tools. */
 export function isNewPackageInstalled(): boolean {
   const extDir = findExtensionDirSync();
   if (!extDir) return false;
@@ -68,7 +65,7 @@ export function isNewPackageInstalled(): boolean {
     const data = JSON.parse(
       readFileSync(join(npmDir, "node_modules", NEW_NAME, "package.json"), "utf-8"),
     );
-    return data?.name === NEW_NAME;
+    return data?.name === NEW_NAME && existsSync(join(npmDir, "node_modules", NEW_NAME, "dist", "index.js"));
   } catch {
     return false;
   }

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -2,12 +2,10 @@ import { readFile, writeFile, rename } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
-import { homedir } from "node:os";
 
 const LEGACY_NAME = "pai-acp";
 const NEW_NAME = "billion-context-pi";
 const REGISTRY_URL = `https://registry.npmjs.org/${NEW_NAME}/latest`;
-const SETTINGS_PATH = join(homedir(), ".pi", "agent", "settings.json");
 
 type PackageJson = { name?: string };
 
@@ -39,6 +37,15 @@ async function getPackageName(): Promise<string | undefined> {
   } catch {
     return undefined;
   }
+}
+
+/** Resolve settings.json location. Prefer inferring from the extension's
+ *  install location (works for any pi fork's configDir: the npm root is
+ *  always <agentDir>/npm, so its parent is agentDir). Fall back to the
+ *  standard ~/.pi/agent path if the structure is unexpected. */
+function resolveSettingsPath(npmDir: string): string {
+  const inferred = join(dirname(npmDir), "settings.json");
+  return inferred;
 }
 
 function findNpmRoot(extDir: string): string | undefined {
@@ -80,10 +87,11 @@ function runNpm(args: string[], cwd: string): Promise<number> {
 /** Atomically rewrite settings.json: replace "npm:pai-acp" with
  *  "npm:billion-context-pi" in the packages array. Returns false if the
  *  file is missing, unparseable, or doesn't reference pai-acp. */
-async function updateSettingsPackages(): Promise<boolean> {
+async function updateSettingsPackages(npmDir: string): Promise<boolean> {
+  const settingsPath = resolveSettingsPath(npmDir);
   let raw: string;
   try {
-    raw = await readFile(SETTINGS_PATH, "utf-8");
+    raw = await readFile(settingsPath, "utf-8");
   } catch {
     return false;
   }
@@ -98,10 +106,10 @@ async function updateSettingsPackages(): Promise<boolean> {
   const newRef = `npm:${NEW_NAME}`;
   if (!data.packages.includes(oldRef)) return false;
   data.packages = data.packages.map((p) => (p === oldRef ? newRef : p));
-  const tmp = `${SETTINGS_PATH}.tmp`;
+  const tmp = `${settingsPath}.tmp`;
   try {
     await writeFile(tmp, JSON.stringify(data, null, "\t"), "utf-8");
-    await rename(tmp, SETTINGS_PATH);
+    await rename(tmp, settingsPath);
     return true;
   } catch {
     return false;
@@ -148,7 +156,7 @@ async function autoMigrate(): Promise<string> {
   }
   // 2. Rewrite settings.json. If this fails, don't uninstall — leave both
   //    packages present so the user can fix it manually.
-  if (!(await updateSettingsPackages())) {
+  if (!(await updateSettingsPackages(npmDir))) {
     return manualNotice();
   }
   // 3. Uninstall the legacy package. Current process is unaffected (ESM

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -102,8 +102,8 @@ function runPi(args: string[]): Promise<number> {
     const child = execFile(
       process.execPath,
       [cliEntry, ...args],
-      { timeout: 120_000, shell: false },
-      (err: NodeJS.ErrnoException | null) => resolve(err ? 1 : 0),
+      { timeout: 120_000, shell: process.platform === "win32" },
+      (err) => resolve(err ? 1 : 0),
     );
     // Ignore stdin so an unexpected prompt cannot hang the child.
     child.stdin?.end();

--- a/src/rename-notice.ts
+++ b/src/rename-notice.ts
@@ -114,18 +114,23 @@ const DIM = "\x1b[2m";
 const RESET = "\x1b[0m";
 
 function manualNotice(): string {
-  return [
-    `${CYAN}\u2192 pai-acp is now billion-context-pi${RESET}`,
-    `${DIM}Your context tools are unchanged — same package, new name.${RESET}`,
-    `To switch:`,
-    `  ${DIM}pi uninstall pai-acp${RESET}`,
-    `  ${DIM}pi install billion-context-pi${RESET}`,
-    `${DIM}(Your ~/.pi/acp.json config carries over.)${RESET}`,
+  // NB: wrap the whole block in a single color span (no per-line resets).
+  // pi's showStatus wraps the message in theme.fg("dim", ...) — a per-line
+  // reset would clear that dim and leave subsequent lines colorless.
+  const body = [
+    "\u2192 pai-acp is now billion-context-pi",
+    "Your context tools are unchanged — same package, new name.",
+    "To switch:",
+    "  pi uninstall pai-acp",
+    "  pi install billion-context-pi",
+    "(Your ~/.pi/acp.json config carries over.)",
   ].join("\n");
+  return `${CYAN}${body}${RESET}`;
 }
 
 function successNotice(): string {
-  return `${GREEN}\u2714 Auto-migrated to billion-context-pi${RESET} — ${DIM}restart Pi to finish.${RESET}`;
+  const body = `✔ Auto-migrated to billion-context-pi — restart Pi to finish.`;
+  return `${GREEN}${body}${RESET}`;
 }
 
 /** Auto-migrate: install the new package, rewrite settings.json, uninstall

--- a/src/update.ts
+++ b/src/update.ts
@@ -6,15 +6,33 @@ import { debug } from "./log.js";
 
 declare const CURRENT_VERSION: string;
 
-const PACKAGE_NAME = "pai-acp";
-const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const LEGACY_NAME = "pai-acp";
+const REGISTRY_BASE = "https://registry.npmjs.org";
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
+// Throttle file is suffixed with the running package name so pai-acp and
+// billion-context-pi don't share the same update-check timestamp.
+function throttleFilePath(name: string): string {
+  return `${process.env.HOME ?? ""}/.pi/agent/.${name}-update-check`;
+}
 const THROTTLE_FILE = `${process.env.HOME ?? ""}/.pi/agent/.pai-acp-update-check`;
 
 // Guards against concurrent checks: the context event fires on every LLM call,
 // so several can race past the throttle read before any writes the timestamp.
 let updateInFlight = false;
+
+/** The running package name, resolved lazily from the extension's own
+ *  package.json. Same source works under both names (pai-acp and the renamed
+ *  billion-context-pi) without editing constants. */
+let cachedPackageName: string | undefined;
+async function getPackageName(): Promise<string | undefined> {
+  if (cachedPackageName !== undefined) return cachedPackageName;
+  const dir = await findExtensionDir();
+  if (!dir) return undefined;
+  const pkg = await readPackageJson(join(dir, "package.json"));
+  cachedPackageName = pkg?.name;
+  return cachedPackageName;
+}
 
 function parseVersion(v: string): number[] {
   return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
@@ -30,19 +48,19 @@ function isNewer(latest: string, current: string): boolean {
   return false;
 }
 
-async function readLastCheck(): Promise<number> {
+async function readLastCheck(name: string): Promise<number> {
   try {
-    const data = await readFile(THROTTLE_FILE, "utf-8");
+    const data = await readFile(throttleFilePath(name), "utf-8");
     return parseInt(data.trim(), 10) || 0;
   } catch {
     return 0;
   }
 }
 
-async function writeLastCheck(timestamp: number): Promise<void> {
+async function writeLastCheck(name: string, timestamp: number): Promise<void> {
   try {
-    await mkdir(dirname(THROTTLE_FILE), { recursive: true });
-    await writeFile(THROTTLE_FILE, String(timestamp), "utf-8");
+    await mkdir(dirname(throttleFilePath(name)), { recursive: true });
+    await writeFile(throttleFilePath(name), String(timestamp), "utf-8");
   } catch {
     // best-effort
   }
@@ -76,7 +94,7 @@ async function findExtensionDir(): Promise<string | undefined> {
   let dir = dirname(fileURLToPath(import.meta.url));
   for (;;) {
     const pkg = await readPackageJson(join(dir, "package.json"));
-    if (pkg?.name === PACKAGE_NAME) return dir;
+    if (pkg?.name === LEGACY_NAME || pkg?.name === "billion-context-pi") return dir;
     const parent = dirname(dir);
     if (parent === dir) return undefined;
     dir = parent;
@@ -94,10 +112,12 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
   if (!npmDir) return false;
 
   try {
+    const packageName = await getPackageName();
+    if (!packageName) return false;
     const code = await new Promise<number>((resolve) => {
       execFile(
         "npm",
-        ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
+        ["install", `${packageName}@${latest}`, "--silent", "--no-audit", "--no-fund"],
         { cwd: npmDir, timeout: 60_000, shell: process.platform === "win32" },
         (err) => resolve(err ? 1 : 0),
       );
@@ -125,15 +145,17 @@ export async function checkForUpdate(
   if (updateInFlight) return;
   updateInFlight = true;
   try {
+    const packageName = await getPackageName();
+    if (!packageName) return;
     const now = Date.now();
-    const lastCheck = await readLastCheck();
+    const lastCheck = await readLastCheck(packageName);
     if (now - lastCheck < CHECK_INTERVAL_MS) return;
 
-    await writeLastCheck(now);
+    await writeLastCheck(packageName, now);
 
     const runtimeVersion = await getRuntimeVersion();
 
-    const res = await fetch(REGISTRY_URL, {
+    const res = await fetch(`${REGISTRY_BASE}/${packageName}/latest`, {
       signal: AbortSignal.timeout(5000),
       headers: { Accept: "application/json" },
     });
@@ -157,7 +179,7 @@ export async function checkForUpdate(
         );
       } else if (!installed && notify) {
         notify(
-          `${PACKAGE_NAME} ${latest} available (you have ${current}). Run: pi update --extension npm:${PACKAGE_NAME}`,
+          `${packageName} ${latest} available (you have ${current}). Run: pi update --extension npm:${packageName}`,
         );
       }
     }


### PR DESCRIPTION
## What

Migrates `pai-acp` → `billion-context-pi` automatically, with a friendly notice as fallback.

## Two modes (auto-selected)

**1. billion-context-pi has a real release (>0.0.1)** → **auto-migrate**:
- `npm install billion-context-pi@latest`
- Atomically rewrite `settings.json`: `npm:pai-acp` → `npm:billion-context-pi`
- `npm uninstall pai-acp` (current process keeps running from in-memory code)
- Notify: `✔ Auto-migrated to billion-context-pi — restart Pi to finish.`

**2. Only placeholder 0.0.1 exists** → **friendly manual notice** (cyan, not scary yellow):
```
→ pai-acp is now billion-context-pi
Your context tools are unchanged — same package, new name.
To switch:
  pi uninstall pai-acp
  pi install billion-context-pi
(Your ~/.pi/acp.json config carries over.)
```

## How it works

- `checkRename(notify)` in `session_start` — self-detects running package name via `package.json`, stays silent once renamed to `billion-context-pi`.
- `newPackageReady()` checks the registry; migration **auto-activates** the moment `billion-context-pi` gets its first real release — no second deploy needed.
- `autoMigrate()` installs new → rewrites settings (atomic tmp+rename) → uninstalls old. Any failure falls back to the manual notice; the legacy package is only removed after settings are updated.

## Pre-flight
- typecheck ✅
- 47 tests pass ✅
- build ✅
- CI ✅ (1m11s)