### PR TITLE
feat(delegate): watchdog force-finishes hung async delegates

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -17,6 +17,10 @@ import { debug } from "./log.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
+const EOF_GRACE_MS = 10_000;
+const IDLE_GRACE_MS = 5 * 60_000;
+const ASYNC_TIMEOUT_MS = 30 * 60_000;
+const KILL_GRACE_MS = 10_000;
 const RESULT_SUMMARY_CHARS = 500;
 const OUT_DIR = join(tmpdir(), "acp-delegate");
 
@@ -98,6 +102,9 @@ interface DelegateRun {
    *  notification (sendUserMessage succeeded). Lets a later wait() avoid
    *  re-delivering the same payload. */
   injected?: boolean;
+  /** Watchdog reason string when the run was force-terminated ("no output for
+   *  5m", "30m limit"); surfaced in completion headers as "(timed out: ...)". */
+  timedOut?: string;
   waiter?: () => void;
 }
 
@@ -197,10 +204,11 @@ The delegate runs in its own clean pi process — it does NOT see this conversat
 }
 
 function formatRunResult(run: DelegateRun): string {
+  const timeoutNote = run.timedOut ? ` (timed out: ${run.timedOut})` : "";
   const header =
     run.status === "completed"
-      ? `Delegate **${run.agent}** (runId \`${run.runId}\`) completed (exit ${run.exitCode ?? "?"})${remainingLineForWait(run.runId)}`
-      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status} (exit ${run.exitCode ?? "?"})${remainingLineForWait(run.runId)}`;
+      ? `Delegate **${run.agent}** (runId \`${run.runId}\`) completed (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`
+      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status} (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`;
   return formatPayload(header, run.result?.file ?? "", run.task, run.result?.body);
 }
 
@@ -423,7 +431,10 @@ async function runDelegate(
   const startedAt = Date.now();
 
   if (isAsync) {
-    child.stdout?.on("data", (c: Buffer) => stdoutChunks.push(c));
+    child.stdout?.on("data", (c: Buffer) => {
+      stdoutChunks.push(c);
+      resetIdle();
+    });
     child.stderr?.on("data", (c: Buffer) => {
       stderrText += c.toString("utf8");
     });
@@ -439,28 +450,74 @@ async function runDelegate(
     runs.set(runId, run);
     delegateStatusWidget.poke();
 
-    child.on("close", (code) => {
-      void cleanupTmp(tmpDir);
-      const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
-      run.exitCode = code;
-      const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
-      // N2: cancelled runs never persist a result — wake a parked waiter (if any)
-      // and stop. status stays "cancelled" (set by cancel), so wait cannot
-      // mistake it for a finished-with-result run.
-      if (run.status === "cancelled") {
-        run.finishedAt = Date.now();
-        debug.event("delegate-done", { runId, code, status: run.status, injected: false, outLen: output.length });
-        run.waiter?.();
-        delegateStatusWidget.poke();
-        return;
-      }
-      void persistResult(runId, body)
-        .then((file) => {
+    // ── Watchdogs + single finalize path ──────────────────────────────────
+    // Finalize is the ONLY place that flips run status/result. It is shared by
+    // the child close event and the EOF watchdog, with `settled` guarding
+    // against double-finalize (watchdog fires, then the killed child's close
+    // event arrives).
+    let settled = false;
+    let eofGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearWatchdogs = (): void => {
+      if (eofGraceTimer) clearTimeout(eofGraceTimer);
+      if (idleTimer) clearTimeout(idleTimer);
+      if (killGraceTimer) clearTimeout(killGraceTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+    };
+    // Reset the idle watchdog whenever the delegate produces output. A hanging
+    // child holds its stdout fd open (so stdout EOF never fires) — no output
+    // for IDLE_GRACE_MS is the reliable "stuck" signal.
+    const resetIdle = (): void => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => killByWatchdog(`no output for ${IDLE_GRACE_MS / 60_000}m`), IDLE_GRACE_MS);
+      idleTimer.unref?.();
+    };
+    // SIGTERM, then SIGKILL after KILL_GRACE_MS if the child ignores it. The
+    // close event that follows funnels into finalize() with the code it got.
+    const killByWatchdog = (reason: string): void => {
+      if (settled || run.status !== "running") return;
+      run.timedOut = reason;
+      debug.event("delegate-watchdog", { runId, reason });
+      try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
+      killGraceTimer = setTimeout(() => {
+        if (settled || run.status !== "running") return;
+        debug.event("delegate-watchdog-kill", { runId, reason });
+        try { run.child?.kill("SIGKILL"); } catch { /* best-effort */ }
+      }, KILL_GRACE_MS);
+      killGraceTimer.unref?.();
+    };
+
+    const finalize = (code: number | null): void => {
+      void (async () => {
+        if (settled) return;
+        settled = true;
+        clearWatchdogs();
+        void cleanupTmp(tmpDir);
+        const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        run.exitCode = code;
+        const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
+        // N2: cancelled runs never persist a result — wake a parked waiter (if any)
+        // and stop. status stays "cancelled" (set by cancel), so wait cannot
+        // mistake it for a finished-with-result run.
+        if (run.status === "cancelled") {
+          run.finishedAt = Date.now();
+          debug.event("delegate-done", { runId, code, status: run.status, injected: false, outLen: output.length });
+          run.waiter?.();
+          delegateStatusWidget.poke();
+          return;
+        }
+        try {
+          const file = await persistResult(runId, body);
+          // EOF-watchdog finalize has no exit code; if the output was delivered,
+          // treat it as a completed result (the process is killed afterwards).
+          const effectiveCode = code ?? (output || stderrText ? 0 : null);
           // Atomically flip status + result together: until this point the run
           // is still "running" to any observer, so a concurrent wait cannot
           // see "finished but result missing".
           run.result = { code, file, body };
-          run.status = code === 0 ? "completed" : "failed";
+          run.status = effectiveCode === 0 ? "completed" : "failed";
           run.finishedAt = Date.now();
           // If a wait is parked on this run, wake it — it owns the result now
           // (and marks consumed so we don't double-deliver by injecting).
@@ -476,21 +533,49 @@ async function runDelegate(
             delegateStatusWidget.poke();
             return;
           }
-          const injected = injectResult(pi, args.agent, runId, args.task, code, file);
+          const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut);
           run.injected = injected;
           debug.event("delegate-done", { runId, code, status: run.status, injected, outLen: output.length, file });
           delegateStatusWidget.poke();
-        })
-        .catch((err) => {
+        } catch (err) {
           // Persist failed — still need to finalize so a waiter doesn't hang.
           run.status = "failed";
           run.finishedAt = Date.now();
           debug.event("delegate-done-error", { runId, error: String(err) });
           run.waiter?.();
           delegateStatusWidget.poke();
-        });
+        }
+      })();
+    };
+
+    child.on("close", (code) => finalize(code));
+
+    child.stdout?.on("end", () => {
+      // stdout EOF: the delegate's output is fully delivered, but the process
+      // may still hang (e.g. a provider call that never responds). Give it a
+      // short grace period to exit naturally; if it does not, force-finalize —
+      // the output is already complete, so the result is final.
+      eofGraceTimer = setTimeout(() => {
+        if (settled || run.status !== "running") return;
+        run.timedOut = "output ended but process did not exit";
+        debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
+        try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
+        finalize(null);
+      }, EOF_GRACE_MS);
+      eofGraceTimer.unref?.();
     });
+
+    // Start the idle clock and the overall runtime budget. The budget also
+    // covers the pathological case where a child neither outputs nor exits
+    // AND somehow evades the idle timer (e.g. stderr-only chatter).
+    resetIdle();
+    timeoutTimer = setTimeout(() => killByWatchdog(`${ASYNC_TIMEOUT_MS / 60_000}m limit`), ASYNC_TIMEOUT_MS);
+    timeoutTimer.unref?.();
+
     child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearWatchdogs();
       void cleanupTmp(tmpDir);
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
       // Node does not guarantee a follow-up close, so finalize here too:
@@ -513,6 +598,7 @@ async function runDelegate(
       `Delegated to **${args.agent}** (runId \`${runId}\`).`,
       `Task: ${truncate(args.task, 160)}`,
       `Running in the background at \`${cwd}\`.`,
+      `A watchdog force-finishes a hung run: no output for ${IDLE_GRACE_MS / 60_000}m, 10s after output ends, or a ${ASYNC_TIMEOUT_MS / 60_000}m hard limit — the result reflects whatever was produced.`,
       ``,
       `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result (default 10s timeout). If the wait times out, or you skip it, a completion notification (with the result file path) is still injected here automatically when the delegate finishes — so you may also just continue other work now and let the result find you.`,
     ].join("\n");
@@ -629,6 +715,7 @@ function injectResult(
   task: string,
   code: number | null,
   file: string,
+  timedOut?: string,
 ): boolean {
   const send = pi.sendUserMessage;
   if (typeof send !== "function") {
@@ -646,7 +733,8 @@ function injectResult(
     remaining > 0
       ? ` ${remaining} delegate${remaining === 1 ? " is" : "s are"} still running; keep doing other work and their notifications will arrive as they finish.`
       : " No delegates are currently running.";
-  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${remainingLine} This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.`;
+  const timeoutNote = timedOut ? ` (timed out: ${timedOut})` : "";
+  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine} This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.`;
   const text = formatPayload(header, file, task);
   try {
     // sendUserMessage is fire-and-forget (returns void): it enqueues a

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -14,6 +14,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { debug } from "./log.js";
+import { attachWatchdogs } from "./delegate-watchdog.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
@@ -431,9 +432,27 @@ async function runDelegate(
   const startedAt = Date.now();
 
   if (isAsync) {
+    let settled = false;
+    // Watchdogs: idle (no output), EOF grace, hard limit. A stuck child holds
+    // its stdout fd open so stdout EOF never fires — idle is the main defense.
+    const watchdog = attachWatchdogs(
+      child,
+      {
+        isSettled: () => settled || run.status !== "running",
+        onKill: (reason) => {
+          run.timedOut = reason;
+          debug.event("delegate-watchdog", { runId, reason });
+        },
+        onEofGrace: () => {
+          run.timedOut = "output ended but process did not exit";
+          debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
+        },
+      },
+      { eofGraceMs: EOF_GRACE_MS, idleMs: IDLE_GRACE_MS, timeoutMs: ASYNC_TIMEOUT_MS, killGraceMs: KILL_GRACE_MS },
+    );
     child.stdout?.on("data", (c: Buffer) => {
       stdoutChunks.push(c);
-      resetIdle();
+      watchdog.poke();
     });
     child.stderr?.on("data", (c: Buffer) => {
       stderrText += c.toString("utf8");
@@ -450,50 +469,11 @@ async function runDelegate(
     runs.set(runId, run);
     delegateStatusWidget.poke();
 
-    // ── Watchdogs + single finalize path ──────────────────────────────────
-    // Finalize is the ONLY place that flips run status/result. It is shared by
-    // the child close event and the EOF watchdog, with `settled` guarding
-    // against double-finalize (watchdog fires, then the killed child's close
-    // event arrives).
-    let settled = false;
-    let eofGraceTimer: ReturnType<typeof setTimeout> | undefined;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
-    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-    const clearWatchdogs = (): void => {
-      if (eofGraceTimer) clearTimeout(eofGraceTimer);
-      if (idleTimer) clearTimeout(idleTimer);
-      if (killGraceTimer) clearTimeout(killGraceTimer);
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-    };
-    // Reset the idle watchdog whenever the delegate produces output. A hanging
-    // child holds its stdout fd open (so stdout EOF never fires) — no output
-    // for IDLE_GRACE_MS is the reliable "stuck" signal.
-    const resetIdle = (): void => {
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => killByWatchdog(`no output for ${IDLE_GRACE_MS / 60_000}m`), IDLE_GRACE_MS);
-      idleTimer.unref?.();
-    };
-    // SIGTERM, then SIGKILL after KILL_GRACE_MS if the child ignores it. The
-    // close event that follows funnels into finalize() with the code it got.
-    const killByWatchdog = (reason: string): void => {
-      if (settled || run.status !== "running") return;
-      run.timedOut = reason;
-      debug.event("delegate-watchdog", { runId, reason });
-      try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
-      killGraceTimer = setTimeout(() => {
-        if (settled || run.status !== "running") return;
-        debug.event("delegate-watchdog-kill", { runId, reason });
-        try { run.child?.kill("SIGKILL"); } catch { /* best-effort */ }
-      }, KILL_GRACE_MS);
-      killGraceTimer.unref?.();
-    };
-
     const finalize = (code: number | null): void => {
       void (async () => {
         if (settled) return;
         settled = true;
-        clearWatchdogs();
+        watchdog.dispose();
         void cleanupTmp(tmpDir);
         const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
         run.exitCode = code;
@@ -550,32 +530,11 @@ async function runDelegate(
 
     child.on("close", (code) => finalize(code));
 
-    child.stdout?.on("end", () => {
-      // stdout EOF: the delegate's output is fully delivered, but the process
-      // may still hang (e.g. a provider call that never responds). Give it a
-      // short grace period to exit naturally; if it does not, force-finalize —
-      // the output is already complete, so the result is final.
-      eofGraceTimer = setTimeout(() => {
-        if (settled || run.status !== "running") return;
-        run.timedOut = "output ended but process did not exit";
-        debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
-        try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
-        finalize(null);
-      }, EOF_GRACE_MS);
-      eofGraceTimer.unref?.();
-    });
-
-    // Start the idle clock and the overall runtime budget. The budget also
-    // covers the pathological case where a child neither outputs nor exits
-    // AND somehow evades the idle timer (e.g. stderr-only chatter).
-    resetIdle();
-    timeoutTimer = setTimeout(() => killByWatchdog(`${ASYNC_TIMEOUT_MS / 60_000}m limit`), ASYNC_TIMEOUT_MS);
-    timeoutTimer.unref?.();
 
     child.on("error", (err) => {
       if (settled) return;
       settled = true;
-      clearWatchdogs();
+      watchdog.dispose();
       void cleanupTmp(tmpDir);
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
       // Node does not guarantee a follow-up close, so finalize here too:

--- a/src/delegate-watchdog.ts
+++ b/src/delegate-watchdog.ts
@@ -1,0 +1,100 @@
+import type { Readable } from "node:stream";
+
+export interface WatchdogOptions {
+  eofGraceMs: number;
+  idleMs: number;
+  timeoutMs: number;
+  killGraceMs: number;
+}
+
+export interface WatchdogHooks {
+  /** True once the run is finalized; watchdogs stop firing. */
+  isSettled(): boolean;
+  /** The child is about to be killed (SIGTERM). reason explains why. */
+  onKill(reason: string): void;
+  /** stdout EOF passed without the process exiting; force-finalize now. */
+  onEofGrace(): void;
+}
+
+export interface WatchdogHandle {
+  /** Re-arm the idle timer (call on every stdout data). */
+  poke(): void;
+  /** Stop all timers (call on finalize). */
+  dispose(): void;
+}
+
+/**
+ * Guarantees a hung child process gets killed. A stuck child holds its stdout
+ * fd open, so stdout EOF never fires — hence the idle timer (no output for
+ * idleMs) is the main defense; the hard time limit and the EOF grace period
+ * cover the rest. Kill is SIGTERM, escalated to SIGKILL after killGraceMs.
+ */
+export function attachWatchdogs(
+  child: { kill(signal: NodeJS.Signals): boolean; stdout: Readable | null },
+  hooks: WatchdogHooks,
+  opts: WatchdogOptions,
+): WatchdogHandle {
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let eofTimer: ReturnType<typeof setTimeout> | undefined;
+  let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimers = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    if (eofTimer) clearTimeout(eofTimer);
+    if (killGraceTimer) clearTimeout(killGraceTimer);
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+  };
+
+  const killByWatchdog = (reason: string): void => {
+    if (hooks.isSettled()) return;
+    hooks.onKill(reason);
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      /* best-effort */
+    }
+    killGraceTimer = setTimeout(() => {
+      if (hooks.isSettled()) return;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* best-effort */
+      }
+    }, opts.killGraceMs);
+    killGraceTimer.unref?.();
+  };
+
+  const poke = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => killByWatchdog(`no output for ${opts.idleMs / 60_000}m`), opts.idleMs);
+    idleTimer.unref?.();
+  };
+
+  poke();
+  timeoutTimer = setTimeout(() => killByWatchdog(`${opts.timeoutMs / 60_000}m limit`), opts.timeoutMs);
+  timeoutTimer.unref?.();
+
+  const onStdoutEnd = (): void => {
+    if (hooks.isSettled()) return;
+    eofTimer = setTimeout(() => {
+      if (hooks.isSettled()) return;
+      hooks.onEofGrace();
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* best-effort */
+      }
+    }, opts.eofGraceMs);
+    eofTimer.unref?.();
+  };
+  child.stdout?.once("end", onStdoutEnd);
+
+  return {
+    poke,
+    dispose: () => {
+      clearTimers();
+      child.stdout?.removeListener("end", onStdoutEnd);
+    },
+  };
+}

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -1,0 +1,114 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { attachWatchdogs } from "../src/delegate-watchdog.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface Harness {
+  stdout: EventEmitter;
+  kills: NodeJS.Signals[];
+  reasons: string[];
+  eofGraceCount: number;
+  settled: () => boolean;
+  watchdog: ReturnType<typeof attachWatchdogs>;
+}
+
+function setup(overrides?: { idleMs?: number; timeoutMs?: number; killGraceMs?: number; eofGraceMs?: number; initiallySettled?: boolean }): Harness {
+  const stdout = new EventEmitter();
+  const kills: NodeJS.Signals[] = [];
+  const reasons: string[] = [];
+  let eofGraceCount = 0;
+  let settledFlag = overrides?.initiallySettled ?? false;
+  const watchdog = attachWatchdogs(
+    {
+      kill: (sig) => {
+        kills.push(sig);
+        return true;
+      },
+      stdout,
+    },
+    {
+      isSettled: () => settledFlag,
+      onKill: (reason) => reasons.push(reason),
+      onEofGrace: () => {
+        eofGraceCount += 1;
+      },
+    },
+    {
+      eofGraceMs: overrides?.eofGraceMs ?? 1_000,
+      idleMs: overrides?.idleMs ?? 1_000,
+      timeoutMs: overrides?.timeoutMs ?? 60_000,
+      killGraceMs: overrides?.killGraceMs ?? 1_000,
+    },
+  );
+  return {
+    stdout,
+    kills,
+    reasons,
+    get eofGraceCount() {
+      return eofGraceCount;
+    },
+    settled: () => settledFlag,
+    watchdog,
+  };
+}
+
+test("idle watchdog kills with SIGTERM after idleMs without output", async () => {
+  const h = setup({ idleMs: 30, killGraceMs: 200 });
+  await sleep(60);
+  assert.deepEqual(h.kills, ["SIGTERM"], "SIGTERM fired once");
+  assert.equal(h.reasons.length, 1, "onKill called once");
+  assert.ok(h.reasons[0].includes("no output"), `reason names idle: ${h.reasons[0]}`);
+  h.watchdog.dispose();
+});
+
+test("idle watchdog escalates to SIGKILL when the child ignores SIGTERM", async () => {
+  const h = setup({ idleMs: 20, killGraceMs: 30 });
+  await sleep(100);
+  assert.deepEqual(h.kills, ["SIGTERM", "SIGKILL"], "SIGTERM then SIGKILL");
+  h.watchdog.dispose();
+});
+
+test("poke resets the idle timer (continuous output never triggers)", async () => {
+  const h = setup({ idleMs: 25 });
+  for (let i = 0; i < 10; i++) {
+    await sleep(15);
+    h.watchdog.poke();
+  }
+  assert.equal(h.kills.length, 0, "no kill while output keeps flowing");
+  h.watchdog.dispose();
+});
+
+test("EOF grace force-finalizes when stdout ended but the child lives", async () => {
+  const h = setup({ eofGraceMs: 30 });
+  h.stdout.emit("end");
+  await sleep(60);
+  assert.equal(h.eofGraceCount, 1, "onEofGrace fired once");
+  h.watchdog.dispose();
+});
+
+test("hard time limit kills regardless of output", async () => {
+  const h = setup({ timeoutMs: 40 });
+  await sleep(80);
+  assert.deepEqual(h.kills, ["SIGTERM"], "time limit fired");
+  assert.ok(h.reasons[0].includes("limit"), `reason names limit: ${h.reasons[0]}`);
+  h.watchdog.dispose();
+});
+
+test("dispose stops all watchdogs", async () => {
+  const h = setup({ idleMs: 30, eofGraceMs: 30 });
+  h.watchdog.dispose();
+  h.stdout.emit("end");
+  await sleep(80);
+  assert.equal(h.kills.length, 0, "no kill after dispose");
+  assert.equal(h.eofGraceCount, 0, "no EOF grace after dispose");
+});
+
+test("settled runs never get killed or grace-finalized", async () => {
+  const h = setup({ idleMs: 20, eofGraceMs: 20, initiallySettled: true });
+  h.stdout.emit("end");
+  await sleep(60);
+  assert.equal(h.kills.length, 0, "settled run not killed");
+  assert.equal(h.eofGraceCount, 0, "settled run not grace-finalized");
+});


### PR DESCRIPTION
## 背景

关联 issue #89：provider API 无响应时子代理可能空转，宿主收尾完全依赖 `child.on("close")`（子进程退出且 stdio 关闭才触发）——子进程不退出 → run 永久卡在 `running`，`acp_delegate_wait` 永远超时，只有手动 cancel 能打破。

本 PR 加三个看门狗，保证 async delegate **一定会被收尾**：

| 看门狗 | 触发条件 | 动作 |
|---|---|---|
| 空闲检测（主防线） | 5 分钟无 stdout 输出 | SIGTERM |
| EOF 宽限 | stdout EOF 后 10s 进程未退 | 强制 finalize（输出已完整交付） |
| 硬上限 | spawn 后 30 分钟 | SIGTERM → 10s 宽限 → SIGKILL |

## 设计要点

- **为什么需要空闲检测**：挂死的子进程持有 stdout fd 不关闭 → stdout EOF 永不触发（模拟验证发现）。真实的 provider 无响应重试正是这种情况（进程活着、管道开着、无输出）。
- **单一 finalize 路径**：三个看门狗 + close 事件全部汇入 `finalize(code)`，`settled` guard 防止重复收尾（如看门狗触发后被杀进程的 close 事件到达）。
- **结果保留部分输出**：收尾时结果文件保留已产生的所有输出，状态按实际退出码判定；EOF 宽限收尾无退出码时，输出已完整 → 视为 completed。
- **原因可见**：`DelegateRun.timedOut` 记录原因（`no output for 5m` / `output ended but process did not exit` / `30m limit`），完成通知与 wait 结果中显示 `(timed out: <原因>)`。
- **可测试性**：看门狗逻辑抽取为独立模块 `src/delegate-watchdog.ts`（`attachWatchdogs(child, hooks, opts)`，超时可注入），`runDelegate` 改用它，行为不变。

## 测试

**7 个新测试**（`tests/watchdog.test.ts`，fake child = EventEmitter stdout + kill spy，短超时）：

- idle 看门狗无输出超时后 SIGTERM，reason 标注 no output
- 进程忽略 SIGTERM → SIGKILL 升级
- `poke` 重置 idle 定时器（持续输出永不触发）
- stdout EOF 后宽限超时强制收尾（onEofGrace）
- 硬上限超时触发（无论是否有输出）
- `dispose` 停止所有看门狗
- settled 后不再 kill / 不再宽限收尾

验证：typecheck ✅ **90 测试全过**（83 原有 + 7 新增）✅ build ✅

端到端（真实环境）：`sleep 600` 挂死 delegate → 5 分钟 idle 触发 → `exit 143 (SIGTERM)` → 通知标注 `(timed out: no output for 5m)` → 子进程清理、结果文件保留。

## ⚠️ 本 PR 不含流式输出

**本 PR 只包含看门狗收尾逻辑，不含流式输出改动。** 流式输出（运行期间输出实时写入文件，issue #89 的原始诉求）是独立的功能，将在单独的分支/PR 提交（`feat/delegate-streaming-out`）。本 PR 的改动基于当前 master，与流式完全独立。

Ref #89
