### PR TITLE
release v0.1.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.27",
+	"version": "0.1.28",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.27",
+			"version": "0.1.28",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.27",
+	"version": "0.1.28",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.28.

## Ships #91 — streaming output + watchdog for async delegates

- **Watchdog** (`delegate-watchdog.ts`): idle/EOF-grace/hard-limit timers force-finish hung async delegates (SIGTERM → SIGKILL), host-agnostic. Fixes the root cause where a hung child keeps its stdout fd open so `close` never fires and a run stays `running` forever.
- **Live streaming** (`delegate-events.ts`): async delegates spawn under pi `--mode json` and stream tool activity (`<runId>.activity`) + reply tokens (`<runId>.out`) to `/tmp/acp-delegate/`, readable mid-run.
- **Provider retry visibility**: `auto_retry_*` events surface as `[retry]` lines in the activity file.
- **omp compatibility** (`c4bbba2`): `isPiHost()` feature-detect gates the json stream — omp (oh-my-pi) has no `--mode json`, so async delegates fall back to `-p` there (stdout streams straight through as the reply; no `.activity` file). Watchdog applies unchanged on both hosts.

## Changes in this PR
- Version bump `0.1.27` → `0.1.28` (acp-kernel unchanged at `0.0.17`).
- `package.json` + `package-lock.json` (2 files, version only).

## Pre-flight (local, on this branch)
- `npm run typecheck` ✅
- `npm test` ✅ 110/110
- `npm run build` ✅ (dist/index.js, acp-kernel inlined)

Content already merged to master via #91; this PR only cuts the release version bump. Merge to trigger CI auto-publish.