### PR TITLE
fix(messages): drop empty assistant turns to avoid provider 400 / crash loop

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -73,7 +73,11 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
         };
       });
     }
-    return [{ id, role: "assistant", contentType: "text", text: extractText(msg.content) }];
+    const text = extractText(msg.content);
+    // Drop thinking-only turns: empty assistant text makes OpenAI-compatible
+    // providers (e.g. GLM) return 400 (no body), which Pi misreads as overflow.
+    if (!text.trim()) return [];
+    return [{ id, role: "assistant", contentType: "text", text }];
   }
   const customText = extractText(msg.content) || fallbackText(msg);
   return customText.length > 0

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -77,6 +77,54 @@ test("entriesToCoreMessages projects user/assistant/toolResult roles and extract
   assert.equal(core[3]!.text, "file contents");
 });
 
+function assistantThinkingOnly(thinking: string): object {
+  return { role: "assistant", content: [{ type: "thinking", thinking }], timestamp: Date.now() };
+}
+function assistantThinkingAndText(thinking: string, text: string): object {
+  return {
+    role: "assistant",
+    content: [{ type: "thinking", thinking }, { type: "text", text }],
+    timestamp: Date.now(),
+  };
+}
+
+test("entriesToCoreMessages drops thinking-only assistant turns (no empty assistant text → no provider 400)", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", user("before")),
+    msgEntry("b", assistantThinkingOnly("internal reasoning, no output") as object),
+    msgEntry("c", user("after")),
+  ];
+  const core = entriesToCoreMessages(entries);
+
+  assert.deepEqual(core.map((m) => m.id), ["a", "c"], "thinking-only assistant dropped, not emitted as empty text");
+  assert.ok(
+    !core.some((m) => m.role === "assistant" && (!m.text || !m.text.trim())),
+    "no empty-text assistant message in output",
+  );
+});
+
+test("entriesToCoreMessages keeps assistant turn that has thinking AND text (text extracted, thinking ignored)", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", assistantThinkingAndText("private reasoning", "visible answer") as object),
+  ];
+  const core = entriesToCoreMessages(entries);
+
+  assert.equal(core.length, 1);
+  assert.equal(core[0]!.role, "assistant");
+  assert.equal(core[0]!.contentType, "text");
+  assert.equal(core[0]!.text, "visible answer", "text kept, thinking block not inlined");
+});
+
+test("entriesToCoreMessages drops assistant turn whose text is whitespace-only", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", user("before")),
+    msgEntry("b", { role: "assistant", content: [{ type: "text", text: "   \n  " }], timestamp: Date.now() } as object),
+    msgEntry("c", user("after")),
+  ];
+  const core = entriesToCoreMessages(entries);
+  assert.deepEqual(core.map((m) => m.id), ["a", "c"], "whitespace-only assistant dropped");
+});
+
 function customEntry(id: string, customType: string, content: string | unknown[]): SessionEntry {
   return {
     type: "custom_message",


### PR DESCRIPTION
## Root cause of #13 (pi 版本崩溃问题)

Screenshot showed \`Error: 400 status code (no body)\` ×2 followed by Pi's \`Context overflow detected, Auto-compacting...\`, while \`/acp\` reported **8% (81.1K / 1.0M)**. The model is a 1M-window model (\`limit=1000000\` in logs), so 8% can never be a genuine overflow. The 400 is a **malformed request body**; Pi misreads that failure as overflow and triggers a doomed auto-compaction (which also 400s → the second error).

## The malformed body: empty assistant message

\`src/messages.ts\` \`projectMessage()\` projected an assistant turn whose text was empty to:

\`\`\`js
{ role: "assistant", contentType: "text", text: "" }
\`\`\`

OpenAI-compatible providers (e.g. GLM / glm-5.2) reject an empty-content assistant message with **HTTP 400 (no body)**. The kernel does not filter empty-text messages, so it reaches the provider verbatim.

Confirmed empirically against the affected session \`…019fbb41….jsonl\` — **42 empty assistant turns**, broken down:

| source | count |
|---|---|
| \`Operation aborted\` (content \`[]\`, \`stopReason:"aborted"\`) | 30 |
| network 500 / \`Stream ended without finish_reason\` | 2 |
| thinking-only (reasoning block, no text, no tool call) | 10 |

**These are NOT produced by ACP compression** — they are aborted/failed streaming turns and thinking-only turns straight from the provider. Once one empty assistant turn lands in context, the next request 400s, which Pi aborts → records another empty assistant turn → next request 400s again. A self-reinforcing crash loop.

The 0.1.25→0.1.27 diff only added \`fallbackText\` for custom roles and never touched the assistant branch, so **this bug is still live on master / installed 0.1.27**. \`acp-kernel@0.0.17\` is identical across 0.1.25–0.1.27, so the fix belongs in the adapter.

## Fix

\`\`\`ts
const text = extractText(msg.content);
// Drop thinking-only turns: empty assistant text makes OpenAI-compatible
// providers (e.g. GLM) return 400 (no body), which Pi misreads as overflow.
if (!text.trim()) return [];
return [{ id, role: "assistant", contentType: "text", text }];
\`\`\`

Dropping is safe: an assistant turn with no text and no tool calls carries no user/task content, and cannot orphan a toolResult (it has no toolCall). This breaks the crash loop at the source — no empty assistant message is ever sent to the provider.

## Tests

3 new in \`tests/messages.test.ts\`:
- thinking-only assistant turn → dropped (no empty text emitted)
- thinking + text → kept, text only (thinking ignored)
- whitespace-only text → dropped

## Verification

- \`npm run typecheck\` ✅
- \`npm test\` → **90/90 pass** (87 + 3)
- \`npm run build\` ✅

Closes #13.