### PR TITLE
feat: always-on logging (errors/warnings/lifecycle) even when debug is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `debug` | `false` | Write diagnostic events to `~/.pi/acp-debug.log`. Also enabled by env `ACP_DEBUG=1`. |
+| `debug` | `false` | Enable verbose **debug-level** events in the log. The always-on log (lifecycle events, errors, warnings) is written regardless; `debug` only adds extra diagnostics. Also enabled by env `ACP_DEBUG=1`. |
 | `autoUpdate` | `true` | On Pi startup, check npm for a newer version and auto-install it (throttled to one check per 3 minutes). Disable to avoid all startup network calls. |
 | `modelContextLimit` | *(auto)* | Override the context limit (in tokens). Defaults to the model's `contextWindow`. |
 | `delegate` | `true` | Enable the `acp_delegate` tools (delegate/wait/cancel) and their system-prompt section. Set `false` to skip registering them (e.g. you use a different sub-agent extension, or run headless where async injection adds no value). |
@@ -169,7 +169,22 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 |----------|--------|
 | `ACP_AUTO_UPDATE` | Set to `0` / `false` / `no` / `off` (case-insensitive) to disable auto-update, overriding the config. |
 | `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit. Takes precedence over the config value. |
-| `ACP_DEBUG` | Set to `1` or `true` to enable debug logging. |
+| `ACP_DEBUG` | Set to `1` or `true` to enable debug-level logging (always-on events are written regardless). |
+| `ACP_LOG_FILE` | Override the log file path (default `~/.pi/acp.log`). |
+
+### Logging
+
+billion-context-pi writes a structured, always-on log to `~/.pi/acp.log` (override with `ACP_LOG_FILE`). It covers the model's whole working session and is useful for diagnosing problems:
+
+- **Always written** (even with `debug: false`): `error`, `warn`, `info` levels — session start, every context turn (token usage / nudge decision), compress/decompress, delegate spawn/done, and **all errors and warnings** (config/state/tool failures, delegate errors, guardrail caps, update failures). Error lines include the message and stack trace.
+- **Written only when `debug: true`**: verbose `debug`-level diagnostics (full field dumps, per-turn internals).
+
+Each line: `<ISO timestamp> [<level>] [<scope>] key=value key=value`. The file rotates to `~/.pi/acp.log.old` at 10 MB.
+
+```sh
+tail -f ~/.pi/acp.log                 # watch the session live
+grep '\[error\]' ~/.pi/acp.log        # surface every recorded failure
+```
 
 ### Compression philosophy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,7 +153,7 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 
 | Key | 默认值 | 说明 |
 |-----|--------|------|
-| `debug` | `false` | 将诊断事件写入 `~/.pi/acp-debug.log`。也可用环境变量 `ACP_DEBUG=1` 启用。 |
+| `debug` | `false` | 启用诊断日志(`error`/`warn`/`info` 始终写入 `~/.pi/acp.log`,此开关仅额外打开详细 `debug` 事件)。也可用环境变量 `ACP_DEBUG=1` 启用。 |
 | `autoUpdate` | `true` | Pi 启动时检查 npm 是否有更新版本并自动安装(限频:每 3 分钟最多一次检查)。禁用以避免所有启动时的网络请求。 |
 | `modelContextLimit` | *(自动)* | 覆盖上下文上限(token 数)。默认为模型的 `contextWindow`。 |
 | `delegate` | `true` | 启用 `acp_delegate` 工具(delegate/wait/cancel)及其系统提示词段落。设为 `false` 则不注册这些工具(例如你用了别的子代理扩展,或跑 headless 场景异步注入没有意义)。 |
@@ -168,7 +168,24 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 |------|------|
 | `ACP_AUTO_UPDATE` | 设为 `0` / `false` / `no` / `off`(不区分大小写)以禁用自动更新,覆盖配置值。 |
 | `ACP_MODEL_CONTEXT_LIMIT` | 覆盖上下文上限。优先级高于配置值。 |
-| `ACP_DEBUG` | 设为 `1` 或 `true` 启用 debug 日志。 |
+| `ACP_DEBUG` | 设为 `1` 或 `true` 启用 debug 日志(`error`/`warn`/`info` 始终写入,无需此开关)。 |
+| `ACP_LOG_FILE` | 覆盖日志文件路径(默认 `~/.pi/acp.log`)。 |
+
+### 日志
+
+billion-context-pi 会向 `~/.pi/acp.log`(可用 `ACP_LOG_FILE` 覆盖)写入结构化的**始终开启**日志,覆盖模型工作的整个会话,便于排查问题:
+
+- `error` — 详细记录所有报错(含 `message` 与 `stack`):上下文变换、压缩/解压/搜索执行失败、delegate 子进程错误、状态读写失败、子代理工具注册失败等。原本被静默吞掉的异常现在一律落盘。
+- `warn` — 值得注意的非致命情况:紧急 nudge 注入、配置加载失败、自动更新网络错误、工具输出被截断、委派结果注入被跳过。
+- `info` — 生命周期事件:会话启动、每轮上下文变换摘要(消息数/token/压缩比/活跃块数)、压缩/解压、delegate 派发与完成、自动更新检查。
+- `debug` —— 仅在 `debug: true` 时额外写入(细粒度的字段级事件)。
+
+每行格式:`<ISO 时间戳> [<级别>] [<范围>] key=value key=value`。文件达到 10 MB 时轮转为 `~/.pi/acp.log.old`。
+
+```bash
+tail -f ~/.pi/acp.log                 # 实时观察会话
+grep '\[error\]' ~/.pi/acp.log        # 汇总所有记录的失败
+```
 
 ### 压缩策略
 

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -5,7 +5,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { debug } from "./log.js";
+import { debug, logError, logInfo, logThrow } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 
 function formatK(n: number): string {
@@ -42,7 +42,13 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
     ],
     parameters: CompressParams,
     async execute(toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-      const result = await handleCompress(params as CompressArgs, runtime, ctx, toolCallId);
+      let result: string;
+      try {
+        result = await handleCompress(params as CompressArgs, runtime, ctx, toolCallId);
+      } catch (e) {
+        logThrow("compress", e, { sid: ctx.sessionManager.getSessionId(), ranges: (params as CompressArgs).content?.length ?? 0 });
+        throw e;
+      }
       return { details: undefined, content: [{ type: "text", text: result }] };
     },
   };
@@ -93,6 +99,25 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     activeAfter: applied.state.blocks.filter((b) => b.active).length,
     newBlocks: newBlocks.map((b) => ({ blockId: b.blockId, tier: b.tier, summaryLen: b.summary.length, directMsgCount: b.directMessageIds.length, effectiveMsgCount: b.effectiveMessageIds.length, summary: b.summary })),
   });
+
+  logInfo("compress", {
+    sid: ctx.sessionManager.getSessionId(),
+    event: "applied",
+    ranges: ranges.length,
+    blocksCreated,
+    tokensCompressed,
+    beforeTokens,
+    afterTokens,
+    warnings: warnings.length,
+    errors: errors.length,
+    newBlockIds: newBlocks.map((b) => b.blockId),
+  });
+  if (errors.length > 0) {
+    logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "errors", count: errors.length, errors: errors.slice(0, 5) });
+  }
+  if (warnings.length > 0) {
+    logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
+  }
 
   const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(tokensCompressed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
   if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,9 @@ export interface AdapterConfig {
    *  Disable via `autoUpdate: false` or env `ACP_AUTO_UPDATE=0` to avoid all
    *  network calls on startup. */
   autoUpdate?: boolean;
-  /** Write ACP debug events to the debug log file (default ~/.pi/acp-debug.log).
+  /** Enable debug-level events in the ACP log file (default ~/.pi/acp.log).
+   *  Always-on events (session/turn/compress/delegate lifecycle, all errors and
+   *  warnings) are written regardless; `debug` only adds verbose diagnostics.
    *  Default: false (or env ACP_DEBUG=1/true). */
   debug?: boolean;
   /** Enable acp_delegate tools (delegate/wait/cancel) and their system-prompt

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { debug } from "./log.js";
+import { debug, logError, logInfo, logThrow } from "./log.js";
 import { parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
@@ -44,7 +44,13 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     ],
     parameters: DecompressParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-      const result = await handleDecompress(params as DecompressArgs, runtime, ctx);
+      let result: string;
+      try {
+        result = await handleDecompress(params as DecompressArgs, runtime, ctx);
+      } catch (e) {
+        logThrow("decompress", e, { sid: ctx.sessionManager.getSessionId(), blockId: (params as DecompressArgs).blockId });
+        throw e;
+      }
       return { details: undefined, content: [{ type: "text", text: result }] };
     },
   };
@@ -123,16 +129,21 @@ async function handleMessageRef(
 
   if (!wantFile) {
     debug.event("decompress-message", { ref, ownerBlockId, mode: "inline", chars: text.length });
+    logInfo("decompress", { sid: ctx.sessionManager.getSessionId(), event: "message", mode: "inline", ref, ownerBlockId, chars: text.length });
     return `Message ${ref} (${role}, block ${ownerBlockId}, ${text.length} chars) restored inline:\n\n${text}`;
   }
 
   const targetPath = args.toFile ? resolveToFilePath(args.toFile) : autoFilePath(`msg-${ref}`);
-  if (typeof targetPath === "object" && "error" in targetPath) return targetPath.error;
+  if (typeof targetPath === "object" && "error" in targetPath) {
+    logError("decompress", { sid: ctx.sessionManager.getSessionId(), event: "message-path-rejected", ref, toFile: args.toFile });
+    return targetPath.error;
+  }
 
   await mkdir(AUTO_DIR, { recursive: true }).catch(() => {});
   await writeFile(targetPath, text, "utf8");
 
   debug.event("decompress-message", { ref, ownerBlockId, mode: "file", path: targetPath, chars: text.length });
+  logInfo("decompress", { sid: ctx.sessionManager.getSessionId(), event: "message", mode: "file", ref, ownerBlockId, path: targetPath, chars: text.length });
 
   return [
     `Message ${ref} (${role}, block ${ownerBlockId}, ${text.length} chars) written to ${targetPath}.`,
@@ -172,21 +183,23 @@ async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: 
   // cost (e.g. small restorations or when it must reason over exact text).
   if (args.inline === true && !args.toFile) {
     debug.event("decompress", { blockId, full, count, mode: "inline" });
+    logInfo("decompress", { sid: ctx.sessionManager.getSessionId(), event: "block", mode: "inline", blockId, full, count });
     return `Restored block ${blockId} (${count} item${count === 1 ? "" : "s"}) inline:\n\n${text}`;
   }
 
-  // file mode (default): write to disk. Determined path is either the explicit
-  // toFile or an auto-generated location. The block stays compressed; only a
-  // short path + preview is added to the conversation.
   const targetPath = args.toFile
     ? resolveToFilePath(args.toFile)
     : autoFilePath(blockId);
-  if (typeof targetPath === "object" && "error" in targetPath) return targetPath.error;
+  if (typeof targetPath === "object" && "error" in targetPath) {
+    logError("decompress", { sid: ctx.sessionManager.getSessionId(), event: "block-path-rejected", blockId, toFile: args.toFile });
+    return targetPath.error;
+  }
 
   await mkdir(AUTO_DIR, { recursive: true }).catch(() => {});
   await writeFile(targetPath, text, "utf8");
 
   debug.event("decompress", { blockId, full, count, mode: "file", path: targetPath, chars: text.length });
+  logInfo("decompress", { sid: ctx.sessionManager.getSessionId(), event: "block", mode: "file", blockId, full, count, path: targetPath, chars: text.length });
 
   const itemWord = count === 1 ? "item" : "items";
   const lines = [

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -14,7 +14,7 @@ import type {
   ExtensionContext,
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import { debug } from "./log.js";
+import { debug, logError, logInfo, logWarn } from "./log.js";
 import { attachWatchdogs } from "./delegate-watchdog.js";
 import { parseEventLine, activityLines, newPortion, ThinkingCollector } from "./delegate-events.js";
 import { isPiHost } from "./runtime.js";
@@ -362,6 +362,7 @@ export function makeDelegateCancelTool(_pi: ExtensionAPI): ToolDefinition<typeof
         run.child?.kill("SIGTERM");
       } catch (err) {
         debug.event("delegate-cancel-kill-error", { runId, error: String(err) });
+        logError("delegate", { event: "cancel-kill-error", runId, error: String(err) });
       }
       delegateStatusWidget.poke();
       return {
@@ -403,36 +404,26 @@ async function runDelegate(
   const requestedAsync = args.async !== false;
   if (requestedAsync && !isAsync) {
     debug.event("delegate-async-downgraded", { reason: `mode=${ctx.mode}` });
+    logInfo("delegate", { event: "async-downgraded", reason: `mode=${ctx.mode}` });
   }
-  debug.event("delegate-spawn", { agent: args.agent, cwd, async: isAsync, useJsonStream, cliArgs });
+  const runId = `del_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+  debug.event("delegate-spawn", { agent: args.agent, runId, cwd, async: isAsync, useJsonStream, cliArgs });
+  logInfo("delegate", { event: "spawn", agent: args.agent, runId, cwd, async: isAsync, useJsonStream, mode: ctx.mode, parentDepth });
 
-  // Spawn a child pi process using the SAME binary that is currently running.
-  // Hardcoding "pi" breaks under renamed forks (e.g. pi-stable whose bin is
-  // "pi-stable"). process.execPath is the Node binary, process.argv[1] is the
-  // cli.js entrypoint of the currently running pi — together they always point
-  // at the right executable regardless of how it was installed.
   const child = spawn(process.execPath, [process.argv[1]!, ...cliArgs], {
     cwd,
     env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
     shell: process.platform === "win32",
   }) as ChildProcess;
-  // Pass the task via stdin (not argv) so tasks starting with `-` are not
-  // mis-parsed as CLI options. pi reads piped stdin as the prompt in print mode.
-  // N1: a fast-exiting child (bad provider, ENOENT, SIGTERM) closes the pipe
-  // before we finish writing → EPIPE → 'error' on stdin. Without a listener
-  // that becomes an uncaughtException and can crash the host pi. Attach an
-  // error listener so the event is swallowed and logged.
   child.stdin?.once("error", (e: Error) => {
     debug.event("delegate-stdin-error", { runId: "pre-spawn", error: String(e) });
+    logError("delegate", { event: "stdin-error", runId, error: String(e) });
   });
   child.stdin?.end(args.task);
 
-  // stderr buffering is shared by async (error / non-zero fallback) and sync
-  // (waitForChild attaches its own stdout listener).
   let stderrText = "";
 
-  const runId = `del_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
   const startedAt = Date.now();
 
   if (isAsync) {
@@ -591,25 +582,27 @@ async function runDelegate(
           // (and marks consumed so we don't double-deliver by injecting).
           if (run.waiter) {
             debug.event("delegate-done", { runId, code, status: run.status, injected: false, via: "wait", outLen: output.length, file });
+            logInfo("delegate", { event: "done", runId, agent: args.agent, code, status: run.status, injected: false, via: "wait", outLen: output.length, file });
             run.waiter();
             delegateStatusWidget.poke();
             return;
           }
-          // If a wait already returned this result, skip the injection.
           if (run.consumed) {
             debug.event("delegate-done", { runId, code, status: run.status, injected: false, via: "consumed", outLen: output.length, file });
+            logInfo("delegate", { event: "done", runId, agent: args.agent, code, status: run.status, injected: false, via: "consumed", outLen: output.length, file });
             delegateStatusWidget.poke();
             return;
           }
           const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut);
           run.injected = injected;
           debug.event("delegate-done", { runId, code, status: run.status, injected, outLen: output.length, file });
+          logInfo("delegate", { event: "done", runId, agent: args.agent, code, status: run.status, injected, outLen: output.length, file });
           delegateStatusWidget.poke();
         } catch (err) {
-          // Persist failed — still need to finalize so a waiter doesn't hang.
           run.status = "failed";
           run.finishedAt = Date.now();
           debug.event("delegate-done-error", { runId, error: String(err) });
+          logError("delegate", { event: "done-error", runId, agent: args.agent, error: String(err) });
           run.waiter?.();
           delegateStatusWidget.poke();
         }
@@ -636,6 +629,7 @@ async function runDelegate(
         run.finishedAt = Date.now();
         run.result = { code: null, file: "", body: `spawn error: ${String(err)}` };
         debug.event("delegate-spawn-error", { runId, error: String(err) });
+        logError("delegate", { event: "spawn-error", runId, agent: args.agent, error: String(err) });
         run.waiter?.();
         delegateStatusWidget.poke();
       }
@@ -784,6 +778,7 @@ function injectResult(
   const send = pi.sendUserMessage;
   if (typeof send !== "function") {
     debug.event("delegate-inject-skipped", { runId, reason: "sendUserMessage unavailable" });
+    logWarn("delegate", { event: "inject-skipped", runId, reason: "sendUserMessage unavailable" });
     return false;
   }
   const status = code === 0 ? "completed" : "failed";
@@ -808,6 +803,7 @@ function injectResult(
     return true;
   } catch (err) {
     debug.event("delegate-inject-error", { runId, error: String(err) });
+    logError("delegate", { event: "inject-error", runId, agent, error: String(err) });
     return false;
   }
 }
@@ -846,6 +842,7 @@ async function persistResult(runId: string, body: string): Promise<string> {
     return file;
   } catch (err) {
     debug.event("delegate-persist-error", { runId, file, error: String(err) });
+    logError("delegate", { event: "persist-error", runId, file, error: String(err) });
     return "";
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,13 +18,15 @@ import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
-import { debug, setDebugEnabled } from "./log.js";
+import { debug, setDebugEnabled, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 
 type AgentMessage = SessionMessageEntry["message"];
+
+declare const CURRENT_VERSION: string;
 
 export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactory {
   return (pi: ExtensionAPI) => {
@@ -60,15 +62,14 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("session_start", async (_event, ctx) => {
     runtime.store.invalidate();
     runtime.clearNudgeTracking();
-    // Load user config (~/.pi/acp.json + project .pi/acp.json) and apply it so
-    // debug/terminalNudge/autoUpdate/modelContextLimit are runtime-configurable
-    // without env vars or reinstalling.
+    const sid = ctx.sessionManager.getSessionId();
+    logInfo("session", { event: "start", sid, cwd: ctx.cwd, debug: runtime.adapter.debug ?? null, version: typeof CURRENT_VERSION !== "undefined" ? CURRENT_VERSION : null });
     try {
       const user = await loadUserConfig(ctx.cwd);
       runtime.setAdapter(applyUserConfig(runtime.adapter, user));
       if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
-    } catch {
-      // best-effort — fall back to factory/env config
+    } catch (e) {
+      logThrow("config", e, { sid, phase: "session_start" });
     }
     if (runtime.adapter.delegate !== false) {
       pi.registerTool(makeDelegateTool(pi));
@@ -90,6 +91,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   });
   pi.on("session_shutdown", () => {
     delegateStatusWidget.dispose();
+    closeLogStream();
   });
 }
 
@@ -129,6 +131,19 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 
       const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
       await runtime.save(turn.state, ctx);
+
+      logInfo("turn", {
+        sid,
+        inMsgs: coreMessages.length,
+        outMsgs: turn.messages.length,
+        tokens: tokenCount,
+        pct: realUsage?.percent ?? (config.modelContextLimit > 0 ? Math.round((tokenCount / config.modelContextLimit) * 100) : null),
+        limit: config.modelContextLimit,
+        nudge: turn.nudge?.shouldInject ? (turn.nudge.breakdown?.emergencyOverride === 1 ? "emergency" : "active") : "idle",
+        nudgeReason: turn.nudge?.reason ?? null,
+        blocks: turn.state.blocks.length,
+        activeBlocks: turn.state.blocks.filter((b) => b.active).length,
+      });
 
       debug.event("processTurn", {
         outMsgs: turn.messages.length,
@@ -172,6 +187,9 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         const rendered = renderNudgeText(turn.nudge);
         const top = [...turn.nudge.compressibleRanges].sort((a, b) => b.tokens - a.tokens)[0];
         const example = top ? `\n\nExample: compress({ content: [{ startId: "${top.startRef}", endId: "${top.endRef}", summary: "..." }] })` : "";
+        if (emergency) {
+          logWarn("nudge", { sid: ctx.sessionManager.getSessionId(), event: "emergency-inject", pct: Math.round(turn.nudge.contextUsage * 100), voice: rendered.voice, compressible: turn.nudge.compressibleRanges.length });
+        }
         if (debugOn && ctx.hasUI) {
           ctx.ui.notify(`[ACP nudge → context]${emergency ? " [EMERGENCY]" : ""}\n${rendered.text}${example}`);
         }
@@ -193,6 +211,9 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
     return { messages: rebuilt };
+    } catch (e) {
+      logThrow("context", e, { sid, phase: "transform" });
+      throw e;
     } finally {
       release();
     }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,15 +1,18 @@
-import { promises as fs } from "node:fs";
+import { appendFileSync, mkdirSync, statSync, renameSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";
 
-const ENV_DEBUG = process.env.ACP_DEBUG === "1" || process.env.ACP_DEBUG === "true";
-const LOG_FILE = process.env.ACP_LOG_FILE ?? path.join(homedir(), ".pi", "acp-debug.log");
+const MAX_BYTES = 10 * 1024 * 1024;
+
+const ENV_DEBUG =
+  process.env.ACP_DEBUG === "1" || process.env.ACP_DEBUG === "true";
+
+function resolveLogFile(): string {
+  return process.env.ACP_LOG_FILE ?? path.join(homedir(), ".pi", "acp.log");
+}
 
 let runtimeDebug: boolean | null = null;
-let initialized = false;
 
-/** Toggle debug at runtime from config (config.debug takes precedence over the
- *  env var when set). Called once during session_start. */
 export function setDebugEnabled(enabled: boolean): void {
   runtimeDebug = enabled;
 }
@@ -18,13 +21,65 @@ function debugOn(): boolean {
   return runtimeDebug ?? ENV_DEBUG;
 }
 
-async function write(line: string): Promise<void> {
-  if (!debugOn()) return;
-  if (!initialized) {
-    initialized = true;
-    await fs.mkdir(path.dirname(LOG_FILE), { recursive: true }).catch(() => {});
+function fmt(v: unknown): string {
+  if (typeof v === "string") return v;
+  if (v instanceof Error) return v.stack || String(v);
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
   }
-  await fs.appendFile(LOG_FILE, line, "utf8").catch(() => {});
+}
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+function writeLine(level: string, scope: string, fields: Record<string, unknown>): void {
+  const file = resolveLogFile();
+  try {
+    if (existsSync(file) && statSync(file).size >= MAX_BYTES) {
+      renameSync(file, file + ".old");
+    }
+  } catch {
+  }
+  const body = Object.keys(fields)
+    .map((k) => `${k}=${fmt(fields[k])}`)
+    .join(" ");
+  const line = `${ts()} [${level}] [${scope}] ${body}\n`;
+  try {
+    mkdirSync(path.dirname(file), { recursive: true });
+    appendFileSync(file, line);
+  } catch {
+  }
+}
+
+export type LogLevel = "error" | "warn" | "info" | "debug";
+
+export function closeLogStream(): void {
+}
+
+export function logError(scope: string, fields: Record<string, unknown>): void {
+  writeLine("error", scope, fields);
+}
+
+export function logWarn(scope: string, fields: Record<string, unknown>): void {
+  writeLine("warn", scope, fields);
+}
+
+export function logInfo(scope: string, fields: Record<string, unknown>): void {
+  writeLine("info", scope, fields);
+}
+
+export function logThrow(scope: string, err: unknown, extra: Record<string, unknown> = {}): void {
+  const fields: Record<string, unknown> = { ...extra };
+  if (err instanceof Error) {
+    fields.error = err.message;
+    fields.stack = err.stack ?? "";
+  } else {
+    fields.error = String(err);
+  }
+  writeLine("error", scope, fields);
 }
 
 export const debug = {
@@ -32,33 +87,18 @@ export const debug = {
     return debugOn();
   },
   get logFile(): string {
-    return LOG_FILE;
+    return resolveLogFile();
   },
   event(scope: string, fields: Record<string, unknown>): void {
-    if (!debugOn()) return;
-    const ts = new Date().toISOString();
-    const body = Object.entries(fields)
-      .map(([k, v]) => `${k}=${fmt(v)}`)
-      .join(" ");
-    void write(`${ts} [${scope}] ${body}\n`);
+    if (debugOn()) writeLine("debug", scope, fields);
   },
 };
 
-function fmt(v: unknown): string {
-  if (typeof v === "string") return v;
-  if (Array.isArray(v)) {
-    try {
-      return JSON.stringify(v);
-    } catch {
-      return `[${v.length}]`;
-    }
-  }
-  if (v && typeof v === "object") {
-    try {
-      return JSON.stringify(v);
-    } catch {
-      return String(v);
-    }
-  }
-  return String(v);
-}
+export const logger = {
+  error: logError,
+  warn: logWarn,
+  info: logInfo,
+  debug(scope: string, fields: Record<string, unknown>): void {
+    debug.event(scope, fields);
+  },
+};

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendi
 import { searchBlocks, type SearchResult } from "acp-kernel";
 import type { AcpRuntime } from "./runtime.js";
 import { buildSearchDocs } from "./search-index.js";
+import { logThrow } from "./log.js";
 
 const SearchParams = Type.Object({
     query: Type.String({ description: "Keywords to locate detail folded into compressed summaries or historical messages." }),
@@ -25,7 +26,13 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
         ],
         parameters: SearchParams,
         async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-            const result = await handleSearch(params as SearchArgs, runtime, ctx);
+            let result: string;
+            try {
+                result = await handleSearch(params as SearchArgs, runtime, ctx);
+            } catch (e) {
+                logThrow("search", e, { sid: ctx.sessionManager.getSessionId(), query: (params as SearchArgs).query });
+                throw e;
+            }
             return { details: undefined, content: [{ type: "text", text: result }] };
         },
     };

--- a/src/setup-subagent-tools.ts
+++ b/src/setup-subagent-tools.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, stat, copyFile, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { debug } from "./log.js";
+import { debug, logError, logWarn } from "./log.js";
 
 const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
 
@@ -141,9 +141,13 @@ export async function runSetupAndNotify(notify?: (msg: string) => void): Promise
     if (result.action === "updated" && notify) {
       notify(`ACP: enabled context tools (compress/decompress/search_context/acp_status) for subagents`);
     }
+    if (result.action === "failed") {
+      logWarn("setup", { event: "subagent-tools", action: result.action, reason: result.reason });
+    }
     return result;
   } catch (e) {
     debug.event("setup-subagent-tools-error", { msg: String(e) });
+    logError("setup", { event: "subagent-tools-error", error: e instanceof Error ? e.message : String(e), stack: e instanceof Error ? e.stack ?? "" : "" });
     return { path: "", action: "failed", reason: String(e) };
   }
 }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,14 +1,12 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { createInitialState, type CompressionState } from "acp-kernel";
+import { logError, logWarn } from "./log.js";
 
 const STATE_SUFFIX = ".acp.json";
 
 function stateFileFor(sessionFile: string | undefined): string | null {
   if (sessionFile) return sessionFile + STATE_SUFFIX;
-  // No session file (--no-session, e.g. delegate children): state is ephemeral,
-  // do NOT persist. Previously this fell back to process.cwd() and polluted
-  // the parent's working directory with .acp-<sid>.json litter.
   return null;
 }
 
@@ -25,8 +23,11 @@ export class SessionStateStore {
         const raw = await fs.readFile(file, "utf8");
         const parsed = JSON.parse(raw) as CompressionState;
         if (parsed && Array.isArray(parsed.blocks)) state = mergeInitialState(parsed);
-      } catch {
-        // missing/corrupt file -> fresh state
+      } catch (e) {
+        const code = (e as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") {
+          logWarn("state", { event: "load-failed", file, error: e instanceof Error ? e.message : String(e) });
+        }
       }
     }
     this.cache = state;
@@ -36,14 +37,20 @@ export class SessionStateStore {
 
   async save(state: CompressionState, sessionFile: string | undefined, _sessionId: string): Promise<void> {
     const file = stateFileFor(sessionFile);
-    if (!file) return; // ephemeral session: don't persist
+    if (!file) return;
     this.cache = state;
     this.loadedKey = file;
     const dir = path.dirname(file);
-    await fs.mkdir(dir, { recursive: true }).catch(() => {});
+    await fs.mkdir(dir, { recursive: true }).catch((e: unknown) => {
+      logError("state", { event: "save-mkdir-failed", dir, error: e instanceof Error ? e.message : String(e) });
+    });
     const tmp = path.join(dir, `.acp-tmp-${path.basename(file)}`);
-    await fs.writeFile(tmp, JSON.stringify(state), "utf8");
-    await fs.rename(tmp, file);
+    try {
+      await fs.writeFile(tmp, JSON.stringify(state), "utf8");
+      await fs.rename(tmp, file);
+    } catch (e) {
+      logError("state", { event: "save-failed", file, error: e instanceof Error ? e.message : String(e) });
+    }
   }
 
   invalidate(): void {

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendi
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
+import { logThrow } from "./log.js";
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -28,7 +29,13 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
     ],
     parameters: StatusParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-      const result = await handleStatus(params as StatusArgs, runtime, ctx);
+      let result: string;
+      try {
+        result = await handleStatus(params as StatusArgs, runtime, ctx);
+      } catch (e) {
+        logThrow("status", e, { sid: ctx.sessionManager.getSessionId(), scope: (params as StatusArgs).scope ?? null });
+        throw e;
+      }
       return { details: undefined, content: [{ type: "text", text: result }] };
     },
   };

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -4,7 +4,7 @@ import {
   type ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
 import { DEFAULT_TOOL_BASH_TIMEOUT, DEFAULT_TOOL_OUTPUT_MAX_BYTES } from "./config.js";
-import { debug } from "./log.js";
+import { debug, logInfo, logWarn } from "./log.js";
 import type { AcpRuntime } from "./runtime.js";
 
 // Vendored locally rather than imported: pi exports isBashToolResult, but omp's
@@ -132,12 +132,14 @@ export function wireToolGuardrails(pi: ExtensionAPI, runtime: AcpRuntime): void 
       if (next) {
         modified = next;
         debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
+        logWarn("guardrail", { event: "output-cap", max, hadPath: !!fullPath });
       }
     }
 
     if (timeoutSecs !== undefined) {
       modified = appendTimeoutNotice(modified ?? event.content, timeoutSecs);
       debug.event("guardrail-bash-timeout-notice", { secs: timeoutSecs });
+      logInfo("guardrail", { event: "bash-timeout-notice", secs: timeoutSecs });
     }
 
     if (modified) return { content: modified };

--- a/src/update.ts
+++ b/src/update.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
-import { debug } from "./log.js";
+import { debug, logInfo, logWarn } from "./log.js";
 
 declare const CURRENT_VERSION: string;
 
@@ -138,32 +138,38 @@ export async function checkForUpdate(
       signal: AbortSignal.timeout(5000),
       headers: { Accept: "application/json" },
     });
-    if (!res.ok) return;
+    if (!res.ok) {
+      logWarn("update", { event: "check-http", status: res.status });
+      return;
+    }
     const data = (await res.json()) as { version?: string };
     const latest = data.version;
     if (!latest) return;
 
     const current = runtimeVersion ?? CURRENT_VERSION;
+    const hasUpdate = isNewer(latest, current);
     debug.event("update-check", {
       current,
       latest,
-      hasUpdate: isNewer(latest, current),
+      hasUpdate,
     });
+    logInfo("update", { event: "check", current, latest, hasUpdate });
 
-    if (isNewer(latest, current)) {
+    if (hasUpdate) {
       const installed = await autoInstallLatest(latest);
       if (installed && notify) {
         notify(
           `\x1b[32m\u2714 ACP auto-updated ${current} \u2192 ${latest}. Restart Pi to finish.\x1b[0m`,
         );
+        logInfo("update", { event: "auto-installed", from: current, to: latest });
       } else if (!installed && notify) {
         notify(
           `${PACKAGE_NAME} ${latest} available (you have ${current}). Run: pi update --extension npm:${PACKAGE_NAME}`,
         );
       }
     }
-  } catch {
-    // network error, registry down, timeout — silent
+  } catch (e) {
+    logWarn("update", { event: "check-error", error: e instanceof Error ? e.message : String(e) });
   } finally {
     updateInFlight = false;
   }

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { homedir } from "node:os";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import type { AdapterConfig } from "./config.js";
-import { debug } from "./log.js";
+import { debug, logWarn } from "./log.js";
 
 /** User-facing config keys (subset of AdapterConfig). Loaded from
  *  ~/.<CONFIG_DIR_NAME>/acp.json (global) and <cwd>/.<CONFIG_DIR_NAME>/acp.json
@@ -31,8 +31,11 @@ export async function loadUserConfig(cwd: string): Promise<UserAcpConfig> {
         Object.assign(merged, pickKnown(parsed));
         debug.event("config-loaded", { file });
       }
-    } catch {
-      // missing or unreadable — skip
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        logWarn("config", { event: "load-failed", file, error: e instanceof Error ? e.message : String(e) });
+      }
     }
   }
   return merged;

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -1,0 +1,97 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile, rm, mkdir, writeFile, stat } from "node:fs/promises";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+
+async function freshLog(): Promise<string> {
+  const dir = await mkdir(path.join(tmpdir(), `acp-log-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`), { recursive: true });
+  return path.join(dir, "acp.log");
+}
+
+async function loadLogger(file: string) {
+  process.env.ACP_LOG_FILE = file;
+  process.env.ACP_DEBUG = "";
+  const mod = await import(`../src/log.js?t=${Date.now()}-${Math.random()}`);
+  return mod;
+}
+
+test("error/warn/info are written when debug is OFF (always-on)", async () => {
+  const file = await freshLog();
+  const log = await loadLogger(file);
+  log.setDebugEnabled(false);
+  log.logError("scope-a", { event: "boom", detail: "x" });
+  log.logWarn("scope-b", { event: "careful" });
+  log.logInfo("scope-c", { event: "started", sid: "s1" });
+  log.closeLogStream();
+  const content = await readFile(file, "utf8");
+  assert.match(content, /\[error\] \[scope-a\] event=boom detail=x/);
+  assert.match(content, /\[warn\] \[scope-b\] event=careful/);
+  assert.match(content, /\[info\] \[scope-c\] event=started sid=s1/);
+  await rm(path.dirname(file), { recursive: true, force: true });
+});
+
+test("debug.event is NOT written when debug is OFF", async () => {
+  const file = await freshLog();
+  const log = await loadLogger(file);
+  log.setDebugEnabled(false);
+  log.debug.event("verbose", { k: "v" });
+  log.closeLogStream();
+  const content = await readFile(file, "utf8").catch((e: NodeJS.ErrnoException) => {
+    if (e.code === "ENOENT") return "";
+    throw e;
+  });
+  assert.equal(content, "", "no debug output when debug is off");
+  await rm(path.dirname(file), { recursive: true, force: true });
+});
+
+test("debug.event IS written when debug is ON", async () => {
+  const file = await freshLog();
+  const log = await loadLogger(file);
+  log.setDebugEnabled(true);
+  log.debug.event("verbose", { k: "v" });
+  log.closeLogStream();
+  const content = await readFile(file, "utf8");
+  assert.match(content, /\[debug\] \[verbose\] k=v/);
+  await rm(path.dirname(file), { recursive: true, force: true });
+});
+
+test("logThrow records message and stack as error", async () => {
+  const file = await freshLog();
+  const log = await loadLogger(file);
+  log.setDebugEnabled(false);
+  const err = new Error("kaboom");
+  log.logThrow("transform", err, { sid: "s9", phase: "ctx" });
+  log.closeLogStream();
+  const content = await readFile(file, "utf8");
+  assert.match(content, /\[error\] \[transform\] sid=s9 phase=ctx error=kaboom stack=/);
+  assert.match(content, /kaboom/);
+  await rm(path.dirname(file), { recursive: true, force: true });
+});
+
+test("log lines carry ISO timestamp, level and scope", async () => {
+  const file = await freshLog();
+  const log = await loadLogger(file);
+  log.setDebugEnabled(false);
+  log.logInfo("session", { event: "start" });
+  log.closeLogStream();
+  const content = await readFile(file, "utf8");
+  const line = content.trim();
+  const prefix = line.split(" [")[0];
+  assert.ok(!Number.isNaN(Date.parse(prefix)), `timestamp parses as date: ${prefix}`);
+  await rm(path.dirname(file), { recursive: true, force: true });
+});
+
+test("rotation renames oversized file to .old", async () => {
+  const dir = path.join(tmpdir(), `acp-log-rot-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`);
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, "acp.log");
+  await writeFile(file, "x".repeat(11 * 1024 * 1024));
+  const log = await loadLogger(file);
+  log.setDebugEnabled(false);
+  log.logInfo("rotate", { event: "post-size" });
+  log.closeLogStream();
+  const oldStat = await stat(file + ".old").catch(() => null);
+  assert.ok(oldStat, "rotated .old file should exist");
+  await rm(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION

## Problem

Previously **every** log line was gated behind the `debug` flag. In normal (non-debug) runs nothing was recorded — not even errors — making field diagnosis nearly impossible.

## Change

Rewrite `src/log.ts` as a **leveled logger** (modeled on `billion-context/src/logger.ts`):

| Level | When written |
|-------|-------------|
| `error` / `warn` / `info` | **always** (even with `debug: false`) |
| `debug` | only when `debug: true` |

- Default file `~/.pi/acp.log` (was `acp-debug.log` — semantics changed to always-on). Override with `ACP_LOG_FILE`.
- Single file, 10 MB rotation (→ `.old`), **synchronous writes** so error lines survive a crash.
- Line format: `<ISO ts> [<level>] [<scope>] k=v k=v`.
- New `logError` / `logWarn` / `logInfo` / `logThrow` (auto message+stack); `debug.event` kept for backwards compat.

## Always-on coverage across the model's whole working period

- `index.ts` — session start/shutdown, per-turn context transform summary (tokens/pct/nudge/blocks), emergency nudge, full transform `try/catch + logThrow`.
- `compress-tool.ts` — compress applied + errors/warnings detail + `logThrow`.
- `decompress-tool.ts` — block/message (inline/file) + path rejection + `logThrow`.
- `search-tool.ts` / `status-tool.ts` — `try/catch + logThrow`.
- `delegate-tool.ts` — spawn/done (info), every `*-error` site (error), inject-skipped (warn).
- `setup-subagent-tools.ts` — failed result (warn), thrown (error).
- `tool-guardrails.ts` — output cap (warn), bash timeout notice (info).
- `update.ts` — http/check/auto-install (info), errors (warn).
- `user-config.ts` — corrupt/unreadable config (warn); ENOENT stays silent.
- `state.ts` — load/save failures (warn/error).

## Tests

New `tests/log.test.ts` (6 cases): always-on error/warn/info, debug gated on/off, `logThrow` message+stack, ISO timestamp, 10 MB rotation.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ — 93 tests pass (incl. 6 new)
- `npm run build` ✅

## Viewing the log

```sh
tail -f ~/.pi/acp.log            # watch the session live
grep '[error]' ~/.pi/acp.log    # surface every recorded failure
```