### PR TITLE
compress: add blockIds for non-contiguous block distillation (T2/T3)

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -53,6 +53,13 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {
   const ranges = args.content ?? [];
   if (ranges.length === 0) return "No ranges provided.";
+  for (const r of ranges) {
+    const hasBlockIds = r.blockIds && r.blockIds.length > 0;
+    const hasRefs = r.startId && r.endId;
+    if (!hasBlockIds && !hasRefs) {
+      return `Each content entry needs either startId+endId or blockIds. Entry missing both (summary starts: "${r.summary.slice(0, 40)}").`;
+    }
+  }
   const { state, coreMessages } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
 

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -13,15 +13,16 @@ function formatK(n: number): string {
 }
 
 const RangeSpec = Type.Object({
-  startId: Type.String({ description: 'Message ref, e.g. "m00005" (from the acp tag), or a block id "b3".' }),
-  endId: Type.String({ description: 'Inclusive end ref. Must be at or after startId.' }),
+  startId: Type.Optional(Type.String({ description: 'Message ref, e.g. "m00005" (from the acp tag), or a block id "b3". Omit when using blockIds.' })),
+  endId: Type.Optional(Type.String({ description: 'Inclusive end ref. Must be at or after startId. Omit when using blockIds.' })),
+  blockIds: Type.Optional(Type.Array(Type.String(), { description: 'Explicit block ids to distill into one higher-tier block (T2/T3), e.g. ["b3","b7"]. Use for non-contiguous blocks: consumes exactly these blocks and leaves raw messages between them visible. Takes precedence over startId/endId.' })),
   summary: Type.String({ description: "Complete technical summary replacing all content in range. Keep only essential details (conclusions, file paths, decisions, exact values, etc.)." }),
   topic: Type.Optional(Type.String({ description: "Short label (3-5 words) for THIS range, e.g. 'Auth System Exploration'. Omit to use top-level topic. When compressing multiple unrelated ranges, give each its own topic for better quality." })),
 });
 
 const CompressParams = Type.Object({
   topic: Type.Optional(Type.String({ description: "Fallback topic for entries without their own. Omit when each content entry specifies its own topic." })),
-  content: Type.Array(RangeSpec, { description: "One or more ranges to compress, each with start/end boundaries and a summary. When compressing multiple unrelated ranges in one call, give each its own topic." }),
+  content: Type.Array(RangeSpec, { description: "One or more ranges to compress. Each entry uses EITHER startId+endId (a contiguous range) OR blockIds (distill specific blocks into a higher tier). When compressing multiple unrelated ranges in one call, give each its own topic." }),
   summaryMaxChars: Type.Optional(Type.Number({ description: "Override max summary length (default max: 20000 chars). Use when content is important and needs more detail — don't lose critical info just to fit the limit." })),
 });
 
@@ -32,10 +33,11 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
     name: "compress",
     label: "Compress",
     description:
-      "Replace older conversation ranges with detailed summaries you write. Single range: compress({ content: [{ startId, endId, summary }] }). Batch: compress({ content: [{ topic, startId, endId, summary }, ...] }) — each entry gets its own summary.",
-    promptSnippet: "compress({ content: [{ startId, endId, summary }] }) or batch multiple ranges",
+      "Replace older conversation ranges with detailed summaries you write. Single range: compress({ content: [{ startId, endId, summary }] }). T2/T3 block distillation (non-contiguous blocks): compress({ content: [{ blockIds: [\"b3\",\"b7\"], summary }] }) — consumes exactly those blocks. Batch: compress({ content: [{ topic, startId, endId, summary }, ...] }) — each entry gets its own summary.",
+    promptSnippet: "compress({ content: [{ startId, endId, summary }] }) or { blockIds: [...], summary }, or batch",
     promptGuidelines: [
       "Each message has an acp tag with its mNNNNN ref, token size, and type. Compress ranges by their refs.",
+      "For T2/T3 distillation of specific blocks, use blockIds: [\"b3\",\"b7\"] — consumes exactly those blocks (non-contiguous OK).",
       "Batch multiple unrelated ranges in one call — each gets its own topic and summary.",
       "Write dense, self-contained summaries — preserve file paths, signatures, errors, and decisions verbatim.",
       "Never compress content the current step is actively using.",
@@ -61,7 +63,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   debug.event("compress-in", {
     sid: ctx.sessionManager.getSessionId(),
     ranges: ranges.length,
-    spans: ranges.map((r) => ({ span: `${r.startId}..${r.endId}`, summaryLen: r.summary.length, summary: r.summary, topic: r.topic ?? topLevelTopic ?? null })),
+    spans: ranges.map((r) => ({ span: r.blockIds && r.blockIds.length > 0 ? `blockIds:[${r.blockIds.join(",")}]` : `${r.startId}..${r.endId}`, summaryLen: r.summary.length, summary: r.summary, topic: r.topic ?? topLevelTopic ?? null })),
     blocksBefore: state.blocks.length,
     activeBefore: state.blocks.filter((b) => b.active).length,
     beforeMsgCount: coreMessages.length,
@@ -69,7 +71,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   });
 
   const applied = runtime.core.applyCompression({
-    ranges: ranges.map((r) => ({ startRef: r.startId, endRef: r.endId, summary: r.summary, topic: r.topic ?? topLevelTopic, summaryMaxChars, compressCallId: toolCallId })),
+    ranges: ranges.map((r) => ({ startRef: r.startId, endRef: r.endId, blockIds: r.blockIds, summary: r.summary, topic: r.topic ?? topLevelTopic, summaryMaxChars, compressCallId: toolCallId })),
     messages: coreMessages,
     state,
     config,

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -53,7 +53,7 @@ MULTI-TIER COMPRESSION
 
 Summaries accumulate as the session grows. When tier-1 summaries pile up, the system injects a nudge prompting you to DISTILL old blocks into a single tier-2 summary. If tier-2 summaries also accumulate, a further nudge asks you to CONDENSE them into tier-3.
 
-To compress blocks: use block IDs as boundaries: compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] }). This deactivates the consumed blocks and creates a new higher-tier block.
+To distill blocks into a higher tier, list the exact block ids: compress({ content: [{ blockIds: ["b3","b7","b15"], summary: "..." }] }) — consumes exactly those blocks (non-contiguous OK) and creates one higher-tier block; the blocks must all be the same tier. For a contiguous block span you may instead use startId/endId: compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] }), but note a span consumes everything in the range (any intervening raw messages and blocks anchored there).
 
 ${TIER2_DISTILL_RULES}
 

--- a/tests/compress-blockids.test.ts
+++ b/tests/compress-blockids.test.ts
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { Value } from "typebox/value";
+import { createAcpExtension } from "../src/index.js";
+
+const STATE_FILE = "/tmp/pai-acp-blockids-it.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+async function cleanState() {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+}
+
+function fakeCtx(entries: any[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+async function fireCtx(handlers: Map<string, ((event: any, ctx: any) => any)[]>, ctx: any) {
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+}
+
+async function setup(entries: any[]) {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const ctx = fakeCtx(entries);
+  await fireCtx(handlers, ctx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  return { compressTool, ctx, handlers };
+}
+
+function resultText(res: any): string {
+  return (res.content[0] as any).text as string;
+}
+
+const big = (n: string) => `detailed message ${n} ` + "x".repeat(3000);
+
+test("schema accepts a blockIds-only content entry (startId/endId now optional)", async () => {
+  await cleanState();
+  const { compressTool } = await setup([userMsg("e1", "hi")]);
+  const params = compressTool.parameters;
+  assert.ok(
+    Value.Check(params, { content: [{ blockIds: ["b1", "b2"], summary: "distilled summary of the two blocks" }] }),
+    "blockIds-only entry should validate (startId/endId optional)",
+  );
+  assert.ok(
+    Value.Check(params, { content: [{ startId: "m00001", endId: "m00002", summary: "range summary covering the early messages" }] }),
+    "classic startId/endId entry should still validate",
+  );
+});
+
+test("compress blockIds distills specific non-contiguous blocks into a higher tier", async () => {
+  await cleanState();
+  const entries = [
+    userMsg("e1", big("one")), userMsg("e2", big("two")),
+    userMsg("e3", big("three")),
+    userMsg("e4", big("four")), userMsg("e5", big("five")),
+    userMsg("e6", big("six")), userMsg("e7", big("seven")), userMsg("e8", big("eight")),
+    userMsg("e9", big("nine")), userMsg("e10", big("ten")), userMsg("e11", big("eleven")), userMsg("e12", big("twelve")),
+  ];
+  const { compressTool, ctx } = await setup(entries);
+
+  await compressTool.execute("tc1", { content: [{ startId: "m00001", endId: "m00002", summary: "Block one: early setup and initialization of the test session harness." }] }, undefined, undefined, ctx);
+  await compressTool.execute("tc2", { content: [{ startId: "m00004", endId: "m00005", summary: "Block two: configuration work and parameter tuning for the pipeline." }] }, undefined, undefined, ctx);
+
+  const res = await compressTool.execute("tc3", { content: [{ blockIds: ["b1", "b2"], summary: "Distilled tier-2 summary combining blocks one and two into a higher tier." }] }, undefined, undefined, ctx);
+  const text = resultText(res);
+  assert.match(text, /\d+ block/, "blockIds distillation should create a higher-tier block");
+  assert.doesNotMatch(text, /error/i, "blockIds distillation should not error");
+});

--- a/tests/compress-blockids.test.ts
+++ b/tests/compress-blockids.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { rm } from "node:fs/promises";
+import { rm, readFileSync } from "node:fs";
+import { rm as rmAsync } from "node:fs/promises";
 import { Value } from "typebox/value";
 import { createAcpExtension } from "../src/index.js";
 
@@ -27,7 +28,11 @@ function userMsg(id: string, text: string) {
 }
 
 async function cleanState() {
-  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  await rmAsync(`${STATE_FILE}.acp.json`, { force: true });
+}
+
+function readState(): any {
+  return JSON.parse(readFileSync(`${STATE_FILE}.acp.json`, "utf8"));
 }
 
 function fakeCtx(entries: any[]) {
@@ -63,6 +68,16 @@ function resultText(res: any): string {
 
 const big = (n: string) => `detailed message ${n} ` + "x".repeat(3000);
 
+function twelveBigEntries() {
+  return [
+    userMsg("e1", big("one")), userMsg("e2", big("two")),
+    userMsg("e3", big("three")),
+    userMsg("e4", big("four")), userMsg("e5", big("five")),
+    userMsg("e6", big("six")), userMsg("e7", big("seven")), userMsg("e8", big("eight")),
+    userMsg("e9", big("nine")), userMsg("e10", big("ten")), userMsg("e11", big("eleven")), userMsg("e12", big("twelve")),
+  ];
+}
+
 test("schema accepts a blockIds-only content entry (startId/endId now optional)", async () => {
   await cleanState();
   const { compressTool } = await setup([userMsg("e1", "hi")]);
@@ -79,14 +94,7 @@ test("schema accepts a blockIds-only content entry (startId/endId now optional)"
 
 test("compress blockIds distills specific non-contiguous blocks into a higher tier", async () => {
   await cleanState();
-  const entries = [
-    userMsg("e1", big("one")), userMsg("e2", big("two")),
-    userMsg("e3", big("three")),
-    userMsg("e4", big("four")), userMsg("e5", big("five")),
-    userMsg("e6", big("six")), userMsg("e7", big("seven")), userMsg("e8", big("eight")),
-    userMsg("e9", big("nine")), userMsg("e10", big("ten")), userMsg("e11", big("eleven")), userMsg("e12", big("twelve")),
-  ];
-  const { compressTool, ctx } = await setup(entries);
+  const { compressTool, ctx } = await setup(twelveBigEntries());
 
   await compressTool.execute("tc1", { content: [{ startId: "m00001", endId: "m00002", summary: "Block one: early setup and initialization of the test session harness." }] }, undefined, undefined, ctx);
   await compressTool.execute("tc2", { content: [{ startId: "m00004", endId: "m00005", summary: "Block two: configuration work and parameter tuning for the pipeline." }] }, undefined, undefined, ctx);
@@ -95,4 +103,24 @@ test("compress blockIds distills specific non-contiguous blocks into a higher ti
   const text = resultText(res);
   assert.match(text, /\d+ block/, "blockIds distillation should create a higher-tier block");
   assert.doesNotMatch(text, /error/i, "blockIds distillation should not error");
+
+  const state = readState();
+  const t2 = state.blocks.filter((b: any) => b.tier === 2 && b.active);
+  assert.equal(t2.length, 1, "exactly one active T2 block created");
+  const b1 = state.blocks.find((b: any) => b.blockId === "b1");
+  const b2 = state.blocks.find((b: any) => b.blockId === "b2");
+  assert.equal(b1.active, false, "source block b1 must be consumed (inactive)");
+  assert.equal(b2.active, false, "source block b2 must be consumed (inactive)");
+  const eff = t2[0].effectiveMessageIds.sort();
+  assert.deepEqual(eff, ["e1", "e2", "e4", "e5"], "T2 effective messages = exactly the two source blocks' messages");
+  assert.ok(!t2[0].effectiveMessageIds.includes("e3"), "intervening entry e3 must stay visible (not folded into T2)");
+  assert.ok(t2[0].directBlockIds.includes("b1") && t2[0].directBlockIds.includes("b2"), "T2 block references its source blocks");
+});
+
+test("boundary-less entry (no startId/endId/blockIds) returns a clear handler error", async () => {
+  await cleanState();
+  const { compressTool, ctx } = await setup(twelveBigEntries());
+  const res = await compressTool.execute("tc1", { content: [{ summary: "an entry with no boundary source whatsoever" }] }, undefined, undefined, ctx);
+  const text = resultText(res);
+  assert.match(text, /needs either startId\+endId or blockIds/i, "handler should reject boundary-less entries with a clear message");
 });


### PR DESCRIPTION
## What

Adds a `blockIds` field to the `compress` tool so the model can distill **specific non-contiguous blocks** into a higher-tier block — the gap exposed by the T2-distill failure on issue #7.

## Why

`startId=bN, endId=bN` resolves to a **contiguous span** that consumes everything in the range (intervening raw messages included). When the model needs to distill a hand-picked set of T1 blocks (e.g. `b3` and `b7`) into T2, it had no way to express that, so it dropped boundaries and stuffed the block list into the summary text. `blockIds` fixes this: it consumes **exactly** the listed blocks and leaves everything between them visible.

## Changes

- `src/compress-tool.ts`: `RangeSpec` gains optional `blockIds: string[]`; `startId`/`endId` now optional. Handler passes `blockIds` through to `acp-kernel`. Tool description / promptSnippet / promptGuidelines updated.
- `src/system-prompt.ts`: T2/T3 block-distill guidance now recommends `blockIds` (primary) and explains the `startId`/`endId` span alternative.
- `tests/compress-blockids.test.ts`: schema accepts `blockIds`-only entry; end-to-end distillation of two non-contiguous T1 blocks into a T2 block.

## Depends on

**acp-kernel PR #41** (`blockIds` support in `applyCompression`). The `acp-kernel` version pin is NOT bumped here — it will be bumped in a release commit once acp-kernel #41 is merged + published, per the cross-repo release workflow (AGENTS.md §5).

Local validation: acp-kernel blockids build overlaid onto `node_modules/acp-kernel/dist` (AGENTS.md §5 pre-validation). `typecheck` clean, **72/72 tests pass**, build OK (397 KB).