### PR TITLE
fix: support oh-my-pi (omp) host

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -8,6 +8,9 @@ type AnyMessage = {
   content?: unknown;
   toolName?: string;
   toolCallId?: string;
+  command?: string;
+  output?: unknown;
+  summary?: string;
 };
 
 const REF_TAG = new RegExp("^(?:\x3cacp\\s[^>]*\x3em\\d{5}\x3c/acp\x3e|\\[m\\d{1,5}\\])\\s?\\n?");
@@ -72,10 +75,19 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
     }
     return [{ id, role: "assistant", contentType: "text", text: extractText(msg.content) }];
   }
-  const customText = extractText(msg.content);
+  const customText = extractText(msg.content) || fallbackText(msg);
   return customText.length > 0
     ? [{ id, role: "user", contentType: "text", text: customText }]
     : [];
+}
+
+function fallbackText(msg: AnyMessage): string {
+  const parts: string[] = [];
+  if (msg.command) parts.push(`$ ${msg.command}`);
+  const out = extractText(msg.output);
+  if (out) parts.push(out);
+  if (msg.summary) parts.push(msg.summary);
+  return parts.join("\n").trim();
 }
 
 function stringifyArgs(args: unknown): string {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,6 +10,21 @@ import { resolveConfig, type AdapterConfig } from "./config.js";
 import { entriesToCoreMessages } from "./messages.js";
 import { SessionStateStore } from "./state.js";
 
+// pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
+// `getBranch()`. Both return chronological SessionEntry[]; feature-detect so the
+// adapter runs under either host (omp's runner silently swallows the TypeError).
+type SessionEntrySource = {
+  buildContextEntries?: () => SessionEntry[];
+  getBranch?: () => SessionEntry[];
+};
+
+export function readContextEntries(sm: ExtensionContext["sessionManager"]): SessionEntry[] {
+  const source = sm as unknown as SessionEntrySource;
+  if (typeof source.buildContextEntries === "function") return source.buildContextEntries();
+  if (typeof source.getBranch === "function") return source.getBranch();
+  return [];
+}
+
 export interface AcpRuntime {
   core: CompressionCore;
   store: SessionStateStore;
@@ -67,7 +82,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   async function stateFor(ctx: ExtensionContext) {
     const sm = ctx.sessionManager;
     const state = await store.load(sm.getSessionFile() ?? undefined, sm.getSessionId());
-    const entries = sm.buildContextEntries();
+    const entries = readContextEntries(sm);
     return { state, coreMessages: entriesToCoreMessages(entries), entries };
   }
 

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -1,5 +1,4 @@
 import {
-  isBashToolResult,
   isToolCallEventType,
   type ExtensionAPI,
   type ToolResultEvent,
@@ -7,6 +6,14 @@ import {
 import { DEFAULT_TOOL_BASH_TIMEOUT, DEFAULT_TOOL_OUTPUT_MAX_BYTES } from "./config.js";
 import { debug } from "./log.js";
 import type { AcpRuntime } from "./runtime.js";
+
+// Vendored locally rather than imported: pi exports isBashToolResult, but omp's
+// compat bundle does not, and a missing named export fails the whole module at
+// load time under omp. The body is just e.toolName === "bash".
+export type BashToolResultEvent = Extract<ToolResultEvent, { toolName: "bash" }>;
+export function isBashToolResult(e: ToolResultEvent): e is BashToolResultEvent {
+  return e.toolName === "bash";
+}
 
 type ContentPart = ToolResultEvent["content"][number];
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -87,6 +87,29 @@ test("context handler tags every message with a ref even when length matches eve
   assert.ok(firstContent.some((b: any) => b.type === "text" && b.text.includes("m0000")), "first msg ref-tagged");
 });
 
+test("context handler works under omp (oh-my-pi) where sessionManager exposes getBranch() not buildContextEntries()", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  const entries = [userMsg("e1", "first"), userMsg("e2", "second")];
+  const ctx = {
+    ...fakeCtx(entries, "/tmp/nonexistent-pai-acp-omp.session.json"),
+    sessionManager: {
+      getBranch: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => "/tmp/nonexistent-pai-acp-omp.session.json",
+    },
+  };
+  const sameLengthMessages = entries.map(() => ({ role: "user", content: "x", timestamp: 0 }));
+
+  const result = await handlers.get("context")![0]!({ type: "context", messages: sameLengthMessages }, ctx);
+  assert.ok(result, "handler must not throw and must return transformed messages under omp");
+  const out = result.messages;
+  assert.equal(out.length, 2);
+  const firstContent = (out[0] as any).content as any[];
+  assert.ok(firstContent.some((b: any) => b.type === "text" && b.text.includes("m0000")), "omp path tags messages with refs");
+});
+
 test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -200,6 +200,35 @@ test("entriesToCoreMessages still skips compaction and model_change", () => {
   assert.deepEqual(core.map((m) => m.id), ["a", "b"]);
 });
 
+test("entriesToCoreMessages preserves omp execution roles (bashExecution/pythonExecution) as user text instead of dropping them", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", { role: "user", content: "run ls", timestamp: Date.now() }),
+    msgEntry("b", { role: "bashExecution", command: "ls -la", output: [{ type: "text", text: "file1\nfile2" }], exitCode: 0, timestamp: Date.now() } as object),
+    msgEntry("c", { role: "pythonExecution", command: "print('hi')", output: "hi", exitCode: 0, timestamp: Date.now() } as object),
+    msgEntry("d", { role: "assistant", content: [{ type: "text", text: "done" }], timestamp: Date.now() } as object),
+  ];
+  const core = entriesToCoreMessages(entries);
+  assert.deepEqual(core.map((m) => m.id), ["a", "b", "c", "d"], "no messages dropped");
+  const b = core[1]!;
+  assert.equal(b.role, "user");
+  assert.ok(b.text!.includes("$ ls -la"), "command rendered as $ command");
+  assert.ok(b.text!.includes("file1"), "output text preserved");
+  const c = core[2]!;
+  assert.equal(c.role, "user");
+  assert.ok(c.text!.includes("print('hi')"));
+  assert.ok(c.text!.includes("hi"));
+});
+
+test("entriesToCoreMessages prefers content over fallback fields when an omp role carries both", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", { role: "bashExecution", content: [{ type: "text", text: "primary text" }], command: "should-not-appear", output: "neither", timestamp: Date.now() } as object),
+  ];
+  const core = entriesToCoreMessages(entries);
+  assert.equal(core.length, 1);
+  assert.equal(core[0]!.role, "user");
+  assert.equal(core[0]!.text, "primary text");
+});
+
 test("coreOutToAgentMessages patches the ref tag onto original messages", () => {
   const tag = acpRef("m00001") + "\n";
   const original = msgEntry("a", user("hello")).message;

--- a/tests/tool-guardrails.test.ts
+++ b/tests/tool-guardrails.test.ts
@@ -5,6 +5,7 @@ import {
   capToolOutput,
   detectBashTimeout,
   appendTimeoutNotice,
+  isBashToolResult,
 } from "../src/tool-guardrails.js";
 import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
 
@@ -121,4 +122,14 @@ test("appendTimeoutNotice adds a new text part when content has no text part", (
   const out = appendTimeoutNotice([img], 30);
   assert.equal(out.length, 2);
   assert.equal(out[1].type, "text");
+});
+
+test("isBashToolResult narrows by toolName and exposes bash details (vendored guard, host-agnostic)", () => {
+  const bash = { toolName: "bash", content: text("ok"), isError: false, details: { fullOutputPath: "/tmp/x" } } as unknown as ToolResultEvent;
+  const other = { toolName: "read", content: text("ok"), isError: false } as unknown as ToolResultEvent;
+  assert.equal(isBashToolResult(bash), true);
+  assert.equal(isBashToolResult(other), false);
+  if (isBashToolResult(bash)) {
+    assert.equal(bash.details?.fullOutputPath, "/tmp/x");
+  }
 });


### PR DESCRIPTION
## 背景

Closes #87（期望支持 omp）

oh-my-pi（[can1357/oh-my-pi](https://github.com/can1357/oh-my-pi)）是 pi 的一个 fork，用户反馈 billion-context-pi 在 omp 下安装后「不能生效」，且消息顺序会出问题。

## 根因

对照 omp 源码确认有两处 API 不兼容：

**1. `sessionManager.buildContextEntries()` 在 omp 中不存在（核心阻塞）**

omp 的 `SessionManager` 只有 `getBranch()` 和 `buildSessionContext()`，全仓搜 `buildContextEntries` 零命中。`src/runtime.ts` 的 `stateFor()` 无条件调用 `sm.buildContextEntries()`，在 omp 下每个 `context` 事件都抛 `TypeError`；而 omp 的 extension runner 把所有 handler 异常吞掉（catch → onError → 返回 undefined），导致 transform 被跳过、压缩完全不生效——即「不能生效」。

（omp 的 legacy-pi-compat 已经把 `@earendil-works/*` 重写成 `@oh-my-pi/*`，所以扩展能加载，问题纯粹在这个运行时 API 差异上。）

**2. omp 的扩展消息角色被丢弃（消息顺序问题）**

omp 的 message 有 `bashExecution` / `pythonExecution`（字段是 `command` / `output` / `exitCode`，没有 `content`）等角色。`projectMessage` 默认分支用 `extractText(msg.content)` 取文本，这些角色没有 `content` → 取到空串 → 返回 `[]` → 消息被整条丢掉，结果就是消息乱序/缺失。

## 修复

- **`src/runtime.ts`**：新增 `readContextEntries(sm)` 做特性检测——有 `buildContextEntries()` 走 pi 路径，否则用 omp 的 `getBranch()`。两者返回的都是按时间顺序的 `SessionEntry[]`（getBranch 内部 `pathTo` 会 reverse，顺序与 pi 一致，不会反向），所以替换是安全的。
- **`src/messages.ts`**：新增 `fallbackText(msg)`，当 `extractText(content)` 为空时，把 `$ command` + output + summary 作为文本兜底。这样 omp 的 bashExecution 等角色会转成 user 文本块（和 omp 自己的 acp-agent 行为一致），不再被丢弃。

## 兼容性

完全向后兼容：pi 的角色都带 `content`，fallback 永远不会触发，pi 行为不变；仅在 omp 下额外生效。

## 验证

- `npm run typecheck`：通过（无 `as any`，无 `@ts-ignore`）
- `npm test`：**86 tests 全部通过**（新增 3 个 omp 相关测试）
- `npm run build`：dist 构建成功

### 新增测试
- `context handler works under omp where sessionManager exposes getBranch() not buildContextEntries()` — 验证 omp 下 handler 不抛错且正常打 ref tag
- `entriesToCoreMessages preserves omp execution roles (bashExecution/pythonExecution) as user text instead of dropping them`
- `entriesToCoreMessages prefers content over fallback fields when an omp role carries both`