### PR TITLE
docs: document Pi plugin priority limitation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Each message gets an invisible `<acp>` ref tag (`m00001`, `m00002`, ...) visible
 
 Pi's built-in auto-compaction is cancelled — ACP is the sole context manager.
 
+## Plugin compatibility & ordering
+
+billion-context takes over context management by intercepting Pi's `context` event. **Pi has no plugin priority mechanism** — when multiple extensions register handlers for the same event, they run in a fixed sequence (load order), with no `priority`/`weight` field and no way for the user to control the order. The `context` event specifically is a *pipeline*: every handler receives the previous handler's output, there is no short-circuit, and the **last** handler has the final say over what reaches the model.
+
+This has two practical implications:
+
+1. **Keep exactly one context-compression plugin installed.** If you run two compression plugins together (e.g. billion-context-pi alongside another), both will rewrite the message list and clobber each other's work — compressed ranges can be re-expanded or corrupted. Pi's built-in auto-compaction is already cancelled automatically by billion-context-pi, but any *third-party* compression/compaction extension should be uninstalled.
+
+2. **Even with a single compression plugin, interference is still possible in rare cases.** Load order under Pi is determined by filesystem discovery order (`fs.readdirSync` over `.pi/extensions/` → global → packages), which is not fully deterministic. If another (non-compression) extension also hooks the `context` event and happens to load *after* billion-context-pi, it could modify the compressed output. billion-context-pi rebuilds its working set from the session log rather than the chained input, which makes it robust to handlers that run *before* it — but it cannot defend against a handler that runs *after* it. This is a limitation of Pi's extension model; if you observe unexpected context behavior, check whether other installed extensions intercept the `context` event.
+
 ## Model-facing tools
 
 | Tool | What it does |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,6 +61,16 @@ assign refs → sync blocks → prune → filter → hide calls → recommend �
 
 Pi 内置的自动压缩会被取消 —— ACP 是唯一的上下文管理者。
 
+## 插件兼容性与排序
+
+billion-context 通过拦截 Pi 的 `context` 事件接管上下文管理。**Pi 没有插件优先级机制** —— 当多个扩展为同一个事件注册 handler 时,它们按固定顺序(加载顺序)执行,没有 `priority`/`weight` 字段,用户也无法控制顺序。`context` 事件尤其是一个*管线*:每个 handler 都接收上一个 handler 的输出,没有短路,**最后一个** handler 对发给模型的内容拥有最终决定权。
+
+这带来两个实际影响:
+
+1. **只保留一个上下文压缩插件。** 如果同时运行两个压缩插件(例如 billion-context-pi 和另一个),它们都会改写消息列表、互相覆盖 —— 已压缩的范围可能被重新展开或破坏。Pi 的内置自动压缩已由 billion-context-pi 自动取消,但任何*第三方*压缩/compaction 扩展都应卸载。
+
+2. **即使只有一个压缩插件,在少数情况下仍可能出现干扰。** Pi 下的加载顺序由文件系统发现顺序(`fs.readdirSync` 遍历 `.pi/extensions/` → 全局 → 包)决定,并不完全确定。如果另一个(非压缩类)扩展也 hook 了 `context` 事件、且恰好加载在 billion-context-pi *之后*,它可能修改压缩后的输出。billion-context-pi 从会话日志重建工作集(而非链式输入),这让它对*排在它之前*的 handler 鲁棒 —— 但无法防御*排在它之后*的 handler。这是 Pi 扩展模型的固有限制;若你观察到上下文行为异常,请检查是否有其他已安装扩展拦截了 `context` 事件。
+
 ## 模型工具
 
 | 工具 | 作用 |


### PR DESCRIPTION
## What

Adds a **"Plugin compatibility & ordering"** section to both `README.md` and `README.zh-CN.md`, documenting the finding from the research in #1: **Pi has no plugin priority mechanism.**

## Why

Research in #1 established that:

- Pi has no `priority`/`weight` field — extensions run in fixed load order (`resource-loader.js:460`: "precedence is handled by load order").
- The `context` event (which ACP intercepts) is a pipeline: handlers chain with no short-circuit, the last handler has the final say (`runner.js:744-772` `emitContext`).
- Load order is filesystem-dependent (`fs.readdirSync`) and not user-controllable.

This was not documented anywhere. Users have no way to know that running multiple context-compression plugins together will clobber each other, or that even a single plugin can (rarely) be affected by other extensions hooking `context`.

## What the new section says

1. **Keep exactly one context-compression plugin installed** — two compression plugins will rewrite the message list and clobber each other's work.
2. **Even with a single plugin, interference is possible in rare cases** — load order is filesystem-dependent; an extension hooking `context` that loads *after* billion-context-pi could modify its output. billion-context-pi rebuilds from the session log (robust to handlers *before* it) but cannot defend against handlers *after* it. This is a limitation of Pi's extension model.

## Files

`README.md`, `README.zh-CN.md` (docs-only, +20 lines, no source changes).

Refs #1.

---

Prepared by awork. Per AGENTS.md, **PR merge is human-only** — I will not merge this PR.
