### PR TITLE
fix: surface compression warnings to the model

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -75,7 +75,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     config,
   });
   await runtime.save(applied.state, ctx);
-  const { blocksCreated, tokensCompressed, errors } = applied.result;
+  const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
 
   const afterTokens = Math.max(0, beforeTokens - tokensCompressed);
 
@@ -95,6 +95,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   });
 
   const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(tokensCompressed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
+  if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
   if (errors.length > 0) lines.push("Errors: " + errors.join("; "));
   return lines.join("\n");
 }

--- a/tests/warnings-passthrough.test.ts
+++ b/tests/warnings-passthrough.test.ts
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+
+const STATE_FILE = "/tmp/pai-acp-warnings-it.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+async function cleanState() {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+}
+
+function fakeCtx(entries: any[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+async function setup(entries: any[]) {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const ctx = fakeCtx(entries);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  return { compressTool, ctx };
+}
+
+const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+const filler = (n: string) => `filler ${n} `.repeat(400);
+
+test("软保护区排除消息 → kernel warnings 透出到结果行", async () => {
+  await cleanState();
+  const entries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+  const res = await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00007", summary: "Compressed the early session content including all setup messages." }] },
+    undefined, undefined, ctx,
+  );
+  const text = (res.content[0] as any).text as string;
+  assert.match(text, /⚠️/, "warning line should be surfaced in the result");
+  assert.match(text, /Excluded \d+ protected message\(s\)/, "warning should mention protected exclusions");
+});


### PR DESCRIPTION
## Problem

The kernel's `applyCompression` returns `warnings: string[]` (types.d.ts:199 — *"host should surface these to the model"*), generated when soft-protected messages (recent N / last N tokens / last user message) are excluded from the requested compression range, e.g.:

```
Excluded 12 protected message(s) m00548...m00565 from compression range (recent/last-user zone).
```

But the adapter's `compress-tool.ts` destructured only `{ blocksCreated, tokensCompressed, errors }` — **the warnings were silently dropped**.

### Consequence: the model's mental map diverges from reality

Not data loss — a map error. The model believes it compressed `[A..Z]` into summary `S`; in reality only `[A..Y]` was folded and the protected `[Y+1..Z]` remains visible. When the model later references a message in the excluded segment:

1. It looks in `decompress(S)` → **not there** → comes up empty
2. The truth sits in the visible tail — but the model doesn't look there, because its map says that range no longer exists
3. Secondary effect: token accounting is off (believes the whole range was freed)

## Fix (adapter-level, 2 lines)

```ts
const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
// ...
if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
```

The kernel already did its part (produced the warnings); this fixes the adapter violating the kernel's contract by not surfacing them. No kernel changes needed.

## Boundary note

Hard-protected exclusions (`ALWAYS_PROTECTED_TOOLS = ["compress"]`) are **silent by design** — they are deterministic, expected rules, and the kernel does not emit warnings for them. ⚠️ fires only for soft-protection (recent-zone / last-user) trimming, which is genuinely unexpected from the model's perspective.

## Tests

1 new test in `tests/warnings-passthrough.test.ts` (soft-protection exclusion → ⚠️ line with `Excluded N protected message(s)` in the result). Full suite: **48 pass**, typecheck clean. Live-verified in the running Pi session:

```
▣ ACP | 13.5K → 5.1K tokens (~8.4K reclaimed, 5 blocks)
⚠️ Excluded 12 protected message(s) m00548, m00549, ... m00565 from compression range (recent/last-user zone).;
   Excluded 4 protected message(s) m00642, m00643, m00656, m00657 ...
```
