### PR TITLE
feat(delegate): watchdog + live activity file & reply stream (json event mode)

### DIFF
--- a/src/delegate-events.ts
+++ b/src/delegate-events.ts
@@ -1,0 +1,174 @@
+// Parsing helpers for `pi --mode json` event streams. The child delegate runs
+// in JSON Event Stream Mode, so its stdout is newline-delimited JSON events
+// instead of the final reply text. These pure functions map raw lines to
+// structured events and format them for the activity file.
+
+export interface ToolStartEvent {
+  kind: "tool-start";
+  toolName: string;
+  argsText: string;
+}
+
+export interface ToolUpdateEvent {
+  kind: "tool-update";
+  toolCallId: string;
+  text: string;
+}
+
+export interface ToolEndEvent {
+  kind: "tool-end";
+  toolName: string;
+  isError: boolean;
+}
+
+export interface ReplyDeltaEvent {
+  kind: "reply-delta";
+  delta: string;
+}
+
+export interface ReplyCompleteEvent {
+  kind: "reply-complete";
+  content: string;
+}
+
+export interface ThinkingDeltaEvent {
+  kind: "thinking-delta";
+  delta: string;
+}
+
+export type ParsedEvent =
+  | ToolStartEvent
+  | ToolUpdateEvent
+  | ToolEndEvent
+  | ReplyDeltaEvent
+  | ReplyCompleteEvent
+  | ThinkingDeltaEvent
+  | ThinkingEndEvent;
+
+export interface ThinkingEndEvent {
+  kind: "thinking-end";
+}
+
+/**
+ * Accumulates thinking_delta tokens and emits one human-readable line per
+ * thinking segment (a segment ends at thinking_end / text_start). Nothing is
+ * emitted when showThinking is off.
+ */
+export class ThinkingCollector {
+  private buf = "";
+
+  constructor(private readonly showThinking: boolean) {}
+
+  push(delta: string): void {
+    this.buf += delta;
+  }
+
+  /** Return the segment line to write ("" when empty or disabled), resetting. */
+  flush(): string {
+    const text = this.buf.trim();
+    this.buf = "";
+    if (!this.showThinking || !text) return "";
+    return `[thinking] ${text}\n`;
+  }
+}
+/** Parse one newline-delimited JSON line; null for non-JSON or irrelevant events. */
+export function parseEventLine(line: string): ParsedEvent | null {
+  let ev: unknown;
+  try {
+    ev = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof ev !== "object" || ev === null) return null;
+  const e = ev as Record<string, unknown>;
+  if (e.type === "message_update") {
+    const am = e.assistantMessageEvent;
+    if (typeof am !== "object" || am === null) return null;
+    const msg = am as Record<string, unknown>;
+    switch (msg.type) {
+      case "text_delta":
+        return { kind: "reply-delta", delta: String(msg.delta ?? "") };
+      case "text_end":
+        return { kind: "reply-complete", content: String(msg.content ?? "") };
+      case "thinking_delta":
+        return { kind: "thinking-delta", delta: String(msg.delta ?? "") };
+      case "thinking_end":
+        return { kind: "thinking-end" };
+      default:
+        return null;
+    }
+  }
+  if (e.type === "tool_execution_start") {
+    return {
+      kind: "tool-start",
+      toolName: String(e.toolName ?? ""),
+      argsText: formatArgs(e.args),
+    };
+  }
+  if (e.type === "tool_execution_update") {
+    return {
+      kind: "tool-update",
+      toolCallId: String(e.toolCallId ?? ""),
+      text: extractContentText(e.partialResult),
+    };
+  }
+  if (e.type === "tool_execution_end") {
+    return {
+      kind: "tool-end",
+      toolName: String(e.toolName ?? ""),
+      isError: Boolean(e.isError),
+    };
+  }
+  return null;
+}
+
+/** bash commands read as the command string; everything else as JSON. */
+function formatArgs(args: unknown): string {
+  if (args && typeof args === "object") {
+    const a = args as Record<string, unknown>;
+    if (typeof a.command === "string") return a.command;
+  }
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return String(args);
+  }
+}
+
+/** Join `content[].text` blocks from a tool result / partialResult payload. */
+export function extractContentText(payload: unknown): string {
+  if (!payload || typeof payload !== "object") return "";
+  const content = (payload as Record<string, unknown>).content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((c) => (c && typeof c === "object" ? String((c as Record<string, unknown>).text ?? "") : ""))
+    .join("");
+}
+
+/** Format a parsed event as human-readable activity file lines (each with a
+ *  trailing newline; empty when none). */
+export function activityLines(ev: ParsedEvent, opts: { showThinking: boolean }): string[] {
+  switch (ev.kind) {
+    case "tool-start":
+      return [`[tool] ${ev.toolName}${ev.argsText ? ` ${ev.argsText}` : ""}\n`];
+    case "tool-update": {
+      if (!ev.text) return [];
+      return [ev.text.endsWith("\n") ? ev.text : `${ev.text}\n`];
+    }
+    case "tool-end":
+      return [`[done] ${ev.toolName}${ev.isError ? " (error)" : ""}\n`];
+    case "thinking-delta":
+      return opts.showThinking ? [`[thinking] ${ev.delta}\n`] : [];
+    default:
+      return [];
+  }
+}
+
+/**
+ * partialResult is an accumulated snapshot (not a delta), so each update
+ * carries everything so far. Return only the newly-appended portion.
+ */
+export function newPortion(text: string, prev: string): string {
+  if (text.startsWith(prev)) return text.slice(prev.length);
+  return text;
+}

--- a/src/delegate-events.ts
+++ b/src/delegate-events.ts
@@ -43,7 +43,9 @@ export type ParsedEvent =
   | ReplyDeltaEvent
   | ReplyCompleteEvent
   | ThinkingDeltaEvent
-  | ThinkingEndEvent;
+  | ThinkingEndEvent
+  | RetryStartEvent
+  | RetryEndEvent;
 
 export interface ThinkingEndEvent {
   kind: "thinking-end";
@@ -71,7 +73,21 @@ export class ThinkingCollector {
     return `[thinking] ${text}\n`;
   }
 }
-/** Parse one newline-delimited JSON line; null for non-JSON or irrelevant events. */
+
+export interface RetryStartEvent {
+  kind: "retry-start";
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  errorMessage: string;
+}
+
+export interface RetryEndEvent {
+  kind: "retry-end";
+  success: boolean;
+  attempt: number;
+}
+
 export function parseEventLine(line: string): ParsedEvent | null {
   let ev: unknown;
   try {
@@ -119,6 +135,22 @@ export function parseEventLine(line: string): ParsedEvent | null {
       isError: Boolean(e.isError),
     };
   }
+  if (e.type === "auto_retry_start") {
+    return {
+      kind: "retry-start",
+      attempt: Number(e.attempt ?? 0),
+      maxAttempts: Number(e.maxAttempts ?? 0),
+      delayMs: Number(e.delayMs ?? 0),
+      errorMessage: String(e.errorMessage ?? ""),
+    };
+  }
+  if (e.type === "auto_retry_end") {
+    return {
+      kind: "retry-end",
+      success: Boolean(e.success),
+      attempt: Number(e.attempt ?? 0),
+    };
+  }
   return null;
 }
 
@@ -159,6 +191,10 @@ export function activityLines(ev: ParsedEvent, opts: { showThinking: boolean }):
       return [`[done] ${ev.toolName}${ev.isError ? " (error)" : ""}\n`];
     case "thinking-delta":
       return opts.showThinking ? [`[thinking] ${ev.delta}\n`] : [];
+    case "retry-start":
+      return [`[retry] attempt ${ev.attempt}/${ev.maxAttempts}, backoff ${ev.delayMs}ms${ev.errorMessage ? ` — ${ev.errorMessage}` : ""}\n`];
+    case "retry-end":
+      return [`[retry] attempt ${ev.attempt} ${ev.success ? "succeeded" : "failed"}\n`];
     default:
       return [];
   }

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -2,7 +2,8 @@ import {
   spawn,
   type ChildProcess,
 } from "node:child_process";
-import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises";
+import { createWriteStream, type WriteStream } from "node:fs";
+import { mkdir, mkdtemp, writeFile, rm, appendFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Type, type Static } from "typebox";
@@ -15,6 +16,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { debug } from "./log.js";
 import { attachWatchdogs } from "./delegate-watchdog.js";
+import { parseEventLine, activityLines, newPortion, ThinkingCollector } from "./delegate-events.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
@@ -139,6 +141,11 @@ const DelegateParams = Type.Object({
   async: Type.Optional(
     Type.Boolean({
       description: "If true (default), return immediately with a runId. In long-lived sessions (interactive/rpc) a short notification is injected into chat when the delegate finishes; in one-shot sessions (print/json, e.g. `pi -p` / SDK) async auto-downgrades to sync and the result is returned here. If false, always block and return the output here.",
+    }),
+  ),
+  showThinking: Type.Optional(
+    Type.Boolean({
+      description: "If true, the delegate's thinking deltas are also written to the live activity file (default: false — only tool activity is shown).",
     }),
   ),
 });
@@ -422,10 +429,8 @@ async function runDelegate(
   });
   child.stdin?.end(args.task);
 
-  // stdout/stderr buffering is only needed by the async path (the sync path
-  // attaches its own listeners in waitForChild). Attach lazily to avoid double
-  // buffering in sync mode.
-  let stdoutChunks: Buffer[] = [];
+  // stderr buffering is shared by async (error / non-zero fallback) and sync
+  // (waitForChild attaches its own stdout listener).
   let stderrText = "";
 
   const runId = `del_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
@@ -450,9 +455,74 @@ async function runDelegate(
       },
       { eofGraceMs: EOF_GRACE_MS, idleMs: IDLE_GRACE_MS, timeoutMs: ASYNC_TIMEOUT_MS, killGraceMs: KILL_GRACE_MS },
     );
+    // Two stream files are fed from the --mode json event stream: text_delta
+    // tokens go to the reply stream (.out), tool activity (and optionally
+    // thinking) goes to the activity stream (.activity). The agent is told
+    // only about the activity file; the .out path arrives with the result.
+    const replyFile = join(OUT_DIR, `${runId}.out`);
+    const activityFile = join(OUT_DIR, `${runId}.activity`);
+    await mkdir(OUT_DIR, { recursive: true });
+    const replyStream = createWriteStream(replyFile, { flags: "a" });
+    const activityStream = createWriteStream(activityFile, { flags: "a" });
+    const endStream = (s: WriteStream): Promise<void> =>
+      new Promise((resolve) => {
+        if (s.destroyed || s.closed) return resolve();
+        s.end(() => resolve());
+      });
+    let replyText = "";
+    let stdoutBuf = "";
+    // partialResult is an accumulated snapshot, so each update carries
+    // everything so far; track the last written text per tool call to append
+    // only the new portion.
+    const lastToolText = new Map<string, string>();
+    const thinking = new ThinkingCollector(args.showThinking === true);
+    const flushThinking = (): void => {
+      const line = thinking.flush();
+      if (line) activityStream.write(line);
+    };
+    const handleEventLine = (line: string): void => {
+      const ev = parseEventLine(line);
+      if (!ev) return;
+      if (ev.kind === "thinking-delta") {
+        thinking.push(ev.delta);
+        return;
+      }
+      if (ev.kind === "thinking-end") {
+        flushThinking();
+        return;
+      }
+      if (ev.kind === "reply-delta") {
+        flushThinking();
+        replyText += ev.delta;
+        replyStream.write(ev.delta);
+        return;
+      }
+      if (ev.kind === "reply-complete") {
+        flushThinking();
+        replyText = ev.content;
+        return;
+      }
+      if (ev.kind === "tool-update") {
+        flushThinking();
+        const prev = lastToolText.get(ev.toolCallId) ?? "";
+        const add = newPortion(ev.text, prev);
+        lastToolText.set(ev.toolCallId, ev.text);
+        if (add) activityStream.write(add.endsWith("\n") ? add : `${add}\n`);
+        return;
+      }
+      flushThinking();
+      const lines = activityLines(ev, { showThinking: args.showThinking === true });
+      if (lines.length) activityStream.write(lines.join(""));
+    };
     child.stdout?.on("data", (c: Buffer) => {
-      stdoutChunks.push(c);
       watchdog.poke();
+      stdoutBuf += c.toString("utf8");
+      let nl: number;
+      while ((nl = stdoutBuf.indexOf("\n")) >= 0) {
+        const line = stdoutBuf.slice(0, nl);
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        handleEventLine(line);
+      }
     });
     child.stderr?.on("data", (c: Buffer) => {
       stderrText += c.toString("utf8");
@@ -475,13 +545,15 @@ async function runDelegate(
         settled = true;
         watchdog.dispose();
         void cleanupTmp(tmpDir);
-        const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        await Promise.all([endStream(replyStream), endStream(activityStream)]);
         run.exitCode = code;
+        const output = replyText.trim();
         const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
         // N2: cancelled runs never persist a result — wake a parked waiter (if any)
         // and stop. status stays "cancelled" (set by cancel), so wait cannot
         // mistake it for a finished-with-result run.
         if (run.status === "cancelled") {
+          await Promise.all([rm(replyFile, { force: true }), rm(activityFile, { force: true })]);
           run.finishedAt = Date.now();
           debug.event("delegate-done", { runId, code, status: run.status, injected: false, outLen: output.length });
           run.waiter?.();
@@ -489,7 +561,13 @@ async function runDelegate(
           return;
         }
         try {
-          const file = await persistResult(runId, body);
+          // The reply stream is the result file; backfill stderr or a placeholder
+          // when the reply text is empty so the delivered file is never blank.
+          const file = replyFile;
+          if (output === "") {
+            const fallback = stderrText.trim();
+            await appendFile(file, fallback ? `${fallback}\n` : "(no output)\n");
+          }
           // EOF-watchdog finalize has no exit code; if the output was delivered,
           // treat it as a completed result (the process is killed afterwards).
           const effectiveCode = code ?? (output || stderrText ? 0 : null);
@@ -530,12 +608,15 @@ async function runDelegate(
 
     child.on("close", (code) => finalize(code));
 
-
     child.on("error", (err) => {
       if (settled) return;
       settled = true;
       watchdog.dispose();
       void cleanupTmp(tmpDir);
+      void replyStream.destroy();
+      void activityStream.destroy();
+      void rm(replyFile, { force: true });
+      void rm(activityFile, { force: true });
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
       // Node does not guarantee a follow-up close, so finalize here too:
       // atomically set status + a synthetic result, and wake a parked waiter.
@@ -557,6 +638,7 @@ async function runDelegate(
       `Delegated to **${args.agent}** (runId \`${runId}\`).`,
       `Task: ${truncate(args.task, 160)}`,
       `Running in the background at \`${cwd}\`.`,
+      `Live activity is streaming to \`${activityFile}\` — read it anytime to watch the delegate work (tool calls and their output${args.showThinking ? ", plus thinking" : ""}).`,
       `A watchdog force-finishes a hung run: no output for ${IDLE_GRACE_MS / 60_000}m, 10s after output ends, or a ${ASYNC_TIMEOUT_MS / 60_000}m hard limit — the result reflects whatever was produced.`,
       ``,
       `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result (default 10s timeout). If the wait times out, or you skip it, a completion notification (with the result file path) is still injected here automatically when the delegate finishes — so you may also just continue other work now and let the result find you.`,
@@ -585,7 +667,14 @@ export async function buildChildArgs(
   const promptFile = join(tmpDir, "role.md");
   await writeFile(promptFile, `${rolePrompt}\n\n---\n\nComplete the task below.`, "utf8");
 
-  const cliArgs = ["-p", "--no-session", "--append-system-prompt", promptFile];
+  // Async delegates run in JSON Event Stream Mode so the host can parse tool
+  // activity (activity file) and reply tokens (.out) from the event stream.
+  // Sync delegates keep print mode: they return a single text result, no
+  // streaming, and the async auto-downgrade (print/json host) must stay safe.
+  const isAsync = args.async !== false && ctx.mode !== "print" && ctx.mode !== "json";
+  const cliArgs = isAsync
+    ? ["--mode", "json", "--no-session", "--append-system-prompt", promptFile]
+    : ["-p", "--no-session", "--append-system-prompt", promptFile];
 
   // Restricted roles receive a tailored --tools allowlist. Worker and
   // unknown agents are left on Pi's full default toolset (all extension/

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -17,6 +17,7 @@ import type {
 import { debug } from "./log.js";
 import { attachWatchdogs } from "./delegate-watchdog.js";
 import { parseEventLine, activityLines, newPortion, ThinkingCollector } from "./delegate-events.js";
+import { isPiHost } from "./runtime.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
@@ -394,18 +395,16 @@ async function runDelegate(
     ...process.env,
     PI_ACP_DELEGATE_DEPTH: String(parentDepth + 1),
   };
-
-  const { cliArgs, tmpDir } = await buildChildArgs(args, agent.prompt, ctx);
+  const { cliArgs, tmpDir, isAsync, useJsonStream } = await buildChildArgs(args, agent.prompt, ctx);
   // One-shot modes (print/json = `pi -p` / SDK) exit after one turn, so async
   // injection (a follow-up turn) is never observed. Downgrade to sync there:
   // the result returns as the tool result within the same turn. Long-lived
   // modes (tui/rpc) keep true async + injection (consumed by the main loop).
   const requestedAsync = args.async !== false;
-  const isAsync = requestedAsync && ctx.mode !== "print" && ctx.mode !== "json";
   if (requestedAsync && !isAsync) {
     debug.event("delegate-async-downgraded", { reason: `mode=${ctx.mode}` });
   }
-  debug.event("delegate-spawn", { agent: args.agent, cwd, async: isAsync, cliArgs });
+  debug.event("delegate-spawn", { agent: args.agent, cwd, async: isAsync, useJsonStream, cliArgs });
 
   // Spawn a child pi process using the SAME binary that is currently running.
   // Hardcoding "pi" breaks under renamed forks (e.g. pi-stable whose bin is
@@ -459,14 +458,16 @@ async function runDelegate(
     // tokens go to the reply stream (.out), tool activity (and optionally
     // thinking) goes to the activity stream (.activity). The agent is told
     // only about the activity file; the .out path arrives with the result.
+    // omp has no json mode, so async delegates run plain `-p` — stdout IS the
+    // reply and there is no tool activity to stream, so no .activity file.
     const replyFile = join(OUT_DIR, `${runId}.out`);
     const activityFile = join(OUT_DIR, `${runId}.activity`);
     await mkdir(OUT_DIR, { recursive: true });
     const replyStream = createWriteStream(replyFile, { flags: "a" });
-    const activityStream = createWriteStream(activityFile, { flags: "a" });
-    const endStream = (s: WriteStream): Promise<void> =>
+    const activityStream = useJsonStream ? createWriteStream(activityFile, { flags: "a" }) : null;
+    const endStream = (s: WriteStream | null): Promise<void> =>
       new Promise((resolve) => {
-        if (s.destroyed || s.closed) return resolve();
+        if (!s || s.destroyed || s.closed) return resolve();
         s.end(() => resolve());
       });
     let replyText = "";
@@ -478,7 +479,7 @@ async function runDelegate(
     const thinking = new ThinkingCollector(args.showThinking === true);
     const flushThinking = (): void => {
       const line = thinking.flush();
-      if (line) activityStream.write(line);
+      if (line) activityStream?.write(line);
     };
     const handleEventLine = (line: string): void => {
       const ev = parseEventLine(line);
@@ -507,21 +508,30 @@ async function runDelegate(
         const prev = lastToolText.get(ev.toolCallId) ?? "";
         const add = newPortion(ev.text, prev);
         lastToolText.set(ev.toolCallId, ev.text);
-        if (add) activityStream.write(add.endsWith("\n") ? add : `${add}\n`);
+        if (add) activityStream?.write(add.endsWith("\n") ? add : `${add}\n`);
         return;
       }
       flushThinking();
       const lines = activityLines(ev, { showThinking: args.showThinking === true });
-      if (lines.length) activityStream.write(lines.join(""));
+      if (lines.length) activityStream?.write(lines.join(""));
     };
     child.stdout?.on("data", (c: Buffer) => {
       watchdog.poke();
-      stdoutBuf += c.toString("utf8");
-      let nl: number;
-      while ((nl = stdoutBuf.indexOf("\n")) >= 0) {
-        const line = stdoutBuf.slice(0, nl);
-        stdoutBuf = stdoutBuf.slice(nl + 1);
-        handleEventLine(line);
+      if (useJsonStream) {
+        stdoutBuf += c.toString("utf8");
+        let nl: number;
+        while ((nl = stdoutBuf.indexOf("\n")) >= 0) {
+          const line = stdoutBuf.slice(0, nl);
+          stdoutBuf = stdoutBuf.slice(nl + 1);
+          handleEventLine(line);
+        }
+      } else {
+        // omp fallback: `-p` prints the plain reply, so stdout IS the reply —
+        // stream it straight through (no line buffering, so a trailing chunk
+        // without a newline is kept too).
+        const text = c.toString("utf8");
+        replyText += text;
+        replyStream.write(text);
       }
     });
     child.stderr?.on("data", (c: Buffer) => {
@@ -614,7 +624,7 @@ async function runDelegate(
       watchdog.dispose();
       void cleanupTmp(tmpDir);
       void replyStream.destroy();
-      void activityStream.destroy();
+      void activityStream?.destroy();
       void rm(replyFile, { force: true });
       void rm(activityFile, { force: true });
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
@@ -638,7 +648,9 @@ async function runDelegate(
       `Delegated to **${args.agent}** (runId \`${runId}\`).`,
       `Task: ${truncate(args.task, 160)}`,
       `Running in the background at \`${cwd}\`.`,
-      `Live activity is streaming to \`${activityFile}\` — read it anytime to watch the delegate work (tool calls and their output${args.showThinking ? ", plus thinking" : ""}).`,
+      useJsonStream
+        ? `Live activity is streaming to \`${activityFile}\` — read it anytime to watch the delegate work (tool calls and their output${args.showThinking ? ", plus thinking" : ""}).`
+        : `The reply is streaming to \`${replyFile}\` — read it anytime to see partial output (this host has no json event mode, so tool activity is not visible).`,
       `A watchdog force-finishes a hung run: no output for ${IDLE_GRACE_MS / 60_000}m, 10s after output ends, or a ${ASYNC_TIMEOUT_MS / 60_000}m hard limit — the result reflects whatever was produced.`,
       ``,
       `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result (default 10s timeout). If the wait times out, or you skip it, a completion notification (with the result file path) is still injected here automatically when the delegate finishes — so you may also just continue other work now and let the result find you.`,
@@ -660,7 +672,7 @@ export async function buildChildArgs(
   args: DelegateArgs,
   rolePrompt: string,
   ctx: ExtensionContext,
-): Promise<{ cliArgs: string[]; tmpDir: string }> {
+): Promise<{ cliArgs: string[]; tmpDir: string; isAsync: boolean; useJsonStream: boolean }> {
   const tmpDir = await mkdtemp(join(tmpdir(), "acp-delegate-"));
   // Combine the role prompt with a small framing instruction so the child
   // treats the positional message as the task to execute.
@@ -669,10 +681,14 @@ export async function buildChildArgs(
 
   // Async delegates run in JSON Event Stream Mode so the host can parse tool
   // activity (activity file) and reply tokens (.out) from the event stream.
-  // Sync delegates keep print mode: they return a single text result, no
-  // streaming, and the async auto-downgrade (print/json host) must stay safe.
+  // `--mode json` is pi-only: omp (oh-my-pi) has no json mode, so async
+  // delegates there fall back to `-p` (plain reply on stdout, no activity
+  // file). Sync delegates always keep print mode: they return a single text
+  // result, no streaming, and the async auto-downgrade (print/json host) must
+  // stay safe.
   const isAsync = args.async !== false && ctx.mode !== "print" && ctx.mode !== "json";
-  const cliArgs = isAsync
+  const useJsonStream = isAsync && isPiHost(ctx.sessionManager);
+  const cliArgs = useJsonStream
     ? ["--mode", "json", "--no-session", "--append-system-prompt", promptFile]
     : ["-p", "--no-session", "--append-system-prompt", promptFile];
 
@@ -696,7 +712,7 @@ export async function buildChildArgs(
     cliArgs.push("--provider", ctx.model.provider, "--model", ctx.model.id);
   }
 
-  return { cliArgs, tmpDir };
+  return { cliArgs, tmpDir, isAsync, useJsonStream };
 }
 
 interface ChildResult {

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -17,6 +17,10 @@ import { debug } from "./log.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
+const EOF_GRACE_MS = 10_000;
+const IDLE_GRACE_MS = 5 * 60_000;
+const ASYNC_TIMEOUT_MS = 30 * 60_000;
+const KILL_GRACE_MS = 10_000;
 const RESULT_SUMMARY_CHARS = 500;
 const OUT_DIR = join(tmpdir(), "acp-delegate");
 
@@ -98,6 +102,9 @@ interface DelegateRun {
    *  notification (sendUserMessage succeeded). Lets a later wait() avoid
    *  re-delivering the same payload. */
   injected?: boolean;
+  /** Watchdog reason string when the run was force-terminated ("no output for
+   *  5m", "30m limit"); surfaced in completion headers as "(timed out: ...)". */
+  timedOut?: string;
   waiter?: () => void;
 }
 
@@ -197,10 +204,11 @@ The delegate runs in its own clean pi process — it does NOT see this conversat
 }
 
 function formatRunResult(run: DelegateRun): string {
+  const timeoutNote = run.timedOut ? ` (timed out: ${run.timedOut})` : "";
   const header =
     run.status === "completed"
-      ? `Delegate **${run.agent}** (runId \`${run.runId}\`) completed (exit ${run.exitCode ?? "?"})${remainingLineForWait(run.runId)}`
-      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status} (exit ${run.exitCode ?? "?"})${remainingLineForWait(run.runId)}`;
+      ? `Delegate **${run.agent}** (runId \`${run.runId}\`) completed (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`
+      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status} (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`;
   return formatPayload(header, run.result?.file ?? "", run.task, run.result?.body);
 }
 
@@ -423,7 +431,10 @@ async function runDelegate(
   const startedAt = Date.now();
 
   if (isAsync) {
-    child.stdout?.on("data", (c: Buffer) => stdoutChunks.push(c));
+    child.stdout?.on("data", (c: Buffer) => {
+      stdoutChunks.push(c);
+      resetIdle();
+    });
     child.stderr?.on("data", (c: Buffer) => {
       stderrText += c.toString("utf8");
     });
@@ -439,28 +450,74 @@ async function runDelegate(
     runs.set(runId, run);
     delegateStatusWidget.poke();
 
-    child.on("close", (code) => {
-      void cleanupTmp(tmpDir);
-      const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
-      run.exitCode = code;
-      const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
-      // N2: cancelled runs never persist a result — wake a parked waiter (if any)
-      // and stop. status stays "cancelled" (set by cancel), so wait cannot
-      // mistake it for a finished-with-result run.
-      if (run.status === "cancelled") {
-        run.finishedAt = Date.now();
-        debug.event("delegate-done", { runId, code, status: run.status, injected: false, outLen: output.length });
-        run.waiter?.();
-        delegateStatusWidget.poke();
-        return;
-      }
-      void persistResult(runId, body)
-        .then((file) => {
+    // ── Watchdogs + single finalize path ──────────────────────────────────
+    // Finalize is the ONLY place that flips run status/result. It is shared by
+    // the child close event and the EOF watchdog, with `settled` guarding
+    // against double-finalize (watchdog fires, then the killed child's close
+    // event arrives).
+    let settled = false;
+    let eofGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearWatchdogs = (): void => {
+      if (eofGraceTimer) clearTimeout(eofGraceTimer);
+      if (idleTimer) clearTimeout(idleTimer);
+      if (killGraceTimer) clearTimeout(killGraceTimer);
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+    };
+    // Reset the idle watchdog whenever the delegate produces output. A hanging
+    // child holds its stdout fd open (so stdout EOF never fires) — no output
+    // for IDLE_GRACE_MS is the reliable "stuck" signal.
+    const resetIdle = (): void => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => killByWatchdog(`no output for ${IDLE_GRACE_MS / 60_000}m`), IDLE_GRACE_MS);
+      idleTimer.unref?.();
+    };
+    // SIGTERM, then SIGKILL after KILL_GRACE_MS if the child ignores it. The
+    // close event that follows funnels into finalize() with the code it got.
+    const killByWatchdog = (reason: string): void => {
+      if (settled || run.status !== "running") return;
+      run.timedOut = reason;
+      debug.event("delegate-watchdog", { runId, reason });
+      try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
+      killGraceTimer = setTimeout(() => {
+        if (settled || run.status !== "running") return;
+        debug.event("delegate-watchdog-kill", { runId, reason });
+        try { run.child?.kill("SIGKILL"); } catch { /* best-effort */ }
+      }, KILL_GRACE_MS);
+      killGraceTimer.unref?.();
+    };
+
+    const finalize = (code: number | null): void => {
+      void (async () => {
+        if (settled) return;
+        settled = true;
+        clearWatchdogs();
+        void cleanupTmp(tmpDir);
+        const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        run.exitCode = code;
+        const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
+        // N2: cancelled runs never persist a result — wake a parked waiter (if any)
+        // and stop. status stays "cancelled" (set by cancel), so wait cannot
+        // mistake it for a finished-with-result run.
+        if (run.status === "cancelled") {
+          run.finishedAt = Date.now();
+          debug.event("delegate-done", { runId, code, status: run.status, injected: false, outLen: output.length });
+          run.waiter?.();
+          delegateStatusWidget.poke();
+          return;
+        }
+        try {
+          const file = await persistResult(runId, body);
+          // EOF-watchdog finalize has no exit code; if the output was delivered,
+          // treat it as a completed result (the process is killed afterwards).
+          const effectiveCode = code ?? (output || stderrText ? 0 : null);
           // Atomically flip status + result together: until this point the run
           // is still "running" to any observer, so a concurrent wait cannot
           // see "finished but result missing".
           run.result = { code, file, body };
-          run.status = code === 0 ? "completed" : "failed";
+          run.status = effectiveCode === 0 ? "completed" : "failed";
           run.finishedAt = Date.now();
           // If a wait is parked on this run, wake it — it owns the result now
           // (and marks consumed so we don't double-deliver by injecting).
@@ -476,21 +533,49 @@ async function runDelegate(
             delegateStatusWidget.poke();
             return;
           }
-          const injected = injectResult(pi, args.agent, runId, args.task, code, file);
+          const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut);
           run.injected = injected;
           debug.event("delegate-done", { runId, code, status: run.status, injected, outLen: output.length, file });
           delegateStatusWidget.poke();
-        })
-        .catch((err) => {
+        } catch (err) {
           // Persist failed — still need to finalize so a waiter doesn't hang.
           run.status = "failed";
           run.finishedAt = Date.now();
           debug.event("delegate-done-error", { runId, error: String(err) });
           run.waiter?.();
           delegateStatusWidget.poke();
-        });
+        }
+      })();
+    };
+
+    child.on("close", (code) => finalize(code));
+
+    child.stdout?.on("end", () => {
+      // stdout EOF: the delegate's output is fully delivered, but the process
+      // may still hang (e.g. a provider call that never responds). Give it a
+      // short grace period to exit naturally; if it does not, force-finalize —
+      // the output is already complete, so the result is final.
+      eofGraceTimer = setTimeout(() => {
+        if (settled || run.status !== "running") return;
+        run.timedOut = "output ended but process did not exit";
+        debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
+        try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
+        finalize(null);
+      }, EOF_GRACE_MS);
+      eofGraceTimer.unref?.();
     });
+
+    // Start the idle clock and the overall runtime budget. The budget also
+    // covers the pathological case where a child neither outputs nor exits
+    // AND somehow evades the idle timer (e.g. stderr-only chatter).
+    resetIdle();
+    timeoutTimer = setTimeout(() => killByWatchdog(`${ASYNC_TIMEOUT_MS / 60_000}m limit`), ASYNC_TIMEOUT_MS);
+    timeoutTimer.unref?.();
+
     child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearWatchdogs();
       void cleanupTmp(tmpDir);
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
       // Node does not guarantee a follow-up close, so finalize here too:
@@ -513,6 +598,7 @@ async function runDelegate(
       `Delegated to **${args.agent}** (runId \`${runId}\`).`,
       `Task: ${truncate(args.task, 160)}`,
       `Running in the background at \`${cwd}\`.`,
+      `A watchdog force-finishes a hung run: no output for ${IDLE_GRACE_MS / 60_000}m, 10s after output ends, or a ${ASYNC_TIMEOUT_MS / 60_000}m hard limit — the result reflects whatever was produced.`,
       ``,
       `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result (default 10s timeout). If the wait times out, or you skip it, a completion notification (with the result file path) is still injected here automatically when the delegate finishes — so you may also just continue other work now and let the result find you.`,
     ].join("\n");
@@ -629,6 +715,7 @@ function injectResult(
   task: string,
   code: number | null,
   file: string,
+  timedOut?: string,
 ): boolean {
   const send = pi.sendUserMessage;
   if (typeof send !== "function") {
@@ -646,7 +733,8 @@ function injectResult(
     remaining > 0
       ? ` ${remaining} delegate${remaining === 1 ? " is" : "s are"} still running; keep doing other work and their notifications will arrive as they finish.`
       : " No delegates are currently running.";
-  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${remainingLine} This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.`;
+  const timeoutNote = timedOut ? ` (timed out: ${timedOut})` : "";
+  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine} This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.`;
   const text = formatPayload(header, file, task);
   try {
     // sendUserMessage is fire-and-forget (returns void): it enqueues a

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -14,6 +14,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { debug } from "./log.js";
+import { attachWatchdogs } from "./delegate-watchdog.js";
 
 const MAX_DEPTH = 2;
 const SYNC_TIMEOUT_MS = 5 * 60_000;
@@ -431,9 +432,27 @@ async function runDelegate(
   const startedAt = Date.now();
 
   if (isAsync) {
+    let settled = false;
+    // Watchdogs: idle (no output), EOF grace, hard limit. A stuck child holds
+    // its stdout fd open so stdout EOF never fires — idle is the main defense.
+    const watchdog = attachWatchdogs(
+      child,
+      {
+        isSettled: () => settled || run.status !== "running",
+        onKill: (reason) => {
+          run.timedOut = reason;
+          debug.event("delegate-watchdog", { runId, reason });
+        },
+        onEofGrace: () => {
+          run.timedOut = "output ended but process did not exit";
+          debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
+        },
+      },
+      { eofGraceMs: EOF_GRACE_MS, idleMs: IDLE_GRACE_MS, timeoutMs: ASYNC_TIMEOUT_MS, killGraceMs: KILL_GRACE_MS },
+    );
     child.stdout?.on("data", (c: Buffer) => {
       stdoutChunks.push(c);
-      resetIdle();
+      watchdog.poke();
     });
     child.stderr?.on("data", (c: Buffer) => {
       stderrText += c.toString("utf8");
@@ -450,50 +469,11 @@ async function runDelegate(
     runs.set(runId, run);
     delegateStatusWidget.poke();
 
-    // ── Watchdogs + single finalize path ──────────────────────────────────
-    // Finalize is the ONLY place that flips run status/result. It is shared by
-    // the child close event and the EOF watchdog, with `settled` guarding
-    // against double-finalize (watchdog fires, then the killed child's close
-    // event arrives).
-    let settled = false;
-    let eofGraceTimer: ReturnType<typeof setTimeout> | undefined;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
-    let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
-    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
-    const clearWatchdogs = (): void => {
-      if (eofGraceTimer) clearTimeout(eofGraceTimer);
-      if (idleTimer) clearTimeout(idleTimer);
-      if (killGraceTimer) clearTimeout(killGraceTimer);
-      if (timeoutTimer) clearTimeout(timeoutTimer);
-    };
-    // Reset the idle watchdog whenever the delegate produces output. A hanging
-    // child holds its stdout fd open (so stdout EOF never fires) — no output
-    // for IDLE_GRACE_MS is the reliable "stuck" signal.
-    const resetIdle = (): void => {
-      if (idleTimer) clearTimeout(idleTimer);
-      idleTimer = setTimeout(() => killByWatchdog(`no output for ${IDLE_GRACE_MS / 60_000}m`), IDLE_GRACE_MS);
-      idleTimer.unref?.();
-    };
-    // SIGTERM, then SIGKILL after KILL_GRACE_MS if the child ignores it. The
-    // close event that follows funnels into finalize() with the code it got.
-    const killByWatchdog = (reason: string): void => {
-      if (settled || run.status !== "running") return;
-      run.timedOut = reason;
-      debug.event("delegate-watchdog", { runId, reason });
-      try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
-      killGraceTimer = setTimeout(() => {
-        if (settled || run.status !== "running") return;
-        debug.event("delegate-watchdog-kill", { runId, reason });
-        try { run.child?.kill("SIGKILL"); } catch { /* best-effort */ }
-      }, KILL_GRACE_MS);
-      killGraceTimer.unref?.();
-    };
-
     const finalize = (code: number | null): void => {
       void (async () => {
         if (settled) return;
         settled = true;
-        clearWatchdogs();
+        watchdog.dispose();
         void cleanupTmp(tmpDir);
         const output = Buffer.concat(stdoutChunks).toString("utf8").trim();
         run.exitCode = code;
@@ -550,32 +530,11 @@ async function runDelegate(
 
     child.on("close", (code) => finalize(code));
 
-    child.stdout?.on("end", () => {
-      // stdout EOF: the delegate's output is fully delivered, but the process
-      // may still hang (e.g. a provider call that never responds). Give it a
-      // short grace period to exit naturally; if it does not, force-finalize —
-      // the output is already complete, so the result is final.
-      eofGraceTimer = setTimeout(() => {
-        if (settled || run.status !== "running") return;
-        run.timedOut = "output ended but process did not exit";
-        debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
-        try { run.child?.kill("SIGTERM"); } catch { /* best-effort */ }
-        finalize(null);
-      }, EOF_GRACE_MS);
-      eofGraceTimer.unref?.();
-    });
-
-    // Start the idle clock and the overall runtime budget. The budget also
-    // covers the pathological case where a child neither outputs nor exits
-    // AND somehow evades the idle timer (e.g. stderr-only chatter).
-    resetIdle();
-    timeoutTimer = setTimeout(() => killByWatchdog(`${ASYNC_TIMEOUT_MS / 60_000}m limit`), ASYNC_TIMEOUT_MS);
-    timeoutTimer.unref?.();
 
     child.on("error", (err) => {
       if (settled) return;
       settled = true;
-      clearWatchdogs();
+      watchdog.dispose();
       void cleanupTmp(tmpDir);
       // Spawn-level error (e.g. EPIPE on a fast-exiting child, ENOENT).
       // Node does not guarantee a follow-up close, so finalize here too:

--- a/src/delegate-watchdog.ts
+++ b/src/delegate-watchdog.ts
@@ -1,0 +1,100 @@
+import type { Readable } from "node:stream";
+
+export interface WatchdogOptions {
+  eofGraceMs: number;
+  idleMs: number;
+  timeoutMs: number;
+  killGraceMs: number;
+}
+
+export interface WatchdogHooks {
+  /** True once the run is finalized; watchdogs stop firing. */
+  isSettled(): boolean;
+  /** The child is about to be killed (SIGTERM). reason explains why. */
+  onKill(reason: string): void;
+  /** stdout EOF passed without the process exiting; force-finalize now. */
+  onEofGrace(): void;
+}
+
+export interface WatchdogHandle {
+  /** Re-arm the idle timer (call on every stdout data). */
+  poke(): void;
+  /** Stop all timers (call on finalize). */
+  dispose(): void;
+}
+
+/**
+ * Guarantees a hung child process gets killed. A stuck child holds its stdout
+ * fd open, so stdout EOF never fires — hence the idle timer (no output for
+ * idleMs) is the main defense; the hard time limit and the EOF grace period
+ * cover the rest. Kill is SIGTERM, escalated to SIGKILL after killGraceMs.
+ */
+export function attachWatchdogs(
+  child: { kill(signal: NodeJS.Signals): boolean; stdout: Readable | null },
+  hooks: WatchdogHooks,
+  opts: WatchdogOptions,
+): WatchdogHandle {
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  let eofTimer: ReturnType<typeof setTimeout> | undefined;
+  let killGraceTimer: ReturnType<typeof setTimeout> | undefined;
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimers = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    if (eofTimer) clearTimeout(eofTimer);
+    if (killGraceTimer) clearTimeout(killGraceTimer);
+    if (timeoutTimer) clearTimeout(timeoutTimer);
+  };
+
+  const killByWatchdog = (reason: string): void => {
+    if (hooks.isSettled()) return;
+    hooks.onKill(reason);
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      /* best-effort */
+    }
+    killGraceTimer = setTimeout(() => {
+      if (hooks.isSettled()) return;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        /* best-effort */
+      }
+    }, opts.killGraceMs);
+    killGraceTimer.unref?.();
+  };
+
+  const poke = (): void => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => killByWatchdog(`no output for ${opts.idleMs / 60_000}m`), opts.idleMs);
+    idleTimer.unref?.();
+  };
+
+  poke();
+  timeoutTimer = setTimeout(() => killByWatchdog(`${opts.timeoutMs / 60_000}m limit`), opts.timeoutMs);
+  timeoutTimer.unref?.();
+
+  const onStdoutEnd = (): void => {
+    if (hooks.isSettled()) return;
+    eofTimer = setTimeout(() => {
+      if (hooks.isSettled()) return;
+      hooks.onEofGrace();
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* best-effort */
+      }
+    }, opts.eofGraceMs);
+    eofTimer.unref?.();
+  };
+  child.stdout?.once("end", onStdoutEnd);
+
+  return {
+    poke,
+    dispose: () => {
+      clearTimers();
+      child.stdout?.removeListener("end", onStdoutEnd);
+    },
+  };
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -25,6 +25,14 @@ export function readContextEntries(sm: ExtensionContext["sessionManager"]): Sess
   return [];
 }
 
+// True only on pi: `--mode json` event streaming (used by async delegates) is a
+// pi feature. omp (oh-my-pi) has no json mode, so delegates must fall back to
+// `-p` there — same detection as readContextEntries above.
+export function isPiHost(sm: ExtensionContext["sessionManager"]): boolean {
+  const source = sm as unknown as SessionEntrySource;
+  return typeof source.buildContextEntries === "function";
+}
+
 export interface AcpRuntime {
   core: CompressionCore;
   store: SessionStateStore;

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -3,9 +3,13 @@ import assert from "node:assert/strict";
 import { buildChildArgs, injectedWaitMessage } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-/** Minimal ctx mock - buildChildArgs only reads ctx.model. */
-function mockCtx(): ExtensionContext {
-  return { model: { provider: "test", id: "test-model" } } as unknown as ExtensionContext;
+/** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
+function mockCtx(host: "pi" | "omp" = "pi"): ExtensionContext {
+  const sessionManager =
+    host === "pi"
+      ? { buildContextEntries: () => [] }
+      : { getBranch: () => [] };
+  return { model: { provider: "test", id: "test-model" }, sessionManager } as unknown as ExtensionContext;
 }
 
 const RESTRICTED_ROLES = ["reviewer", "researcher", "planner", "oracle"] as const;
@@ -166,4 +170,41 @@ test("injectedWaitMessage surfaces remaining delegates and tolerates a missing f
   );
   assert.ok(msg!.includes("2 delegates are still running"), "passes through the remaining line");
   assert.ok(!msg!.includes("read the result file"), "omits the file line when file is absent");
+});
+
+// ─── host detection: --mode json (pi) vs -p fallback (omp) ──────────────────
+
+test("buildChildArgs uses --mode json on pi for async delegates", async () => {
+  const { cliArgs, isAsync, useJsonStream } = await buildChildArgs(
+    { agent: "worker", task: "test" },
+    "prompt",
+    mockCtx("pi"),
+  );
+  assert.equal(isAsync, true);
+  assert.equal(useJsonStream, true);
+  assert.deepEqual(cliArgs.slice(0, 2), ["--mode", "json"]);
+});
+
+test("buildChildArgs falls back to -p on omp for async delegates", async () => {
+  const { cliArgs, isAsync, useJsonStream } = await buildChildArgs(
+    { agent: "worker", task: "test" },
+    "prompt",
+    mockCtx("omp"),
+  );
+  assert.equal(isAsync, true);
+  assert.equal(useJsonStream, false);
+  assert.equal(cliArgs[0], "-p");
+});
+
+test("buildChildArgs keeps -p for sync delegates even on pi", async () => {
+  const ctx = mockCtx("pi") as ExtensionContext & { mode: string };
+  ctx.mode = "print";
+  const { cliArgs, isAsync, useJsonStream } = await buildChildArgs(
+    { agent: "worker", task: "test" },
+    "prompt",
+    ctx,
+  );
+  assert.equal(isAsync, false);
+  assert.equal(useJsonStream, false);
+  assert.equal(cliArgs[0], "-p");
 });

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -94,3 +94,36 @@ test("ThinkingCollector merges deltas into one line per segment", () => {
   off.push("hidden ");
   assert.equal(off.flush(), "", "disabled collector emits nothing");
 });
+
+test("parses auto_retry_start and auto_retry_end", () => {
+  const start = parseEventLine('{"type":"auto_retry_start","attempt":1,"maxAttempts":3,"delayMs":2000,"errorMessage":"529 {\\"error\\":{\\"type\\":\\"overloaded_error\\"}}"}');
+  assert.deepEqual(start, {
+    kind: "retry-start",
+    attempt: 1,
+    maxAttempts: 3,
+    delayMs: 2000,
+    errorMessage: '529 {"error":{"type":"overloaded_error"}}',
+  });
+
+  const end = parseEventLine('{"type":"auto_retry_end","success":true,"attempt":2}');
+  assert.deepEqual(end, { kind: "retry-end", success: true, attempt: 2 });
+});
+
+test("activityLines formats retry events", () => {
+  assert.deepEqual(
+    activityLines({ kind: "retry-start", attempt: 1, maxAttempts: 3, delayMs: 2000, errorMessage: "529 overloaded" }, { showThinking: false }),
+    ["[retry] attempt 1/3, backoff 2000ms — 529 overloaded\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "retry-start", attempt: 2, maxAttempts: 3, delayMs: 5000, errorMessage: "" }, { showThinking: false }),
+    ["[retry] attempt 2/3, backoff 5000ms\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "retry-end", success: true, attempt: 2 }, { showThinking: false }),
+    ["[retry] attempt 2 succeeded\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "retry-end", success: false, attempt: 3 }, { showThinking: false }),
+    ["[retry] attempt 3 failed\n"],
+  );
+});

--- a/tests/events.test.ts
+++ b/tests/events.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseEventLine, activityLines, extractContentText, newPortion, ThinkingCollector } from "../src/delegate-events.js";
+
+test("parses text_delta and text_end from message_update", () => {
+  const delta = parseEventLine('{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"Hello "}}');
+  assert.deepEqual(delta, { kind: "reply-delta", delta: "Hello " });
+
+  const end = parseEventLine('{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"Hello world"}}');
+  assert.deepEqual(end, { kind: "reply-complete", content: "Hello world" });
+});
+
+test("parses thinking_delta wrapped in message_update", () => {
+  const ev = parseEventLine('{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":" wan"}}');
+  assert.deepEqual(ev, { kind: "thinking-delta", delta: " wan" });
+});
+
+test("parses tool_execution_start with bash command args", () => {
+  const ev = parseEventLine('{"type":"tool_execution_start","toolCallId":"call_1","toolName":"bash","args":{"command":"echo hi"}}');
+  assert.deepEqual(ev, { kind: "tool-start", toolName: "bash", argsText: "echo hi" });
+});
+
+test("parses tool_execution_update partialResult text", () => {
+  const ev = parseEventLine(
+    '{"type":"tool_execution_update","toolCallId":"call_1","toolName":"bash","args":{"command":"echo hi"},"partialResult":{"content":[{"type":"text","text":"hi\\n"}],"details":{}}}',
+  );
+  assert.deepEqual(ev, { kind: "tool-update", toolCallId: "call_1", text: "hi\n" });
+});
+
+test("parses tool_execution_end with isError", () => {
+  const ok = parseEventLine('{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{"content":[{"type":"text","text":"hi\\n"}]},"isError":false}');
+  assert.deepEqual(ok, { kind: "tool-end", toolName: "bash", isError: false });
+
+  const err = parseEventLine('{"type":"tool_execution_end","toolCallId":"call_1","toolName":"bash","result":{},"isError":true}');
+  assert.deepEqual(err, { kind: "tool-end", toolName: "bash", isError: true });
+});
+
+test("ignores non-JSON lines and irrelevant events", () => {
+  assert.equal(parseEventLine("not json"), null);
+  assert.equal(parseEventLine('{"type":"turn_start","sessionId":"s"}'), null);
+  assert.equal(parseEventLine('{"type":"message_update","assistantMessageEvent":{"type":"text_start"}}'), null);
+});
+
+test("extractContentText joins text blocks and tolerates non-array content", () => {
+  assert.equal(extractContentText({ content: [{ type: "text", text: "a" }, { type: "text", text: "b" }] }), "ab");
+  assert.equal(extractContentText({ content: [] }), "");
+  assert.equal(extractContentText({}), "");
+  assert.equal(extractContentText(null), "");
+});
+
+test("activityLines formats tool activity and gates thinking", () => {
+  assert.deepEqual(
+    activityLines({ kind: "tool-start", toolName: "bash", argsText: "echo hi" }, { showThinking: false }),
+    ["[tool] bash echo hi\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "tool-update", toolCallId: "c", text: "hi\n" }, { showThinking: false }),
+    ["hi\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "tool-end", toolName: "bash", isError: true }, { showThinking: false }),
+    ["[done] bash (error)\n"],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "thinking-delta", delta: " wan" }, { showThinking: false }),
+    [],
+  );
+  assert.deepEqual(
+    activityLines({ kind: "thinking-delta", delta: " wan" }, { showThinking: true }),
+    ["[thinking]  wan\n"],
+  );
+});
+
+test("newPortion returns only the appended part of a snapshot", () => {
+  assert.equal(newPortion("hello", ""), "hello");
+  assert.equal(newPortion("hello world", "hello"), " world");
+  assert.equal(newPortion("hello", "hello"), "");
+  assert.equal(newPortion("rewritten", "hello"), "rewritten");
+});
+
+test("parses thinking_end from message_update", () => {
+  const ev = parseEventLine('{"type":"message_update","assistantMessageEvent":{"type":"thinking_end","contentIndex":0}}');
+  assert.deepEqual(ev, { kind: "thinking-end" });
+});
+
+test("ThinkingCollector merges deltas into one line per segment", () => {
+  const on = new ThinkingCollector(true);
+  on.push("The user ");
+  on.push("wants me ");
+  assert.equal(on.flush(), "[thinking] The user wants me\n");
+  assert.equal(on.flush(), "", "second flush is empty");
+
+  const off = new ThinkingCollector(false);
+  off.push("hidden ");
+  assert.equal(off.flush(), "", "disabled collector emits nothing");
+});

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -1,0 +1,114 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { attachWatchdogs } from "../src/delegate-watchdog.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+interface Harness {
+  stdout: EventEmitter;
+  kills: NodeJS.Signals[];
+  reasons: string[];
+  eofGraceCount: number;
+  settled: () => boolean;
+  watchdog: ReturnType<typeof attachWatchdogs>;
+}
+
+function setup(overrides?: { idleMs?: number; timeoutMs?: number; killGraceMs?: number; eofGraceMs?: number; initiallySettled?: boolean }): Harness {
+  const stdout = new EventEmitter();
+  const kills: NodeJS.Signals[] = [];
+  const reasons: string[] = [];
+  let eofGraceCount = 0;
+  let settledFlag = overrides?.initiallySettled ?? false;
+  const watchdog = attachWatchdogs(
+    {
+      kill: (sig) => {
+        kills.push(sig);
+        return true;
+      },
+      stdout,
+    },
+    {
+      isSettled: () => settledFlag,
+      onKill: (reason) => reasons.push(reason),
+      onEofGrace: () => {
+        eofGraceCount += 1;
+      },
+    },
+    {
+      eofGraceMs: overrides?.eofGraceMs ?? 1_000,
+      idleMs: overrides?.idleMs ?? 1_000,
+      timeoutMs: overrides?.timeoutMs ?? 60_000,
+      killGraceMs: overrides?.killGraceMs ?? 1_000,
+    },
+  );
+  return {
+    stdout,
+    kills,
+    reasons,
+    get eofGraceCount() {
+      return eofGraceCount;
+    },
+    settled: () => settledFlag,
+    watchdog,
+  };
+}
+
+test("idle watchdog kills with SIGTERM after idleMs without output", async () => {
+  const h = setup({ idleMs: 30, killGraceMs: 200 });
+  await sleep(60);
+  assert.deepEqual(h.kills, ["SIGTERM"], "SIGTERM fired once");
+  assert.equal(h.reasons.length, 1, "onKill called once");
+  assert.ok(h.reasons[0].includes("no output"), `reason names idle: ${h.reasons[0]}`);
+  h.watchdog.dispose();
+});
+
+test("idle watchdog escalates to SIGKILL when the child ignores SIGTERM", async () => {
+  const h = setup({ idleMs: 20, killGraceMs: 30 });
+  await sleep(100);
+  assert.deepEqual(h.kills, ["SIGTERM", "SIGKILL"], "SIGTERM then SIGKILL");
+  h.watchdog.dispose();
+});
+
+test("poke resets the idle timer (continuous output never triggers)", async () => {
+  const h = setup({ idleMs: 25 });
+  for (let i = 0; i < 10; i++) {
+    await sleep(15);
+    h.watchdog.poke();
+  }
+  assert.equal(h.kills.length, 0, "no kill while output keeps flowing");
+  h.watchdog.dispose();
+});
+
+test("EOF grace force-finalizes when stdout ended but the child lives", async () => {
+  const h = setup({ eofGraceMs: 30 });
+  h.stdout.emit("end");
+  await sleep(60);
+  assert.equal(h.eofGraceCount, 1, "onEofGrace fired once");
+  h.watchdog.dispose();
+});
+
+test("hard time limit kills regardless of output", async () => {
+  const h = setup({ timeoutMs: 40 });
+  await sleep(80);
+  assert.deepEqual(h.kills, ["SIGTERM"], "time limit fired");
+  assert.ok(h.reasons[0].includes("limit"), `reason names limit: ${h.reasons[0]}`);
+  h.watchdog.dispose();
+});
+
+test("dispose stops all watchdogs", async () => {
+  const h = setup({ idleMs: 30, eofGraceMs: 30 });
+  h.watchdog.dispose();
+  h.stdout.emit("end");
+  await sleep(80);
+  assert.equal(h.kills.length, 0, "no kill after dispose");
+  assert.equal(h.eofGraceCount, 0, "no EOF grace after dispose");
+});
+
+test("settled runs never get killed or grace-finalized", async () => {
+  const h = setup({ idleMs: 20, eofGraceMs: 20, initiallySettled: true });
+  h.stdout.emit("end");
+  await sleep(60);
+  assert.equal(h.kills.length, 0, "settled run not killed");
+  assert.equal(h.eofGraceCount, 0, "settled run not grace-finalized");
+});


### PR DESCRIPTION
## Background

Ref #89 — two asks: (1) see what a delegate is doing **while it runs**; (2) auto-terminate delegates that **hang** (provider unresponsive → child never exits → run stuck in "running" forever).

## Watchdog (was PR #90, folded in)

Async delegates are force-finished when: no output for 5m (idle — the main defense, since a hung child holds its stdout fd open so EOF never fires), 10s after output ends, or a 30m hard limit. Sequence: SIGTERM → 10s grace → SIGKILL. The result reflects whatever was produced, with a `(timed out: <reason>)` header.

Logic extracted to `src/delegate-watchdog.ts` (`attachWatchdogs(child, hooks, opts)`, injectable timeouts) — 7 unit tests in `tests/watchdog.test.ts` (fake child + short timers): idle SIGTERM, SIGKILL escalation, poke reset, EOF grace, hard limit, dispose, settled guard.

## Live activity file + reply stream

Async delegates now spawn with `--mode json` instead of `-p`. The host parses the newline-delimited event stream into **two live files**:

| File | Content | When you see it |
|---|---|---|
| `.out` | assistant reply token stream (`text_delta` accumulations, `text_end` authoritative) | delivered as the result file on finish |
| `.activity` | human-readable tool activity — `[tool] bash <cmd>`, live output chunks, `[done] bash` | streamed in real time, readable anytime |

Key points:

- **Real-time bash output**: `tool_execution_update.partialResult` is written as it arrives — verified `tick-1`/`tick-2` visible mid-run while the command still sleeps.
- **Snapshot dedup**: `partialResult` is an accumulated snapshot (not a delta) — only the newly-appended portion is written per update.
- **`showThinking` option** (default `false`): thinking deltas merged per segment into one `[thinking] <full segment>` line instead of token fragments.
- **Provider retry visibility**: `auto_retry_start` / `auto_retry_end` events (transient errors: overloaded / rate limit / 5xx) are formatted as `[retry] attempt 1/3, backoff 2000ms — 529 Overloaded` and `[retry] attempt 2 succeeded` — the original #89 scenario (provider unresponsive → delegate retrying unseen) is now observable.
- **Spawn returns only the `.activity` path**; the `.out` path arrives with the result notification.
- **Sync delegates keep `-p`** — no streaming, no behavior change; the async auto-downgrade for print/json hosts stays safe (buildChildArgs computes the same `isAsync`).

## Tests

20 new unit tests (7 watchdog + 13 events) using real event samples captured from `pi --mode json`. 103 total, typecheck + build green. E2E verified on a local install: reply extraction, mid-run activity visibility, snapshot dedup, merged thinking, `.out` delivery, watchdog idle kill (exit 143 + `(no output)` result).

⚠️ This PR **replaces** PR #90 (closed). Watchdog and activity-stream land as one unit.