### PR TITLE
docs: rebrand ACP to billion-context in README prose (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [English](./README.md) | [中文](./README.zh-CN.md)
 
 <p align="center">
-<strong>Active Context Pruning</strong> for <a href="https://pi.dev">Pi</a>
+<strong>Billion-Context</strong> for <a href="https://pi.dev">Pi</a>
 <br />
 The model decides <em>when</em> and <em>what</em> to compress — not a hard limit.
 </p>
@@ -24,9 +24,9 @@ The model decides <em>when</em> and <em>what</em> to compress — not a hard lim
 
 ## Why?
 
-When conversations get long, the model runs out of context. Most tools hard-truncate — silently dropping earlier messages. **ACP** gives the model a `compress` tool: the LLM decides **when** and **what** to compress into high-fidelity summaries, preserving critical details (file paths, decisions, error strings) while reclaiming context space.
+When conversations get long, the model runs out of context. Most tools hard-truncate — silently dropping earlier messages. **billion-context** gives the model a `compress` tool: the LLM decides **when** and **what** to compress into high-fidelity summaries, preserving critical details (file paths, decisions, error strings) while reclaiming context space.
 
-Unlike Pi's built-in auto-compaction (which replaces everything with a single summary), ACP:
+Unlike Pi's built-in auto-compaction (which replaces everything with a single summary), billion-context:
 - **Preserves structure** — compressed ranges become labeled blocks you can decompress later
 - **Multi-tier** — summaries can be further distilled (T1 → T2 → T3) as sessions grow
 - **Searchable** — `search_context` finds information inside compressed blocks without decompressing
@@ -52,7 +52,7 @@ That's it. The extension auto-loads on next Pi startup. No configuration needed 
 
 ## How it works
 
-ACP intercepts Pi's `context` event (fired before each LLM call) and runs an 8-stage pipeline:
+billion-context intercepts Pi's `context` event (fired before each LLM call) and runs an 8-stage pipeline:
 
 ```
 assign refs → sync blocks → prune → filter → hide calls → recommend → nudge → emergency truncate
@@ -60,7 +60,7 @@ assign refs → sync blocks → prune → filter → hide calls → recommend �
 
 Each message gets an invisible `<acp>` ref tag (`m00001`, `m00002`, ...) visible to the model but not the user. The model uses these refs to specify compression ranges.
 
-Pi's built-in auto-compaction is cancelled — ACP is the sole context manager.
+Pi's built-in auto-compaction is cancelled — billion-context is the sole context manager.
 
 ## Model-facing tools
 
@@ -159,7 +159,7 @@ The model receives detailed guidance (in its system prompt) on **when** to compr
 
 ### What gets protected
 
-ACP protects three categories of content from compression:
+billion-context protects three categories of content from compression:
 
 1. **Always-protected tools** — `compress` calls are hard-protected (they're load-bearing metadata; compressing them breaks decompress and the "summary is historical" contract).
 2. **Soft recent-zone** — the last N messages (default 5) and last ~5K tokens are soft-protected so the model keeps its working set. Tool results from `decompress`, `search_context`, `read`, and `bash` are **excluded** from this zone: they're large and meant to be compressible once consumed, so they don't eat the protected budget.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 [English](./README.md) | [中文](./README.zh-CN.md)
 
 <p align="center">
-<strong>主动上下文剪枝</strong> — <a href="https://pi.dev">Pi</a> 的 ACP 插件
+<strong>Billion-Context</strong> — <a href="https://pi.dev">Pi</a> 的上下文压缩插件
 <br />
 由模型决定<em>何时</em>压缩、压缩<em>什么</em> — 而非硬性截断。
 </p>
@@ -20,11 +20,11 @@
 
 ---
 
-## 为什么选择 ACP
+## 为什么选择 billion-context
 
-当对话变长,模型的上下文会耗尽。多数工具采用硬截断 —— 静默丢弃早期消息。**ACP** 把 `compress` 工具交给模型:由 LLM 决定**何时**压缩、压缩**什么**,将内容压缩成高保真摘要,在回收上下文空间的同时保留关键细节(文件路径、决策、错误字符串)。
+当对话变长,模型的上下文会耗尽。多数工具采用硬截断 —— 静默丢弃早期消息。**billion-context** 把 `compress` 工具交给模型:由 LLM 决定**何时**压缩、压缩**什么**,将内容压缩成高保真摘要,在回收上下文空间的同时保留关键细节(文件路径、决策、错误字符串)。
 
-与 Pi 内置的自动压缩(把所有内容替换成单个摘要)不同,ACP:
+与 Pi 内置的自动压缩(把所有内容替换成单个摘要)不同,billion-context:
 
 - **保留结构** — 压缩的范围变成带标签的块,可后续解压
 - **多级压缩** — 摘要可被进一步蒸馏(T1 → T2 → T3),随会话增长保持有界
@@ -51,7 +51,7 @@ pi install npm:billion-context-pi
 
 ## 工作原理
 
-ACP 拦截 Pi 的 `context` 事件(每次 LLM 调用前触发),运行一个 8 阶段管线:
+billion-context 拦截 Pi 的 `context` 事件(每次 LLM 调用前触发),运行一个 8 阶段管线:
 
 ```
 assign refs → sync blocks → prune → filter → hide calls → recommend → nudge → emergency truncate
@@ -59,7 +59,7 @@ assign refs → sync blocks → prune → filter → hide calls → recommend �
 
 每条消息获得一个不可见的 `<acp>` 引用标签(`m00001`、`m00002`、...),对模型可见但用户不可见。模型用这些引用来指定压缩范围。
 
-Pi 内置的自动压缩会被取消 —— ACP 是唯一的上下文管理者。
+Pi 内置的自动压缩会被取消 —— billion-context 是唯一的上下文管理者。
 
 ## 模型工具
 
@@ -158,7 +158,7 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 
 ### 哪些内容会被保护
 
-ACP 保护三类内容不被压缩:
+billion-context 保护三类内容不被压缩:
 
 1. **永久保护的工具** — `compress` 调用被硬保护(它们是承载关键元数据的;压缩它们会破坏 decompress 和"摘要是历史"的契约)。
 2. **软近期区** — 最后 N 条消息(默认 5)和最后约 5K token 被软保护,让模型保留工作集。来自 `decompress`、`search_context`、`read`、`bash` 的工具结果被**排除**出此区:它们体量大、消费后就该能压缩,所以不该占用保护预算。


### PR DESCRIPTION
## What

Rebrands the standalone **ACP** product references to **billion-context** in the README prose (EN + ZH), reflecting the project rename. Docs-only.

## Why

The project was renamed `pai-acp → billion-context-pi` ( landed in v0.1.24 / #68 ), but the README body still referred to the product as "ACP" in several prose sentences. This cleans up those remaining brand references so the docs consistently call the product **billion-context**.

## What changed

Replaced standalone brand "ACP" / "Active Context Pruning" → "billion-context" / "Billion-Context" in:

**README.md** (6 spots): tagline, `## Why?` body (`**ACP** gives...`, `...summary), ACP:`), `## How it works` (`ACP intercepts...`), "sole context manager" line, `### What gets protected` (`ACP protects three...`).

**README.zh-CN.md** (7 spots): tagline, `## 为什么选择 ACP` heading + body, `## 工作原理`, "唯一的上下文管理者" line, `### 哪些内容会被保护`.

## What was intentionally kept as "ACP"

Technical identifiers are unchanged — these are real command/tool/file names, not brand prose:
- `/acp` command name and its output banner ("ACP Context Analysis")
- Tool names: `acp_status`, `acp_delegate`, `acp_delegate_wait`, `acp_delegate_cancel`
- Config file `acp.json`, log path `~/.pi/acp-debug.log`
- Env vars `ACP_DEBUG`, `ACP_AUTO_UPDATE`, `ACP_MODEL_CONTEXT_LIMIT`
- The `acp-kernel` library name

## Files

`README.md`, `README.zh-CN.md` (docs-only, 13 lines changed).

Refs #1.

---

Prepared by awork. Per AGENTS.md, **PR merge is human-only** — I will not merge this PR.
