### PR TITLE
feat: add tool guardrails (bash default timeout + output cap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
   "debug": false,
   "autoUpdate": true,
   "modelContextLimit": 200000,
-  "delegate": true
+  "delegate": true,
+  "toolBashDefaultTimeout": 600,
+  "toolOutputMaxBytes": 0
 }
 ```
 
@@ -152,8 +154,10 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 | `autoUpdate` | `true` | On Pi startup, check npm for a newer version and auto-install it (throttled to one check per 3 minutes). Disable to avoid all startup network calls. |
 | `modelContextLimit` | *(auto)* | Override the context limit (in tokens). Defaults to the model's `contextWindow`. |
 | `delegate` | `true` | Enable the `acp_delegate` tools (delegate/wait/cancel) and their system-prompt section. Set `false` to skip registering them (e.g. you use a different sub-agent extension, or run headless where async injection adds no value). |
+| `toolBashDefaultTimeout` | `600` | Seconds injected into the `bash` tool when the model omits `timeout`. Pi has **no** default of its own, so without this a forgotten timeout can hang for thousands of seconds. `0` restores Pi's unbounded behavior. |
+| `toolOutputMaxBytes` | `0` (off) | Optional hard byte cap on tool result text (applied via the `tool_result` hook). Pi already truncates at 50KB/2000 lines; set this lower (e.g. `8192`) for a tighter context-budget safety net. Oversized output is head-truncated with a notice; for `bash`, the full output remains in its temp file (`BashToolDetails.fullOutputPath`). |
 
-> **Only these four keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`, nudge thresholds) are code-level and not user-overridable.
+> **Only these six keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`, nudge thresholds) are code-level and not user-overridable.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
   "autoUpdate": true,
   "modelContextLimit": 200000,
   "delegate": true,
-  "toolBashDefaultTimeout": 600,
-  "toolOutputMaxBytes": 0
+  "toolBashDefaultTimeout": 60,
+  "toolOutputMaxBytes": 200000
 }
 ```
 
@@ -154,8 +154,8 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 | `autoUpdate` | `true` | On Pi startup, check npm for a newer version and auto-install it (throttled to one check per 3 minutes). Disable to avoid all startup network calls. |
 | `modelContextLimit` | *(auto)* | Override the context limit (in tokens). Defaults to the model's `contextWindow`. |
 | `delegate` | `true` | Enable the `acp_delegate` tools (delegate/wait/cancel) and their system-prompt section. Set `false` to skip registering them (e.g. you use a different sub-agent extension, or run headless where async injection adds no value). |
-| `toolBashDefaultTimeout` | `600` | Seconds injected into the `bash` tool when the model omits `timeout`. Pi has **no** default of its own, so without this a forgotten timeout can hang for thousands of seconds. `0` restores Pi's unbounded behavior. |
-| `toolOutputMaxBytes` | `0` (off) | Optional hard byte cap on tool result text (applied via the `tool_result` hook). Pi already truncates at 50KB/2000 lines; set this lower (e.g. `8192`) for a tighter context-budget safety net. Oversized output is head-truncated with a notice; for `bash`, the full output remains in its temp file (`BashToolDetails.fullOutputPath`). |
+| `toolBashDefaultTimeout` | `60` | Seconds injected into the `bash` tool when the model omits `timeout`. Pi has **no** default of its own, so without this a forgotten timeout can hang for thousands of seconds. On timeout the model is guided to re-run with a larger `timeout`. `0` restores Pi's unbounded behavior. |
+| `toolOutputMaxBytes` | `200000` | Hard byte cap on tool result text (~5000 lines at ~40 B/line; applied via the `tool_result` hook). Stops runaway output that Pi's own 50KB/2000-line cap can't catch (e.g. tools Pi doesn't cap). When it fires the model is told how to see the full output — for `bash` the full output is in its temp file (`BashToolDetails.fullOutputPath`); set lower (e.g. `8192`) for a tighter context budget, or `0` to disable. |
 
 > **Only these six keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`, nudge thresholds) are code-level and not user-overridable.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,8 +142,8 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
   "autoUpdate": true,
   "modelContextLimit": 200000,
   "delegate": true,
-  "toolBashDefaultTimeout": 600,
-  "toolOutputMaxBytes": 0
+  "toolBashDefaultTimeout": 60,
+  "toolOutputMaxBytes": 200000
 }
 ```
 
@@ -153,8 +153,8 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 | `autoUpdate` | `true` | Pi 启动时检查 npm 是否有更新版本并自动安装(限频:每 3 分钟最多一次检查)。禁用以避免所有启动时的网络请求。 |
 | `modelContextLimit` | *(自动)* | 覆盖上下文上限(token 数)。默认为模型的 `contextWindow`。 |
 | `delegate` | `true` | 启用 `acp_delegate` 工具(delegate/wait/cancel)及其系统提示词段落。设为 `false` 则不注册这些工具(例如你用了别的子代理扩展,或跑 headless 场景异步注入没有意义)。 |
-| `toolBashDefaultTimeout` | `600` | 当模型未指定 `timeout` 时注入 `bash` 工具的超时秒数。Pi **本身没有默认超时**,不加这个,一次遗漏的超时可能挂起几千秒。设为 `0` 恢复 Pi 的无界行为。 |
-| `toolOutputMaxBytes` | `0`(关闭) | 可选的工具结果文本硬上限(字节,通过 `tool_result` hook 应用)。Pi 自身已按 50KB/2000 行截断;设更小(如 `8192`)可作为上下文预算的更紧安全网。超限输出会从头截断并附提示;对 `bash`,完整输出仍保留在其临时文件(`BashToolDetails.fullOutputPath`)中。 |
+| `toolBashDefaultTimeout` | `60` | 当模型未指定 `timeout` 时注入 `bash` 工具的超时秒数。Pi **本身没有默认超时**,不加这个,一次遗漏的超时可能挂起几千秒。超时后会提示模型用更大的 `timeout` 重跑。设为 `0` 恢复 Pi 的无界行为。 |
+| `toolOutputMaxBytes` | `200000` | 工具结果文本硬上限(字节,约 5000 行 @ ~40 字节/行,通过 `tool_result` hook 应用)。用于兜住 Pi 自身 50KB/2000 行截断管不到的输出(例如 Pi 未加限制的工具)。触发截断时会告诉模型如何查看完整输出——对 `bash`,完整输出在其临时文件(`BashToolDetails.fullOutputPath`)中;设更小(如 `8192`)可更省上下文,设 `0` 关闭。 |
 
 > **只有这六个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`、nudge 阈值)是代码级的,不向用户开放。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -141,7 +141,9 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
   "debug": false,
   "autoUpdate": true,
   "modelContextLimit": 200000,
-  "delegate": true
+  "delegate": true,
+  "toolBashDefaultTimeout": 600,
+  "toolOutputMaxBytes": 0
 }
 ```
 
@@ -151,8 +153,10 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 | `autoUpdate` | `true` | Pi 启动时检查 npm 是否有更新版本并自动安装(限频:每 3 分钟最多一次检查)。禁用以避免所有启动时的网络请求。 |
 | `modelContextLimit` | *(自动)* | 覆盖上下文上限(token 数)。默认为模型的 `contextWindow`。 |
 | `delegate` | `true` | 启用 `acp_delegate` 工具(delegate/wait/cancel)及其系统提示词段落。设为 `false` 则不注册这些工具(例如你用了别的子代理扩展,或跑 headless 场景异步注入没有意义)。 |
+| `toolBashDefaultTimeout` | `600` | 当模型未指定 `timeout` 时注入 `bash` 工具的超时秒数。Pi **本身没有默认超时**,不加这个,一次遗漏的超时可能挂起几千秒。设为 `0` 恢复 Pi 的无界行为。 |
+| `toolOutputMaxBytes` | `0`(关闭) | 可选的工具结果文本硬上限(字节,通过 `tool_result` hook 应用)。Pi 自身已按 50KB/2000 行截断;设更小(如 `8192`)可作为上下文预算的更紧安全网。超限输出会从头截断并附提示;对 `bash`,完整输出仍保留在其临时文件(`BashToolDetails.fullOutputPath`)中。 |
 
-> **只有这四个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`、nudge 阈值)是代码级的,不向用户开放。
+> **只有这六个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`、nudge 阈值)是代码级的,不向用户开放。
 
 ### 环境变量
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,8 +21,23 @@ export interface AdapterConfig {
    *  section. Default: true. Set `delegate: false` (adapter config or
    *  ~/.pi/acp.json) to skip registering them. */
   delegate?: boolean;
+  /** Default timeout in seconds injected into the bash tool when the model
+   *  omits `timeout`. Pi has NO built-in default, so without this a command
+   *  that the model forgets to time out can hang for thousands of seconds.
+   *  Default: 600 (10 min — covers most builds while catching runaway hangs).
+   *  Set to 0 to disable (restore Pi's unbounded behavior). */
+  toolBashDefaultTimeout?: number;
+  /** Hard byte cap applied to tool result text via the `tool_result` hook.
+   *  Pi already truncates at 50KB/2000 lines; this is a tighter optional safety
+   *  net for context budget. Default: 0 (off — opt-in). When set, oversized
+   *  text output is head-truncated with a notice; bash full output remains in
+   *  its temp file (BashToolDetails.fullOutputPath). */
+  toolOutputMaxBytes?: number;
   coreOverrides?: Partial<Config>;
 }
+
+export const DEFAULT_TOOL_BASH_TIMEOUT = 600;
+export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 0;
 
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,20 +24,24 @@ export interface AdapterConfig {
   /** Default timeout in seconds injected into the bash tool when the model
    *  omits `timeout`. Pi has NO built-in default, so without this a command
    *  that the model forgets to time out can hang for thousands of seconds.
-   *  Default: 600 (10 min — covers most builds while catching runaway hangs).
-   *  Set to 0 to disable (restore Pi's unbounded behavior). */
+   *  Default: 60 (catches hangs quickly). On timeout the model is guided to
+   *  re-run with a larger `timeout`. Set to 0 to disable (restore Pi's
+   *  unbounded behavior). */
   toolBashDefaultTimeout?: number;
   /** Hard byte cap applied to tool result text via the `tool_result` hook.
-   *  Pi already truncates at 50KB/2000 lines; this is a tighter optional safety
-   *  net for context budget. Default: 0 (off — opt-in). When set, oversized
-   *  text output is head-truncated with a notice; bash full output remains in
-   *  its temp file (BashToolDetails.fullOutputPath). */
+   *  Default: 200000 (~200KB, roughly 5000 lines at ~40 bytes/line) — a
+   *  generous ceiling that stops runaway output. Pi already caps bash/read/grep
+   *  at 50KB/2000 lines (bash full output is saved to a temp file), so this
+   *  default mainly caps tools Pi doesn't cap. Set lower (e.g. 8192) for a
+   *  tighter context budget, or 0 to disable. When capped, oversized text is
+   *  head-truncated with a notice telling the model how to see the full output
+   *  (bash: read BashToolDetails.fullOutputPath). */
   toolOutputMaxBytes?: number;
   coreOverrides?: Partial<Config>;
 }
 
-export const DEFAULT_TOOL_BASH_TIMEOUT = 600;
-export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 0;
+export const DEFAULT_TOOL_BASH_TIMEOUT = 60;
+export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000;
 
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
+import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, setDebugEnabled } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
@@ -32,6 +33,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     wireSessionLifecycle(pi, runtime);
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
+    wireToolGuardrails(pi, runtime);
     pi.registerTool(makeCompressTool(runtime));
     pi.registerTool(makeDecompressTool(runtime));
     pi.registerTool(makeSearchTool(runtime));

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -39,8 +39,36 @@ export function capToolOutput(
   if (total <= max) return undefined;
   const head = keepHead(combined, max);
   const dropped = total - Buffer.byteLength(head, "utf8");
-  kept.push({ type: "text", text: head + buildNotice(dropped, max, fullPath) } as ContentPart);
+  kept.push({ type: "text", text: head + buildCapNotice(dropped, max, fullPath) } as ContentPart);
   return kept;
+}
+
+const TIMEOUT_RE = /Command timed out after (\d+) seconds/;
+
+export function detectBashTimeout(content: ToolResultEvent["content"]): number | undefined {
+  for (const c of content) {
+    if (c.type !== "text") continue;
+    const m = (c as { text: string }).text.match(TIMEOUT_RE);
+    if (m) return Number(m[1]);
+  }
+  return undefined;
+}
+
+export function appendTimeoutNotice(
+  content: ToolResultEvent["content"],
+  secs: number,
+): ToolResultEvent["content"] {
+  const notice = buildTimeoutNotice(secs);
+  const next = [...content];
+  for (let i = next.length - 1; i >= 0; i--) {
+    const part = next[i];
+    if (part && part.type === "text") {
+      next[i] = { type: "text", text: (part as { text: string }).text + notice } as ContentPart;
+      return next;
+    }
+  }
+  next.push({ type: "text", text: notice } as ContentPart);
+  return next;
 }
 
 function keepHead(str: string, maxBytes: number): string {
@@ -58,11 +86,16 @@ function keepHead(str: string, maxBytes: number): string {
   return head;
 }
 
-function buildNotice(dropped: number, maxBytes: number, fullPath?: string): string {
+function buildCapNotice(dropped: number, maxBytes: number, fullPath?: string): string {
   const where = fullPath
-    ? `Full output saved: ${fullPath}`
-    : "Refine the tool call (narrow pattern / lower limit) to reduce output.";
-  return `\n\n[ACP guardrail: dropped ~${formatBytes(dropped)} (cap ${formatBytes(maxBytes)}). ${where}]`;
+    ? `Full output saved to: ${fullPath} — read it to see everything.`
+    : "To see more, narrow the query or redirect output to a file and read the relevant slice.";
+  return `\n\n[ACP guardrail: output capped at ${formatBytes(maxBytes)} (~${formatBytes(dropped)} dropped). ${where}]`;
+}
+
+function buildTimeoutNotice(secs: number): string {
+  const suggested = Math.min(Math.max(Math.ceil(secs * 2), 120), 3600);
+  return `\n\n[ACP guardrail: command killed after ${secs}s. To give it more time, re-run the bash tool with a larger \`timeout\` argument (e.g. \`"timeout": ${suggested}\`).]`;
 }
 
 function formatBytes(n: number): string {
@@ -80,13 +113,26 @@ export function wireToolGuardrails(pi: ExtensionAPI, runtime: AcpRuntime): void 
   });
 
   pi.on("tool_result", (event) => {
+    const isBash = isBashToolResult(event);
+    const fullPath = isBash ? event.details?.fullOutputPath : undefined;
+    const timeoutSecs =
+      isBash && event.isError ? detectBashTimeout(event.content) : undefined;
+
+    let modified: ToolResultEvent["content"] | undefined;
     const max = runtime.adapter.toolOutputMaxBytes;
-    if (max === undefined || max <= 0) return;
-    const fullPath = isBashToolResult(event) ? event.details?.fullOutputPath : undefined;
-    const next = capToolOutput(event.content, max, fullPath);
-    if (next) {
-      debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
-      return { content: next };
+    if (max !== undefined && max > 0) {
+      const next = capToolOutput(event.content, max, fullPath);
+      if (next) {
+        modified = next;
+        debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
+      }
     }
+
+    if (timeoutSecs !== undefined) {
+      modified = appendTimeoutNotice(modified ?? event.content, timeoutSecs);
+      debug.event("guardrail-bash-timeout-notice", { secs: timeoutSecs });
+    }
+
+    if (modified) return { content: modified };
   });
 }

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -1,0 +1,92 @@
+import {
+  isBashToolResult,
+  isToolCallEventType,
+  type ExtensionAPI,
+  type ToolResultEvent,
+} from "@earendil-works/pi-coding-agent";
+import { DEFAULT_TOOL_BASH_TIMEOUT, DEFAULT_TOOL_OUTPUT_MAX_BYTES } from "./config.js";
+import { debug } from "./log.js";
+import type { AcpRuntime } from "./runtime.js";
+
+type ContentPart = ToolResultEvent["content"][number];
+
+export function resolveBashTimeout(
+  input: { timeout?: number },
+  defaultTimeout: number | undefined,
+): number | undefined {
+  if (input.timeout !== undefined) return undefined;
+  const d = defaultTimeout ?? DEFAULT_TOOL_BASH_TIMEOUT;
+  if (!Number.isFinite(d) || d <= 0) return undefined;
+  return d;
+}
+
+export function capToolOutput(
+  content: ToolResultEvent["content"],
+  maxBytes: number | undefined,
+  fullPath?: string,
+): ToolResultEvent["content"] | undefined {
+  const max = maxBytes ?? DEFAULT_TOOL_OUTPUT_MAX_BYTES;
+  if (!Number.isFinite(max) || max <= 0) return undefined;
+  const kept: ContentPart[] = [];
+  const texts: string[] = [];
+  for (const c of content) {
+    if (c.type === "text") texts.push((c as { text: string }).text);
+    else kept.push(c);
+  }
+  if (texts.length === 0) return undefined;
+  const combined = texts.join("\n");
+  const total = Buffer.byteLength(combined, "utf8");
+  if (total <= max) return undefined;
+  const head = keepHead(combined, max);
+  const dropped = total - Buffer.byteLength(head, "utf8");
+  kept.push({ type: "text", text: head + buildNotice(dropped, max, fullPath) } as ContentPart);
+  return kept;
+}
+
+function keepHead(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, "utf8");
+  if (buf.length <= maxBytes) return str;
+  let end = maxBytes;
+  while (end > 0) {
+    const b = buf[end];
+    if (b === undefined || (b & 0xc0) !== 0x80) break;
+    end--;
+  }
+  let head = buf.subarray(0, end).toString("utf8");
+  const nl = head.lastIndexOf("\n");
+  if (nl >= Math.floor(maxBytes / 2)) head = head.slice(0, nl);
+  return head;
+}
+
+function buildNotice(dropped: number, maxBytes: number, fullPath?: string): string {
+  const where = fullPath
+    ? `Full output saved: ${fullPath}`
+    : "Refine the tool call (narrow pattern / lower limit) to reduce output.";
+  return `\n\n[ACP guardrail: dropped ~${formatBytes(dropped)} (cap ${formatBytes(maxBytes)}). ${where}]`;
+}
+
+function formatBytes(n: number): string {
+  return n >= 1024 ? `${(n / 1024).toFixed(1)}KB` : `${n}B`;
+}
+
+export function wireToolGuardrails(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  pi.on("tool_call", (event) => {
+    if (!isToolCallEventType("bash", event)) return;
+    const t = resolveBashTimeout(event.input, runtime.adapter.toolBashDefaultTimeout);
+    if (t !== undefined) {
+      event.input.timeout = t;
+      debug.event("guardrail-bash-timeout", { applied: t });
+    }
+  });
+
+  pi.on("tool_result", (event) => {
+    const max = runtime.adapter.toolOutputMaxBytes;
+    if (max === undefined || max <= 0) return;
+    const fullPath = isBashToolResult(event) ? event.details?.fullOutputPath : undefined;
+    const next = capToolOutput(event.content, max, fullPath);
+    if (next) {
+      debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
+      return { content: next };
+    }
+  });
+}

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -13,6 +13,8 @@ export interface UserAcpConfig {
   autoUpdate?: boolean;
   modelContextLimit?: number;
   delegate?: boolean;
+  toolBashDefaultTimeout?: number;
+  toolOutputMaxBytes?: number;
 }
 
 /** Read global + project acp.json, project overrides global. Returns {} on any
@@ -40,7 +42,7 @@ function join(... parts: string[]): string {
   return path.join(...parts);
 }
 
-const KNOWN = new Set(["debug", "autoUpdate", "modelContextLimit", "delegate"]);
+const KNOWN = new Set(["debug", "autoUpdate", "modelContextLimit", "delegate", "toolBashDefaultTimeout", "toolOutputMaxBytes"]);
 
 function pickKnown(parsed: Record<string, unknown>): UserAcpConfig {
   const out: UserAcpConfig = {};

--- a/tests/tool-guardrails.test.ts
+++ b/tests/tool-guardrails.test.ts
@@ -1,18 +1,23 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveBashTimeout, capToolOutput } from "../src/tool-guardrails.js";
+import {
+  resolveBashTimeout,
+  capToolOutput,
+  detectBashTimeout,
+  appendTimeoutNotice,
+} from "../src/tool-guardrails.js";
 import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
 
 type Content = ToolResultEvent["content"];
 const text = (t: string): Content => [{ type: "text", text: t }];
 
 test("resolveBashTimeout returns undefined when the model already set a timeout", () => {
-  assert.equal(resolveBashTimeout({ timeout: 30 }, 600), undefined);
+  assert.equal(resolveBashTimeout({ timeout: 30 }, 60), undefined);
 });
 
 test("resolveBashTimeout injects the default when the model omitted timeout", () => {
-  assert.equal(resolveBashTimeout({}, 600), 600);
-  assert.equal(resolveBashTimeout({ timeout: undefined }, 600), 600);
+  assert.equal(resolveBashTimeout({}, 60), 60);
+  assert.equal(resolveBashTimeout({ timeout: undefined }, 60), 60);
 });
 
 test("resolveBashTimeout returns undefined when the default is disabled (0 / negative / NaN)", () => {
@@ -21,8 +26,8 @@ test("resolveBashTimeout returns undefined when the default is disabled (0 / neg
   assert.equal(resolveBashTimeout({}, Number.NaN), undefined);
 });
 
-test("resolveBashTimeout falls back to the 600s built-in default when default is undefined", () => {
-  assert.equal(resolveBashTimeout({}, undefined), 600);
+test("resolveBashTimeout falls back to the 60s built-in default when default is undefined", () => {
+  assert.equal(resolveBashTimeout({}, undefined), 60);
 });
 
 test("capToolOutput leaves small output untouched (returns undefined)", () => {
@@ -83,4 +88,37 @@ test("capToolOutput is UTF-8 safe (never splits a multibyte sequence)", () => {
     assert.ok(i + size <= buf.length, "no truncated multibyte sequence at byte " + i);
     i += size;
   }
+});
+
+test("detectBashTimeout extracts the seconds from Pi's timeout error text", () => {
+  assert.equal(detectBashTimeout(text("Command timed out after 60 seconds")), 60);
+  assert.equal(detectBashTimeout(text("partial output\nCommand timed out after 300 seconds")), 300);
+});
+
+test("detectBashTimeout returns undefined when there is no timeout error", () => {
+  assert.equal(detectBashTimeout(text("Command aborted")), undefined);
+  assert.equal(detectBashTimeout(text("no error here")), undefined);
+  assert.equal(detectBashTimeout([]), undefined);
+});
+
+test("appendTimeoutNotice appends actionable guidance to the last text part", () => {
+  const out = appendTimeoutNotice(text("Command timed out after 60 seconds"), 60);
+  assert.equal(out.length, 1);
+  const t = (out[0] as { text: string }).text;
+  assert.match(t, /killed after 60s/);
+  assert.match(t, /`timeout`/);
+  assert.match(t, /"timeout": 120/);
+});
+
+test("appendTimeoutNotice suggests a larger timeout that scales with the kill time", () => {
+  const out = appendTimeoutNotice(text("Command timed out after 300 seconds"), 300);
+  const t = (out[0] as { text: string }).text;
+  assert.match(t, /"timeout": 600/);
+});
+
+test("appendTimeoutNotice adds a new text part when content has no text part", () => {
+  const img = { type: "image", source: { media_type: "image/png", data: "AAAA" } } as Content[number];
+  const out = appendTimeoutNotice([img], 30);
+  assert.equal(out.length, 2);
+  assert.equal(out[1].type, "text");
 });

--- a/tests/tool-guardrails.test.ts
+++ b/tests/tool-guardrails.test.ts
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveBashTimeout, capToolOutput } from "../src/tool-guardrails.js";
+import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
+
+type Content = ToolResultEvent["content"];
+const text = (t: string): Content => [{ type: "text", text: t }];
+
+test("resolveBashTimeout returns undefined when the model already set a timeout", () => {
+  assert.equal(resolveBashTimeout({ timeout: 30 }, 600), undefined);
+});
+
+test("resolveBashTimeout injects the default when the model omitted timeout", () => {
+  assert.equal(resolveBashTimeout({}, 600), 600);
+  assert.equal(resolveBashTimeout({ timeout: undefined }, 600), 600);
+});
+
+test("resolveBashTimeout returns undefined when the default is disabled (0 / negative / NaN)", () => {
+  assert.equal(resolveBashTimeout({}, 0), undefined);
+  assert.equal(resolveBashTimeout({}, -5), undefined);
+  assert.equal(resolveBashTimeout({}, Number.NaN), undefined);
+});
+
+test("resolveBashTimeout falls back to the 600s built-in default when default is undefined", () => {
+  assert.equal(resolveBashTimeout({}, undefined), 600);
+});
+
+test("capToolOutput leaves small output untouched (returns undefined)", () => {
+  assert.equal(capToolOutput(text("hello"), 100), undefined);
+});
+
+test("capToolOutput returns undefined when the cap is disabled", () => {
+  assert.equal(capToolOutput(text("x".repeat(10_000)), 0), undefined);
+  assert.equal(capToolOutput(text("x".repeat(10_000)), undefined), undefined);
+});
+
+test("capToolOutput truncates oversized text to under the byte cap and adds a notice", () => {
+  const big = "line\n".repeat(4000);
+  const out = capToolOutput(text(big), 500);
+  assert.ok(out, "should return truncated content");
+  const t = (out![0] as { text: string }).text;
+  assert.ok(Buffer.byteLength(t, "utf8") <= 500 + 200, "truncated payload must be near the cap (notice adds a little)");
+  assert.match(t, /ACP guardrail/);
+  assert.match(t, /dropped/);
+});
+
+test("capToolOutput keeps a complete last line (no mid-line cut)", () => {
+  const big = "0123456789\n".repeat(2000);
+  const out = capToolOutput(text(big), 100);
+  const t = (out![0] as { text: string }).text;
+  const body = t.split("\n\n[ACP guardrail")[0];
+  for (const line of body.split("\n")) {
+    assert.ok(line.length === 0 || line.length === 10, "no partial line: " + JSON.stringify(line));
+  }
+});
+
+test("capToolOutput mentions the saved full-output path for bash-style results", () => {
+  const big = "x".repeat(10_000);
+  const out = capToolOutput(text(big), 500, "/tmp/acp-full.log");
+  const t = (out![0] as { text: string }).text;
+  assert.match(t, /\/tmp\/acp-full\.log/);
+});
+
+test("capToolOutput preserves non-text (image) content alongside truncated text", () => {
+  const img = { type: "image", source: { media_type: "image/png", data: "AAAA" } } as Content[number];
+  const content: Content = [{ type: "text", text: "x".repeat(10_000) }, img];
+  const out = capToolOutput(content, 500);
+  assert.ok(out);
+  assert.equal(out!.some((c) => c.type === "image"), true, "image part must survive");
+  assert.equal(out!.some((c) => c.type === "text"), true, "truncated text part must be present");
+});
+
+test("capToolOutput is UTF-8 safe (never splits a multibyte sequence)", () => {
+  const big = "中文测试\n".repeat(3000);
+  const out = capToolOutput(text(big), 200);
+  const t = (out![0] as { text: string }).text;
+  const body = t.split("\n\n[ACP guardrail")[0];
+  const buf = Buffer.from(body, "utf8");
+  let i = 0;
+  while (i < buf.length) {
+    const b = buf[i];
+    const size = b < 0x80 ? 1 : b < 0xe0 ? 2 : b < 0xf0 ? 3 : 4;
+    assert.ok(i + size <= buf.length, "no truncated multibyte sequence at byte " + i);
+    i += size;
+  }
+});


### PR DESCRIPTION
## Summary

Adds two tool-level guardrails to billion-context-pi, addressing #7:

1. **Default bash timeout** — when the model omits `timeout`, bcp injects a configurable default (600s). Pi itself has **no default bash timeout** (its only cap is `MAX_TIMEOUT_MS = 2_147_483_647` ≈ 24.8 days), so a forgotten timeout can hang a session for thousands of seconds.
2. **Optional tool-output cap** — an opt-in hard byte cap on tool result text via the `tool_result` hook, for tighter context budgets. Pi already truncates at 50KB / 2000 lines; this lets users set a lower safety net.

Both are implemented as Pi extension hooks (`tool_call` + `tool_result`) — non-breaking, complementary to bcp's after-the-fact compression.

## Why this is needed (verified)

| | Pi's built-in behavior |
|---|---|
| bash timeout | `resolveTimeoutMs(undefined)` → `undefined` → **no timer**. Schema description literally says `"no default timeout"`. |
| tool output | truncated at 50KB / 2000 lines; bash full output saved to `BashToolDetails.fullOutputPath` (re-`read`-able), grep has no file save. |

So the bash hang is real and unguarded; the output cap is a belt-and-suspenders for context budget.

## Behavior & defaults

| Config key | Default | Description |
|------------|---------|-------------|
| `toolBashDefaultTimeout` | `600` (s) | Injected into bash when the model omits `timeout`. `0` restores Pi's unbounded behavior. Model-supplied `timeout` is always respected. **Non-destructive.** |
| `toolOutputMaxBytes` | `0` (off) | Opt-in hard byte cap on tool result text (head-truncated with a byte-count notice). e.g. `8192`. bash's full output stays in its temp file, so capping is non-destructive for bash. |

- **Timeout is ON by default** (prevents real hangs; non-destructive).
- **Output cap is OFF by default** (conservative; bash is non-destructive, grep is destructive but re-runnable).

Timeout/limit = before-the-fact prevention; bcp compression = after-the-fact summarization. They complement, not conflict.

## Files

- `src/tool-guardrails.ts` (new) — `resolveBashTimeout` / `capToolOutput` / `wireToolGuardrails` (UTF-8-safe head truncation, preserves non-text parts, points bash to `fullOutputPath`)
- `src/config.ts` — `AdapterConfig` + `DEFAULT_TOOL_BASH_TIMEOUT` / `DEFAULT_TOOL_OUTPUT_MAX_BYTES`
- `src/user-config.ts` — `UserAcpConfig` + `KNOWN` set (both keys configurable via `acp.json`)
- `src/index.ts` — wire `wireToolGuardrails` into `createAcpExtension`
- `tests/tool-guardrails.test.ts` (new, 11 cases) — timeout injection; UTF-8 boundary safety; image-part preservation; full-path notice; no mid-line cut
- `README.md` + `README.zh-CN.md` — config table + descriptions

## Verification

- `npm run typecheck` — clean
- `npm test` — **59/59 pass** (48 pre-existing + 11 new)
- `npm run build` — OK (dist 392KB, guardrails bundled inline)

Closes #7.
