### PR TITLE
Release v0.1.24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# pai-acp Development Specification
+# billion-context-pi Development Specification
 
 > **This document is the highest-priority specification. All developers (including AI Agents) MUST comply.**
 
 ## 1. Project Overview
 
-**pai-acp** is the [Pi coding agent](https://github.com/nickthecook/pi) adapter for ACP (Active Context Pruning). It wires acp-kernel's compression pipeline into Pi's extension system, providing model-driven context management.
+**billion-context-pi** is the [Pi coding agent](https://github.com/nickthecook/pi) adapter for ACP (Active Context Pruning). It wires acp-kernel's compression pipeline into Pi's extension system, providing model-driven context management.
 
 ### Tech Stack
 
@@ -20,8 +20,8 @@
 
 | Field | Value |
 |-------|-------|
-| npm package | `pai-acp` |
-| GitHub | https://github.com/ranxianglei/pai-acp |
+| npm package | `billion-context-pi` |
+| GitHub | https://github.com/ranxianglei/billion-context-pi |
 | License | MIT |
 
 ## 2. Architecture
@@ -74,7 +74,7 @@ npm test               # node --import tsx --test tests/*.test.ts
 
 ```bash
 npm run build
-cp dist/index.js ~/.pi/agent/npm/node_modules/pai-acp/dist/index.js
+cp dist/index.js ~/.pi/agent/npm/node_modules/billion-context-pi/dist/index.js
 # Restart Pi to pick up changes
 ```
 
@@ -103,9 +103,9 @@ Same baseline as acp-kernel (branch naming, CI auto-publish, PR-merge-is-human-o
 ⚠️ **Publishing order is strict:**
 1. Release `acp-kernel` first (open + merge its release PR, wait for CI publish).
 2. **Verify it is live on npm:** `npm view acp-kernel version` returns the new version.
-3. THEN release pai-acp.
+3. THEN release billion-context-pi.
 
-Rationale: pai-acp CI runs `npm ci`, which installs the exact `acp-kernel` version pinned in `package.json`. A release branch that bumps `acp-kernel` to a not-yet-published version fails CI at install time.
+Rationale: billion-context-pi CI runs `npm ci`, which installs the exact `acp-kernel` version pinned in `package.json`. A release branch that bumps `acp-kernel` to a not-yet-published version fails CI at install time.
 
 ### Local pre-validation (saves a round-trip)
 
@@ -115,20 +115,20 @@ Before waiting for npm, validate the upgrade path locally using acp-kernel's own
 # 1. In acp-kernel (on master):
 npm run build
 
-# 2. In pai-acp: overlay the new dist onto node_modules (local only, do NOT commit)
+# 2. In billion-context-pi: overlay the new dist onto node_modules (local only, do NOT commit)
 cp ~/projects/acp-kernel/dist/index.js     node_modules/acp-kernel/dist/index.js
 cp ~/projects/acp-kernel/dist/index.js.map node_modules/acp-kernel/dist/index.js.map
 
-# 3. Bump package.json (both lines, see below), then run pai-acp CI checks
+# 3. Bump package.json (both lines, see below), then run billion-context-pi CI checks
 npm run typecheck && npm test && npm run build
 ```
 
-### pai-acp release commit — TWO version fields
+### billion-context-pi release commit — TWO version fields
 
-Unlike acp-kernel (one line), a pai-acp release commit bumps BOTH its own version AND the `acp-kernel` dependency:
+Unlike acp-kernel (one line), a billion-context-pi release commit bumps BOTH its own version AND the `acp-kernel` dependency:
 
 ```diff
-   "name": "pai-acp",
+   "name": "billion-context-pi",
 -  "version": "0.1.12",
 +  "version": "0.1.13",
    ...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pai-acp
+# billion-context-pi
 
 [English](./README.md) | [中文](./README.zh-CN.md)
 
@@ -11,13 +11,13 @@ The model decides <em>when</em> and <em>what</em> to compress — not a hard lim
 ---
 
 <p align="center">
-<a href="https://www.npmjs.com/package/pai-acp"><img src="https://img.shields.io/npm/v/pai-acp.svg?style=flat-square" alt="npm"></a>
-<a href="https://github.com/ranxianglei/pai-acp/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/pai-acp.svg?style=flat-square" alt="license"></a>
-<a href="https://github.com/ranxianglei/pai-acp"><img src="https://img.shields.io/badge/GitHub-ranxianglei%2Fpai--acp-181717?style=flat-square&logo=github" alt="GitHub"></a>
+<a href="https://www.npmjs.com/package/billion-context-pi"><img src="https://img.shields.io/npm/v/billion-context-pi.svg?style=flat-square" alt="npm"></a>
+<a href="https://github.com/ranxianglei/billion-context-pi/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/billion-context-pi.svg?style=flat-square" alt="license"></a>
+<a href="https://github.com/ranxianglei/billion-context-pi"><img src="https://img.shields.io/badge/GitHub-ranxianglei%2Fbillion--context--pi-181717?style=flat-square&logo=github" alt="GitHub"></a>
 </p>
 
 <p align="center">
-<code>pi install npm:pai-acp</code>
+<code>pi install npm:billion-context-pi</code>
 </p>
 
 ---
@@ -40,12 +40,12 @@ This means:
 ## Install
 
 ```bash
-pi install npm:pai-acp
+pi install npm:billion-context-pi
 ```
 
 That's it. The extension auto-loads on next Pi startup. No configuration needed — it reads your model's context window automatically.
 
-> **Uninstall `pi-subagents` first (optional, recommended).** pai-acp ships its own `acp_delegate` sub-agent tool (see below) that replaces pi-subagents at a fraction of the context cost (~600 tok vs ~7K tok/turn). If you have pi-subagents installed, remove it to avoid duplicate delegation tools:
+> **Uninstall `pi-subagents` first (optional, recommended).** billion-context-pi ships its own `acp_delegate` sub-agent tool (see below) that replaces pi-subagents at a fraction of the context cost (~600 tok vs ~7K tok/turn). If you have pi-subagents installed, remove it to avoid duplicate delegation tools:
 > ```bash
 > pi remove npm:pi-subagents
 > ```
@@ -101,7 +101,7 @@ Rich status display for the user:
 ╭─────────────────────────────────────────────╮
 │           ACP Context Analysis              │
 ╰─────────────────────────────────────────────╯
- pai-acp@0.1.14
+ billion-context-pi@0.1.14
 
 Context: 12% (120K / 1.0M)
 Growth: +15K since last nudge
@@ -121,7 +121,7 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
 
 ## Configuration
 
-pai-acp works out of the box with no configuration. Three optional keys can be set in a JSON config file.
+billion-context-pi works out of the box with no configuration. Three optional keys can be set in a JSON config file.
 
 ### Config file
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,13 +9,13 @@
 ---
 
 <p align="center">
-<a href="https://www.npmjs.com/package/pai-acp"><img src="https://img.shields.io/npm/v/pai-acp.svg?style=flat-square" alt="npm"></a>
-<a href="https://github.com/ranxianglei/pai-acp/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/pai-acp.svg?style=flat-square" alt="license"></a>
-<a href="https://github.com/ranxianglei/pai-acp"><img src="https://img.shields.io/badge/GitHub-ranxianglei%2Fpai--acp-181717?style=flat-square&logo=github" alt="GitHub"></a>
+<a href="https://www.npmjs.com/package/billion-context-pi"><img src="https://img.shields.io/npm/v/billion-context-pi.svg?style=flat-square" alt="npm"></a>
+<a href="https://github.com/ranxianglei/billion-context-pi/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/billion-context-pi.svg?style=flat-square" alt="license"></a>
+<a href="https://github.com/ranxianglei/billion-context-pi"><img src="https://img.shields.io/badge/GitHub-ranxianglei%2Fbillion--context--pi-181717?style=flat-square&logo=github" alt="GitHub"></a>
 </p>
 
 <p align="center">
-<code>pi install npm:pai-acp</code>
+<code>pi install npm:billion-context-pi</code>
 </p>
 
 ---
@@ -39,12 +39,12 @@
 ## 安装
 
 ```bash
-pi install npm:pai-acp
+pi install npm:billion-context-pi
 ```
 
 完成。扩展在下次 Pi 启动时自动加载。无需配置 —— 它会自动读取模型的上下文窗口。
 
-> **建议先卸载 `pi-subagents`(可选,推荐)。** pai-acp 自带 `acp_delegate` 子代理工具(见下文),以极低的上下文成本(~600 tok vs ~7K tok/轮)替代 pi-subagents。如果你已安装 pi-subagents,卸载它以避免重复的委派工具:
+> **建议先卸载 `pi-subagents`(可选,推荐)。** billion-context-pi 自带 `acp_delegate` 子代理工具(见下文),以极低的上下文成本(~600 tok vs ~7K tok/轮)替代 pi-subagents。如果你已安装 pi-subagents,卸载它以避免重复的委派工具:
 > ```bash
 > pi remove npm:pi-subagents
 > ```
@@ -100,7 +100,7 @@ Pi 内置的自动压缩会被取消 —— ACP 是唯一的上下文管理者�
 ╭─────────────────────────────────────────────╮
 │           ACP Context Analysis              │
 ╰─────────────────────────────────────────────╯
- pai-acp@0.1.14
+ billion-context-pi@0.1.14
 
 Context: 12% (120K / 1.0M)
 Growth: +15K since last nudge
@@ -120,7 +120,7 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
 
 ## 配置
 
-pai-acp 开箱即用,无需任何配置。可以在 JSON 配置文件中设置三个可选 key。
+billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件中设置三个可选 key。
 
 ### 配置文件
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.22",
+	"version": "0.1.24",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.22",
+			"version": "0.1.24",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.23",
+	"version": "0.1.24",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
First release from the renamed billion-context-pi repo.

## What's new since pai-acp 0.1.22
- Rename from `pai-acp` → `billion-context-pi` (hardcoded package name in `update.ts`, `commands.ts`, `fleet-widget.ts`)
- Cross-platform robustness: `os.homedir()` everywhere (Windows compatibility)

## This is the successor to pai-acp
Users of `pai-acp` will be auto-migrated by the rename notice in pai-acp@0.1.22 (the final pai-acp release).