### PR TITLE
release v0.1.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.28",
+	"version": "0.1.29",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.28",
+			"version": "0.1.29",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^26.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.28",
+	"version": "0.1.29",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release branch for **v0.1.29**.

## What's in this release

Ships the crash fix from #98 (merged to master after the 0.1.28 cut, so **published 0.1.28 does NOT contain it** — this release lands it on npm):

- **fix(messages): drop empty assistant turns to avoid provider 400 / crash loop** (#98, closes #13)
  - Root cause of the \"pi 版本崩溃问题\": thinking-only / aborted assistant turns were projected to `{role:"assistant", text:""}`, which GLM (OpenAI-compatible) rejects with HTTP 400 (no body). Pi then misreads the 400 as context overflow and triggers a doomed auto-compaction (second 400), forming a self-reinforcing crash loop.
  - Fix: drop assistant turns with no text and no tool calls instead of emitting empty text. Verified: 42 such turns in the affected session.
  - acp-kernel unchanged (still 0.0.17) — bug was entirely in the adapter.

Plus everything else already on master since 0.1.28 (token-calibration, delegate-activity-stream, compress blockIds).

## Release commit

Bumps `package.json` `0.1.28 → 0.1.29`. `acp-kernel` stays `0.0.17` (no kernel change this cycle, so only the one version line — same shape as the `release v0.1.28` commit). `package-lock.json` refreshed.

## Pre-flight (all green)

- `npm run typecheck` ✅
- `npm test` → **113/113 pass**
- `npm run build` ✅ (dist 400.09 KB)

Merge → CI auto-publishes. (PR merge is human-only, per AGENTS.md §4.)