### PR TITLE
fix(delegate): dedup wait() result when already injected

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -94,6 +94,10 @@ interface DelegateRun {
   child?: ChildProcess;
   result?: { code: number | null; file: string; body: string };
   consumed?: boolean;
+  /** True once the close handler injected the result as a system
+   *  notification (sendUserMessage succeeded). Lets a later wait() avoid
+   *  re-delivering the same payload. */
+  injected?: boolean;
   waiter?: () => void;
 }
 
@@ -206,6 +210,23 @@ function remainingLineForWait(selfRunId: string): string {
   return remaining > 0 ? ` ${remaining} delegate${remaining === 1 ? " is" : "s are"} still running.` : "";
 }
 
+/** If the delegate already delivered its result via a system notification
+ *  (the close handler injected before this wait was called), return a short
+ *  "already delivered" message pointing at the result file, so the model
+ *  never sees the same result twice (once via the injected notification,
+ *  once via this tool result). Returns null when the run was NOT injected,
+ *  in which case the caller delivers the full payload via formatRunResult(). */
+export function injectedWaitMessage(
+  run: { injected?: boolean; result?: { file: string } },
+  runId: string,
+  remainingLine: string,
+): string | null {
+  if (!run.injected) return null;
+  const file = run.result?.file;
+  const fileLine = file ? ` If you need details, read the result file: \`${file}\`.` : "";
+  return `Delegate \`${runId}\` already delivered its result via a system notification when it finished — no need to wait on it again.${remainingLine}${fileLine}`;
+}
+
 export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof WaitParams> {
   return {
     name: "acp_delegate_wait",
@@ -231,6 +252,15 @@ export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof W
         return { details: undefined, content: [{ type: "text", text: `Delegate \`${args.runId}\` was cancelled (no result).${remainingLineForWait(args.runId)}` }] };
       }
       if (run.status !== "running") {
+        // The delegate already finished. If the close handler already injected
+        // its result as a system notification (it fired before this wait was
+        // called), don't re-deliver the full payload — point at the file
+        // instead, so the model never sees the same result twice.
+        const dedup = injectedWaitMessage(run, args.runId, remainingLineForWait(args.runId));
+        if (dedup) {
+          run.consumed = true;
+          return { details: undefined, content: [{ type: "text", text: dedup }] };
+        }
         // status is only flipped together with result (see close handler), so
         // a non-running, non-cancelled run always has a result. Guard anyway.
         run.consumed = true;
@@ -447,6 +477,7 @@ async function runDelegate(
             return;
           }
           const injected = injectResult(pi, args.agent, runId, args.task, code, file);
+          run.injected = injected;
           debug.event("delegate-done", { runId, code, status: run.status, injected, outLen: output.length, file });
           delegateStatusWidget.poke();
         })

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs } from "../src/delegate-tool.js";
+import { buildChildArgs, injectedWaitMessage } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs only reads ctx.model. */
@@ -132,4 +132,38 @@ test("buildChildArgs uses explicit model override when provided", async () => {
   assert.equal(cliArgs[providerIdx + 1], "anthropic");
   assert.ok(modelIdx >= 0);
   assert.equal(cliArgs[modelIdx + 1], "claude-5");
+});
+
+// ─── wait() dedup: already-injected run returns "already delivered" ───────
+// Race scenario: the delegate finishes quickly, the close handler injects the
+// result as a system notification, and THEN the model calls acp_delegate_wait.
+// Without dedup the model sees the same result twice (notification + tool
+// result). injectedWaitMessage is the pure helper that short-circuits this.
+
+test("injectedWaitMessage returns null when run was NOT injected", () => {
+  assert.equal(injectedWaitMessage({ injected: false }, "del_x", ""), null);
+  assert.equal(injectedWaitMessage({}, "del_x", ""), null);
+});
+
+test("injectedWaitMessage dedup message names the runId and the result file", () => {
+  const msg = injectedWaitMessage(
+    { injected: true, result: { file: "/tmp/acp-delegate/del_x.out" } },
+    "del_x",
+    "",
+  );
+  assert.ok(msg, "returns a message for an injected run");
+  assert.ok(msg!.includes("del_x"), "names the runId");
+  assert.ok(msg!.includes("/tmp/acp-delegate/del_x.out"), "points at the result file");
+  assert.ok(msg!.includes("already delivered"), "states it was already delivered");
+  assert.ok(msg!.includes("no need to wait"), "tells the model not to wait again");
+});
+
+test("injectedWaitMessage surfaces remaining delegates and tolerates a missing file", () => {
+  const msg = injectedWaitMessage(
+    { injected: true, result: {} },
+    "del_x",
+    " 2 delegates are still running.",
+  );
+  assert.ok(msg!.includes("2 delegates are still running"), "passes through the remaining line");
+  assert.ok(!msg!.includes("read the result file"), "omits the file line when file is absent");
 });


### PR DESCRIPTION
## Problem

When an async delegate finishes **quickly**, the close handler injects the result as a system notification **before** the model can call `acp_delegate_wait`. The wait tool then hits its early-return path (`run.status !== "running"`) and delivers the **same** result again as a tool result — the model sees the result **twice**.

This was observed live during testing: after calling `acp_delegate_wait` and getting the formatted result, the `[acp_delegate completed] ...` system notification still arrived afterward with the identical payload.

The root cause is a delivery race: `injectResult` (fire-and-forget `sendUserMessage`) in the close handler has no way to know a `wait()` is about to claim the same result, because the model needs a full inference turn to decide to call wait — by then injection has already fired.

## Fix

Track an `injected` flag on the run, set `true` when `injectResult` succeeds in the close handler. In `acp_delegate_wait`'s early-return path, if the run was already injected, return a short **"already delivered"** message that points at the result file, instead of re-emitting `formatRunResult()`.

The full payload stays reachable two ways: the injected notification, and the persisted result file. No information loss.

| Delivery path | Before | After |
|---|---|---|
| wait parks → close fires | ✅ waiter delivers, no inject | ✅ unchanged |
| close fires → wait called (early-return) | ❌ inject **and** wait both deliver | ✅ wait returns "already delivered" |
| close fires, model never waits | ✅ inject only | ✅ unchanged |

## Changes

- `src/delegate-tool.ts`
  - `DelegateRun.injected?: boolean` — set when `sendUserMessage` succeeds in the close handler
  - exported pure helper `injectedWaitMessage(run, runId, remainingLine)` — returns the dedup message or `null` (extracted for unit testing, matching the `resolveBashTimeout` / `detectBashTimeout` pattern)
  - `acp_delegate_wait` early-return calls it before falling through to `formatRunResult`
- `tests/delegate-tool.test.ts` — 3 new tests for `injectedWaitMessage` (null for non-injected, names runId+file, surfaces remaining line + tolerates missing file)

## Validation

- `npm test` → **83/83 pass**
- `npm run typecheck` → clean

## Notes

- Patch-level fix; no behavior change for the two non-racy paths.
- Version bump intentionally omitted (matches repo convention — feature/fix PRs do not bump; release is a separate PR, e.g. #82). Suggest a follow-up `release v0.1.26` PR to cut the patch.