### PR TITLE
feat: preserve decompress ops meta-memory in block summaries

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -74,12 +74,34 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     state,
     config,
   });
+  const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
+  const newBlocks = applied.state.blocks.slice(-blocksCreated);
+  const msgById = new Map(coreMessages.map((m) => [m.id, m]));
+  for (const block of newBlocks) {
+    const ops: string[] = [];
+    const seen = new Set<string>();
+    for (const id of block.directMessageIds) {
+      const msg = msgById.get(id);
+      if (msg && msg.toolName === "decompress" && msg.toolCallId && !seen.has(msg.toolCallId)) {
+        seen.add(msg.toolCallId);
+        ops.push(`decompress(${msg.text ?? ""})`);
+      }
+    }
+    for (const bid of block.directBlockIds) {
+      const consumed = applied.state.blocks.find((b) => b.blockId === bid);
+      if (!consumed) continue;
+      for (const line of consumed.summary.split("\n")) {
+        const arg = line.match(/^\[auto\] decompress ops: (.+)$/)?.[1];
+        if (arg) ops.push(arg);
+      }
+    }
+    if (ops.length > 0 && !block.summary.includes("decompress(")) {
+      block.summary += `\n[auto] decompress ops: ${ops.join(", ")}`;
+    }
+  }
   await runtime.save(applied.state, ctx);
-  const { blocksCreated, tokensCompressed, errors } = applied.result;
 
   const afterTokens = Math.max(0, beforeTokens - tokensCompressed);
-
-  const newBlocks = applied.state.blocks.slice(-blocksCreated);
   debug.event("compress-out", {
     sid: ctx.sessionManager.getSessionId(),
     blocksCreated,
@@ -95,6 +117,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   });
 
   const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(tokensCompressed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
+  if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
   if (errors.length > 0) lines.push("Errors: " + errors.join("; "));
   return lines.join("\n");
 }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -49,6 +49,10 @@ WHEN NOT TO COMPRESS
 
 ${HOW_TO_COMPRESS_RULES}
 
+SUMMARY META-MEMORY RULE (adapter addendum — narrow exception to DROP)
+
+- When the range actually compressed into a block contains a decompress tool call, the summary MUST contain the literal \`decompress(<original args>)\` (blockId or message UUID, listed per call). decompress is a memory-meta operation — losing it erases the model's own operation history.
+
 MULTI-TIER COMPRESSION
 
 Summaries accumulate as the session grows. When tier-1 summaries pile up, the system injects a nudge prompting you to DISTILL old blocks into a single tier-2 summary. If tier-2 summaries also accumulate, a further nudge asks you to CONDENSE them into tier-3.
@@ -58,6 +62,10 @@ To compress blocks: use block IDs as boundaries: compress({ content: [{ startId:
 ${TIER2_DISTILL_RULES}
 
 ${TIER3_CONDENSE_RULES}
+
+META-MEMORY EXCEPTION (adapter addendum — overrides DROP for this one item)
+
+[Exception] decompress operations recorded in block summaries ("[auto] decompress ops: ..." lines) MUST be preserved when distilling or condensing — they are the model's operation-history meta-memory and DROP's "process details" does not apply to them.
 
 THE PHILOSOPHY OF DECOMPRESS
 

--- a/tests/compress-tool.test.ts
+++ b/tests/compress-tool.test.ts
@@ -1,0 +1,160 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm, readFile } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+
+const STATE_FILE = "/tmp/pai-acp-compress-tool-it.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+function toolCallMsg(id: string, callId: string, args: unknown) {
+  return {
+    type: "message", id, parentId: null, timestamp: "",
+    message: { role: "assistant", content: [{ type: "toolCall", name: "decompress", id: callId, arguments: args }], timestamp: Date.now() },
+  };
+}
+
+async function cleanState() {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+}
+
+function fakeCtx(entries: any[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+async function setup(entries: any[]) {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const ctx = fakeCtx(entries);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  return { compressTool, ctx };
+}
+
+async function readBlocks() {
+  const raw = await readFile(`${STATE_FILE}.acp.json`, "utf8");
+  return (JSON.parse(raw) as any).blocks;
+}
+
+const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+const filler = (n: string) => `filler ${n} `.repeat(400);
+
+test("范围含 decompress 调用且摘要未提及 → 机械补记 [auto] 行", async () => {
+  await cleanState();
+  const entries = [
+    toolCallMsg("e1", "dc1", { blockId: "b1" }),
+    userMsg("e2", longText),
+    userMsg("e3", filler("three")), userMsg("e4", filler("four")),
+    userMsg("e5", filler("five")), userMsg("e6", filler("six")),
+    userMsg("e7", filler("seven")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+  const res = await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00002", summary: "Compressed early session content including setup messages." }] },
+    undefined, undefined, ctx,
+  );
+  const blocks = await readBlocks();
+  assert.equal(blocks.length, 1);
+  assert.ok(
+    blocks[0].summary.includes('[auto] decompress ops: decompress({"blockId":"b1"})'),
+    `block summary should carry the mechanical ops line, got: ${blocks[0].summary}`,
+  );
+});
+
+test("T2 蒸馏 b1 时 [auto] 行接力到新摘要", async () => {
+  await cleanState();
+  const entries = [
+    toolCallMsg("e1", "dc1", { blockId: "b1" }),
+    userMsg("e2", longText),
+    userMsg("e3", filler("three")), userMsg("e4", filler("four")),
+    userMsg("e5", filler("five")), userMsg("e6", filler("six")),
+    userMsg("e7", filler("seven")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+  await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00002", summary: "Compressed early session content including setup messages." }] },
+    undefined, undefined, ctx,
+  );
+  await compressTool.execute(
+    "tc2",
+    { content: [{ startId: "b1", endId: "b1", summary: "Tier-2 distillation of the early session content and its key takeaways." }] },
+    undefined, undefined, ctx,
+  );
+  const blocks = await readBlocks();
+  const b2 = blocks.find((b: any) => b.tier === 2);
+  assert.ok(b2, "tier-2 block should exist");
+  assert.ok(
+    b2.summary.includes('[auto] decompress ops: decompress({"blockId":"b1"})'),
+    `tier-2 summary should relay the ops line, got: ${b2.summary}`,
+  );
+});
+
+test("范围无 decompress 调用 → 零误报（无 [auto] 行）", async () => {
+  await cleanState();
+  const entries = [
+    userMsg("e1", longText), userMsg("e2", longText),
+    userMsg("e3", filler("three")), userMsg("e4", filler("four")),
+    userMsg("e5", filler("five")), userMsg("e6", filler("six")),
+    userMsg("e7", filler("seven")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+  await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00002", summary: "Compressed early session content including setup messages." }] },
+    undefined, undefined, ctx,
+  );
+  const blocks = await readBlocks();
+  assert.ok(
+    !blocks[0].summary.includes("[auto] decompress ops"),
+    `no decompress ops line expected, got: ${blocks[0].summary}`,
+  );
+});
+
+test("软保护区排除消息 → kernel warnings 透出到结果行", async () => {
+  await cleanState();
+  const entries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+  const res = await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00007", summary: "Compressed the early session content including all setup messages." }] },
+    undefined, undefined, ctx,
+  );
+  const text = (res.content[0] as any).text as string;
+  assert.match(text, /⚠️/, "warning line should be surfaced in the result");
+  assert.match(text, /Excluded \d+ protected message\(s\)/, "warning should mention protected exclusions");
+});


### PR DESCRIPTION
## Problem

Model-written block summaries can silently drop the record of `decompress` tool calls inside the compressed range. decompress is a **memory-meta operation** — losing it erases the model's own operation history. In practice this produces a failure mode where the model confidently denies actions it demonstrably performed (verified live: the model twice asserted it had "never called decompress" while having done so on-screen, because the summary of that range omitted the call).

## Fix (adapter-level, 4 parts)

1. **Mechanical backstop** (`src/compress-tool.ts`): after `applyCompression`, scan each new block's `directMessageIds` for `decompress` tool calls (deduped by `toolCallId`), relay `[auto]` lines from consumed blocks (T2/T3), and if the block summary lacks the literal `decompress(`, append a `[auto] decompress ops: decompress(<original args>)` line before `save()`.
2. **Tier relay** (`src/compress-tool.ts`): when distilling blocks, `[auto]` lines from consumed blocks' summaries are preserved in the new summary.
3. **System prompt addenda** (`src/system-prompt.ts`, +8 lines, frozen text untouched): a narrow rule (summaries covering a range that actually included decompress calls MUST record them verbatim) and a meta-memory exception for T2/T3 distillation (explicitly exempt from DROP's process-details rule).
4. **Warnings passthrough fix** (`src/compress-tool.ts`): the kernel already emits `warnings` (`ApplyCompressionResult.warnings`, types.d.ts:199 — "host should surface these to the model"), but the adapter was destructuring them away. Now surfaced in the tool result (e.g. `⚠️ Excluded N protected message(s) ...`).

## Why the adapter, not the kernel

acp-kernel's DESIGN.md contract (§1 Mental Model) states the summary text is model-produced and opaque to the core ("reduced to a string input"). Appending to summary text would violate that boundary. The kernel already provides the structured data (`directMessageIds`, `toolName`/`toolCallId`); the adapter consumes it. The `[auto]` marker keeps the model-authored/model-machine distinction explicit.

## Tests

4 new tests in `tests/compress-tool.test.ts` (T1 append / T2 relay / zero false-positive / warnings passthrough). Full suite: **51 pass**, typecheck clean, build OK. Live-verified in the running Pi session: `[auto] decompress ops: decompress({"blockId":"b13","inline":true})` appended to a real block; ⚠️ exclusions surfaced in the compress result.
