### PR TITLE
release v0.1.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.24",
+	"version": "0.1.25",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.24",
+			"version": "0.1.25",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.16",
+				"acp-kernel": "0.0.17",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3223,9 +3223,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.16.tgz",
-			"integrity": "sha512-fepPOzGsUaz/ilHUuhLUMd2DskL/QM8H9YXcSrlIjJYKLJgeCTLAy3BGLhqmessR6DJF9BL48PKbQ+WfCq/8XQ==",
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.17.tgz",
+			"integrity": "sha512-Mu7CIU1jo79cqHV6tZ8OgZe9ed4HBctVUsoSLKK3SStpkExZw7O3lcUTJLXNqyViuYA83gVH4Z8t43hn89qDDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.24",
+	"version": "0.1.25",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.16",
+		"acp-kernel": "0.0.17",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
## Release v0.1.25

Bumps version `0.1.24` → `0.1.25` and acp-kernel `0.0.16` → `0.0.17`.

### Shipped since v0.1.24
- **feat:** tool guardrails — bash default timeout 60s + output cap 200KB, with timeout/output guidance
- **fix:** surface compression warnings to the model
- **fix:** preserve custom_message entries in context transform
- **docs:** rebrand ACP → billion-context (README prose, EN + ZH) + Pi plugin priority limitation

### Pre-flight checks (all green)
- `npm run typecheck` ✅
- `npm test` → **70/70 pass** ✅
- `npm run build` → dist/index.js 388KB (self-contained) ✅

### Cross-repo dependency
acp-kernel `0.0.17` is **live on npm** (`npm view acp-kernel version` confirmed), so the publishing order constraint is satisfied.

### Files changed (2)
- `package.json` — version + acp-kernel pin
- `package-lock.json` — refreshed via `npm install`

---
_Merge is human-only per AGENTS.md §4. CI auto-publishes on merge._