### PR TITLE
release v0.1.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.25",
+			"version": "0.1.26",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.25",
+	"version": "0.1.26",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release bundling the two delegate fixes shipped since v0.1.25.

## What changed since v0.1.25

- **#79** `fix(delegate): apply restricted tool guardrails` — read-only roles (reviewer / researcher / planner / oracle) now spawn with a `--tools` allowlist (`read,bash,grep,find,ls` + auto-appended ACP context tools); `worker` stays on the full default toolset. Soft guardrail (bash can bypass — not a security boundary).
- **#85** `fix(delegate): dedup wait() result when already injected` — when an async delegate finishes before the model calls `acp_delegate_wait`, the wait tool now returns a short "already delivered" pointer instead of re-emitting the full payload (previously the result was delivered twice: once via the injected notification, once via the tool result).

## Bump

`0.1.25 → 0.1.26` in `package.json` + `package-lock.json`. No dependency changes (`acp-kernel` stays at `0.0.17`).

## After merge

```
npm run build && npm publish
```

Both fixes were validated end-to-end against a locally-built install (spawn `cliArgs` captured for researcher vs worker; `injected=true` race path observed returning the dedup message). 83/83 tests pass.