### PR TITLE
fix(delegate): pass --tools whitelist to child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,21 @@ This has two practical implications:
 
 ### acp_delegate — clean-context delegation
 
-Hand a self-contained task to a fresh pi process running in a clean context. Five built-in roles, each with a tailored tool whitelist and system prompt:
+Hand a self-contained task to a fresh pi process running in a clean context. Five built-in roles, each with a system prompt and a **soft tool guardrail**:
 
 | Role | Tools | Best for |
 |------|-------|----------|
-| `reviewer` | read, bash | Read-only code review (bugs, risks, file:line) |
-| `researcher` | read, bash | Read-only codebase investigation |
+| `reviewer` | read, bash, grep, find, ls + ACP | Read-only code review (bugs, risks, file:line) |
+| `researcher` | read, bash, grep, find, ls + ACP | Read-only codebase investigation |
 | `worker` | read, edit, write, bash | Make code changes |
-| `planner` | read, bash | Analyze + propose a step-by-step plan |
-| `oracle` | read, bash | Answer questions / advise |
+| `planner` | read, bash, grep, find, ls + ACP | Analyze + propose a step-by-step plan |
+| `oracle` | read, bash, grep, find, ls + ACP | Answer questions / advise |
 
-The full delegate result is saved to a file (`/tmp/acp-delegate/<runId>.out`); the tool result and injected notification carry only the **task title + file path** (no preview) — use `read` for the details. This keeps the parent context lean.
+Read-only roles (reviewer, researcher, planner, oracle) receive a restricted tool allowlist (`read, bash, grep, find, ls`) plus ACP context tools (`compress, decompress, search_context, acp_status`) so they can manage their own context. This prevents accidental file modifications, but `bash` can bypass it - **it is a guardrail, not a security boundary**.
+
+Worker runs on Pi's full default toolset - no `--tools` allowlist is applied, so any loaded extension or custom tools (e.g. ACP, LSP, MCP) remain available. This keeps primary-task delegation fully capable. The `read, edit, write, bash` listing above reflects core tools only.
+
+The full delegate result is saved to a file (`/tmp/acp-delegate/<runId>.out`); the tool result and injected notification carry only the **task title + file path** (no preview) - use `read` for the details. This keeps the parent context lean.
 
 - **Interactive (TUI) & RPC modes**: `async:true` (default) runs the child in the background; a short completion notification is injected into the chat when it finishes.
 - **Print / JSON modes** (`pi -p`, SDK): `async:true` auto-downgrades to **synchronous** — the result returns as the tool result in the same turn (the parent exits after one turn, so background injection would be lost).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,17 +85,21 @@ billion-context 通过拦截 Pi 的 `context` 事件接管上下文管理。**Pi
 
 ### acp_delegate — 干净上下文委派
 
-把一个自包含的任务交给一个运行在干净上下文中的新 pi 进程。五个内置角色,各自有定制的工具白名单和系统提示:
+把一个自包含的任务交给一个运行在干净上下文中的新 pi 进程。五个内置角色,各自有系统提示和**软工具护栏**:
 
 | 角色 | 工具 | 适用场景 |
 |------|------|----------|
-| `reviewer` | read, bash | 只读代码审查(bug、风险、file:line) |
-| `researcher` | read, bash | 只读代码库调研 |
+| `reviewer` | read, bash, grep, find, ls + ACP | 只读代码审查(bug、风险、file:line) |
+| `researcher` | read, bash, grep, find, ls + ACP | 只读代码库调研 |
 | `worker` | read, edit, write, bash | 修改代码 |
-| `planner` | read, bash | 分析 + 提出分步计划 |
-| `oracle` | read, bash | 回答问题 / 建议 |
+| `planner` | read, bash, grep, find, ls + ACP | 分析 + 提出分步计划 |
+| `oracle` | read, bash, grep, find, ls + ACP | 回答问题 / 建议 |
 
-委派的完整结果保存到文件(`/tmp/acp-delegate/<runId>.out`);工具结果和注入通知只携带**任务标题 + 文件路径**(无预览)— 需要细节时用 `read` 读取。这让父上下文保持精简。
+只读角色(reviewer、researcher、planner、oracle)获得受限工具白名单(`read, bash, grep, find, ls`)+ ACP 上下文工具(`compress, decompress, search_context, acp_status`),以便管理自己的上下文。这能防止意外修改文件,但 `bash` 可绕过 - **这是护栏,不是安全边界**。
+
+Worker 运行在 Pi 的完整默认工具集上 - 不应用 `--tools` 白名单,因此任何已加载的扩展或自定义工具(如 ACP、LSP、MCP)保持可用。这确保主任务委派能力完整。上表中的 `read, edit, write, bash` 仅反映核心工具。
+
+委派的完整结果保存到文件(`/tmp/acp-delegate/<runId>.out`);工具结果和注入通知只携带**任务标题 + 文件路径**(无预览)- 需要细节时用 `read` 读取。这让父上下文保持精简。
 
 - **交互(TUI)与 RPC 模式**:`async:true`(默认)在后台运行子进程;完成时一条简短通知注入到聊天框。
 - **Print / JSON 模式**(`pi -p`、SDK):`async:true` 自动降级为**同步** — 结果在同一轮作为工具结果返回(父进程一轮后即退出,后台注入会丢失)。

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -20,22 +20,37 @@ const SYNC_TIMEOUT_MS = 5 * 60_000;
 const RESULT_SUMMARY_CHARS = 500;
 const OUT_DIR = join(tmpdir(), "acp-delegate");
 
+/** ACP context-management tools that every restricted delegate must retain
+ *  so it can manage its own context under billion-context-pi. */
+const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
+
+/** Roles that receive a restricted tool allowlist. Worker is intentionally
+ *  absent - it runs on Pi's full default toolset (all extension/custom tools
+ *  stay active) so primary-task delegation is not degraded. */
+const RESTRICTED_TOOLS = "read,bash,grep,find,ls";
+
 interface AgentDef {
   prompt: string;
   tools: string;
+  /** When true, the role's `tools` are passed as a `--tools` allowlist to the
+   *  child process, and ACP context tools are automatically appended. When
+   *  absent/false, the child runs on Pi's full default toolset. */
+  restricted?: boolean;
 }
 
 // Minimal roster. The tool description lists these so the model knows how to
 // pick one — no separate prompt injection needed (keeps fixed cost tiny).
 const AGENTS: Record<string, AgentDef> = {
   reviewer: {
-    tools: "read,bash",
+    tools: RESTRICTED_TOOLS,
+    restricted: true,
     prompt: `You are a senior code reviewer with read-only access.
 Read the given code and report: bugs, security/safety risks, correctness issues, and concrete improvement suggestions.
 Be specific — cite file:line for every finding. Do NOT modify any files; only read and report.`,
   },
   researcher: {
-    tools: "read,bash",
+    tools: RESTRICTED_TOOLS,
+    restricted: true,
     prompt: `You are a code researcher with read-only access.
 Investigate the codebase to answer the question thoroughly. Report findings with exact file:line references, function/type signatures, and relevant code snippets.
 Do NOT modify any files; only read and report.`,
@@ -47,13 +62,15 @@ Make exactly the requested code changes — minimal, focused, following existing
 After editing, briefly summarize what you changed and why. Do not expand scope.`,
   },
   planner: {
-    tools: "read,bash",
+    tools: RESTRICTED_TOOLS,
+    restricted: true,
     prompt: `You are a technical planner with read-only access.
 Analyze the task and produce a concrete, ordered step-by-step implementation plan with rationale for each step.
 Cite file:line for code you reference. Do NOT modify any files; only read and propose.`,
   },
   oracle: {
-    tools: "read,bash",
+    tools: RESTRICTED_TOOLS,
+    restricted: true,
     prompt: `You are an expert advisor with read-only access.
 Answer the question concisely with clear reasoning. Cite file:line when referencing code. Do NOT modify any files.`,
   },
@@ -139,7 +156,7 @@ const agentListLine = (name: string): string => {
     planner: "analyze + propose step-by-step plan (read-only)",
     oracle: "answer questions / advise (read-only)",
   };
-  return `  • ${name} — ${blurb[name]} [tools: ${def.tools}]`;
+  return `  • ${name} - ${blurb[name]} [tools: ${def.tools}${def.restricted ? " + ACP context tools" : ""}]`;
 };
 
 export function makeDelegateTool(pi: ExtensionAPI): ToolDefinition<typeof DelegateParams> {
@@ -494,11 +511,15 @@ export async function buildChildArgs(
 
   const cliArgs = ["-p", "--no-session", "--append-system-prompt", promptFile];
 
-  // Pass the role's tool whitelist to the child (--tools is Pi CLI native).
-  // read-only roles must not receive edit/write; also disables child extension tools.
+  // Restricted roles receive a tailored --tools allowlist. Worker and
+  // unknown agents are left on Pi's full default toolset (all extension/
+  // custom tools stay active). The allowlist is a *soft guardrail*: it
+  // prevents accidental edit/write by read-only roles, but bash can bypass
+  // it - this is not a security boundary.
   const agentDef = AGENTS[args.agent];
-  if (agentDef?.tools) {
-    cliArgs.push("--tools", agentDef.tools);
+  if (agentDef?.restricted) {
+    const merged = [...new Set([...agentDef.tools.split(",").map(s => s.trim()), ...ACP_TOOLS])];
+    cliArgs.push("--tools", merged.join(","));
   }
 
   if (args.model && args.model.includes("/")) {

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -481,7 +481,7 @@ async function runDelegate(
   return formatSyncResult(args.agent, runId, args.task, result, file);
 }
 
-async function buildChildArgs(
+export async function buildChildArgs(
   args: DelegateArgs,
   rolePrompt: string,
   ctx: ExtensionContext,
@@ -493,6 +493,13 @@ async function buildChildArgs(
   await writeFile(promptFile, `${rolePrompt}\n\n---\n\nComplete the task below.`, "utf8");
 
   const cliArgs = ["-p", "--no-session", "--append-system-prompt", promptFile];
+
+  // Pass the role's tool whitelist to the child (--tools is Pi CLI native).
+  // read-only roles must not receive edit/write; also disables child extension tools.
+  const agentDef = AGENTS[args.agent];
+  if (agentDef?.tools) {
+    cliArgs.push("--tools", agentDef.tools);
+  }
 
   if (args.model && args.model.includes("/")) {
     const [providerId, ...rest] = args.model.split("/");

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -3,32 +3,92 @@ import assert from "node:assert/strict";
 import { buildChildArgs } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-/** Minimal ctx mock — buildChildArgs only reads ctx.model. */
+/** Minimal ctx mock - buildChildArgs only reads ctx.model. */
 function mockCtx(): ExtensionContext {
   return { model: { provider: "test", id: "test-model" } } as unknown as ExtensionContext;
 }
 
-test("buildChildArgs includes --tools whitelist for read-only roles", async () => {
-  const { cliArgs } = await buildChildArgs(
-    { agent: "reviewer", task: "review code" },
-    "You are a reviewer.",
-    mockCtx(),
-  );
-  const toolsIdx = cliArgs.indexOf("--tools");
-  assert.ok(toolsIdx >= 0, "--tools flag present for reviewer");
-  assert.equal(cliArgs[toolsIdx + 1], "read,bash", "reviewer gets read,bash whitelist");
-});
+const RESTRICTED_ROLES = ["reviewer", "researcher", "planner", "oracle"] as const;
+const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"];
 
-test("buildChildArgs includes --tools whitelist for worker role", async () => {
+/** Parse the --tools value from cliArgs, or null if absent. */
+function getToolsValue(cliArgs: string[]): string | null {
+  const idx = cliArgs.indexOf("--tools");
+  if (idx < 0) return null;
+  return cliArgs[idx + 1] ?? null;
+}
+
+// ─── Restricted roles: --tools present with base tools + ACP ───────────────
+
+for (const role of RESTRICTED_ROLES) {
+  test(`buildChildArgs includes --tools with ACP append for ${role}`, async () => {
+    const { cliArgs } = await buildChildArgs(
+      { agent: role, task: "test task" },
+      "prompt",
+      mockCtx(),
+    );
+    const toolsStr = getToolsValue(cliArgs);
+    assert.ok(toolsStr, `--tools flag present for ${role}`);
+    const tools = toolsStr!.split(",");
+
+    // Base tools present
+    for (const bt of ["read", "bash", "grep", "find", "ls"]) {
+      assert.ok(tools.includes(bt), `${role} tools include ${bt}`);
+    }
+    // ACP tools present
+    for (const at of ACP_TOOLS) {
+      assert.ok(tools.includes(at), `${role} tools include ACP tool ${at}`);
+    }
+    // No edit/write
+    assert.ok(!tools.includes("edit"), `${role} tools do NOT include edit`);
+    assert.ok(!tools.includes("write"), `${role} tools do NOT include write`);
+    // No glob (not a Pi core tool)
+    assert.ok(!tools.includes("glob"), `${role} tools do NOT include glob`);
+    // No duplicates
+    assert.equal(tools.length, new Set(tools).size, `${role} tools have no duplicates`);
+    // Expected order: base tools first, then ACP tools
+    const expected = ["read", "bash", "grep", "find", "ls", ...ACP_TOOLS];
+    assert.deepEqual(tools, expected, `${role} tools in expected order`);
+  });
+}
+
+// ─── Worker: no --tools, full default toolset ─────────────────────────────
+
+test("buildChildArgs omits --tools for worker role", async () => {
   const { cliArgs } = await buildChildArgs(
     { agent: "worker", task: "fix bug" },
     "You are a worker.",
     mockCtx(),
   );
-  const toolsIdx = cliArgs.indexOf("--tools");
-  assert.ok(toolsIdx >= 0, "--tools flag present for worker");
-  assert.equal(cliArgs[toolsIdx + 1], "read,edit,write,bash");
+  assert.equal(getToolsValue(cliArgs), null, "worker does NOT receive --tools");
 });
+
+test("buildChildArgs worker still inherits provider/model from ctx", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "worker", task: "fix bug" },
+    "prompt",
+    mockCtx(),
+  );
+  const providerIdx = cliArgs.indexOf("--provider");
+  const modelIdx = cliArgs.indexOf("--model");
+  assert.ok(providerIdx >= 0, "worker has --provider from ctx.model");
+  assert.equal(cliArgs[providerIdx + 1], "test");
+  assert.ok(modelIdx >= 0, "worker has --model from ctx.model");
+  assert.equal(cliArgs[modelIdx + 1], "test-model");
+});
+
+// ─── Unknown agent: no --tools ─────────────────────────────────────────────
+
+test("buildChildArgs omits --tools for unknown agent name", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "nonexistent-role", task: "test" },
+    "prompt",
+    mockCtx(),
+  );
+  assert.equal(getToolsValue(cliArgs), null, "--tools not added for unknown agent");
+});
+
+// ─── --tools comes before --provider/--model ───────────────────────────────
 
 test("buildChildArgs places --tools before --provider/--model", async () => {
   const { cliArgs } = await buildChildArgs(
@@ -42,15 +102,7 @@ test("buildChildArgs places --tools before --provider/--model", async () => {
   assert.ok(toolsIdx < providerIdx, "--tools comes before --provider");
 });
 
-test("buildChildArgs omits --tools for unknown agent name", async () => {
-  const { cliArgs } = await buildChildArgs(
-    { agent: "nonexistent-role", task: "test" },
-    "prompt",
-    mockCtx(),
-  );
-  const toolsIdx = cliArgs.indexOf("--tools");
-  assert.equal(toolsIdx, -1, "--tools not added for unknown agent");
-});
+// ─── ctx.model inheritance (no explicit model) ────────────────────────────
 
 test("buildChildArgs inherits model from ctx when model not specified", async () => {
   const { cliArgs } = await buildChildArgs(
@@ -64,4 +116,20 @@ test("buildChildArgs inherits model from ctx when model not specified", async ()
   assert.equal(cliArgs[providerIdx + 1], "test");
   assert.ok(modelIdx >= 0, "--model present from ctx.model");
   assert.equal(cliArgs[modelIdx + 1], "test-model");
+});
+
+// ─── explicit model override ──────────────────────────────────────────────
+
+test("buildChildArgs uses explicit model override when provided", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "worker", task: "test", model: "anthropic/claude-5" },
+    "prompt",
+    mockCtx(),
+  );
+  const providerIdx = cliArgs.indexOf("--provider");
+  const modelIdx = cliArgs.indexOf("--model");
+  assert.ok(providerIdx >= 0);
+  assert.equal(cliArgs[providerIdx + 1], "anthropic");
+  assert.ok(modelIdx >= 0);
+  assert.equal(cliArgs[modelIdx + 1], "claude-5");
 });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildChildArgs } from "../src/delegate-tool.js";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+/** Minimal ctx mock — buildChildArgs only reads ctx.model. */
+function mockCtx(): ExtensionContext {
+  return { model: { provider: "test", id: "test-model" } } as unknown as ExtensionContext;
+}
+
+test("buildChildArgs includes --tools whitelist for read-only roles", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "reviewer", task: "review code" },
+    "You are a reviewer.",
+    mockCtx(),
+  );
+  const toolsIdx = cliArgs.indexOf("--tools");
+  assert.ok(toolsIdx >= 0, "--tools flag present for reviewer");
+  assert.equal(cliArgs[toolsIdx + 1], "read,bash", "reviewer gets read,bash whitelist");
+});
+
+test("buildChildArgs includes --tools whitelist for worker role", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "worker", task: "fix bug" },
+    "You are a worker.",
+    mockCtx(),
+  );
+  const toolsIdx = cliArgs.indexOf("--tools");
+  assert.ok(toolsIdx >= 0, "--tools flag present for worker");
+  assert.equal(cliArgs[toolsIdx + 1], "read,edit,write,bash");
+});
+
+test("buildChildArgs places --tools before --provider/--model", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "reviewer", task: "test", model: "openai/gpt-5" },
+    "prompt",
+    mockCtx(),
+  );
+  const toolsIdx = cliArgs.indexOf("--tools");
+  const providerIdx = cliArgs.indexOf("--provider");
+  assert.ok(toolsIdx >= 0 && providerIdx >= 0);
+  assert.ok(toolsIdx < providerIdx, "--tools comes before --provider");
+});
+
+test("buildChildArgs omits --tools for unknown agent name", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "nonexistent-role", task: "test" },
+    "prompt",
+    mockCtx(),
+  );
+  const toolsIdx = cliArgs.indexOf("--tools");
+  assert.equal(toolsIdx, -1, "--tools not added for unknown agent");
+});
+
+test("buildChildArgs inherits model from ctx when model not specified", async () => {
+  const { cliArgs } = await buildChildArgs(
+    { agent: "reviewer", task: "test" },
+    "prompt",
+    mockCtx(),
+  );
+  const providerIdx = cliArgs.indexOf("--provider");
+  const modelIdx = cliArgs.indexOf("--model");
+  assert.ok(providerIdx >= 0, "--provider present from ctx.model");
+  assert.equal(cliArgs[providerIdx + 1], "test");
+  assert.ok(modelIdx >= 0, "--model present from ctx.model");
+  assert.equal(cliArgs[modelIdx + 1], "test-model");
+});


### PR DESCRIPTION
## What

`buildChildArgs` was not passing agent tool whitelists to child Pi processes. A read-only reviewer could receive edit/write tools.

## Changes

- `src/delegate-tool.ts`: `buildChildArgs` appends `--tools <whitelist>` from `AGENTS[args.agent].tools`
- `tests/delegate-tool.test.ts`: +5 tests

## Verification

typecheck ✅ | build ✅ | 58/58 tests pass