### PR TITLE
release v0.1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.26",
+	"version": "0.1.27",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.26",
+			"version": "0.1.27",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.26",
+	"version": "0.1.27",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.27

发版包含 PR #88（oh-my-pi / omp 支持）：
- `fix: support oh-my-pi (omp) host` — 特性检测 `buildContextEntries()` (pi) vs `getBranch()` (omp)；保留 omp 无 content 的执行角色（bashExecution/pythonExecution）
- `fix: vendor isBashToolResult so the module loads under omp` — 本地化 guard，修复 omp 下模块加载失败

### 本次只升 billion-context-pi 自身版本（0.1.26 → 0.1.27）
acp-kernel 保持 0.0.17（本次无 acp-kernel 变更，已确认 0.0.17 在 npm 上已发布，CI `npm ci` 可正常安装）。

### Pre-flight
- `npm install`（刷新 package-lock.json）
- `npm run typecheck`：通过
- `npm test`：87 tests 全过
- `npm run build`：成功（dist/index.js 389.96 KB）

### 改动
仅 `package.json` + `package-lock.json`（2 文件），只动 version 字段。

---
合并后 CI 自动发布到 npm（`billion-context-pi@0.1.27`）。

> 注：#93（omp 新 session 第一条空消息）不在本版范围，单独跟进。