### PR TITLE
Release v0.1.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pai-acp",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pai-acp",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pai-acp",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "Active Context Pruning (ACP) extension for Pi — model-driven context compression that keeps conversations flowing.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.22 — pai-acp rename notice final release.

## Changes since 0.1.21
- `rename-notice.ts` (new): install-only migration to billion-context-pi + factory self-disable
- `update.ts`: dynamic package name, per-package throttle file
- `commands.ts`: dynamic /acp display name
- Cross-platform robustness: `os.homedir()` everywhere, createRequire fallback, timer cleanup

## Notes
This is the **final pai-acp release**. On launch it detects that billion-context-pi has a real release and automatically installs it (no uninstall of pai-acp — install is additive). On the next restart pai-acp self-disables and billion-context-pi takes over. The user can then uninstall pai-acp manually.

After this release ships, `pai-acp` can be `npm deprecate`d.