### PR TITLE
fix(windows): findNpmRoot infinite loop + test timing/path-separator

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -64,13 +64,14 @@ async function readPackageJson(path: string): Promise<PackageJson | undefined> {
   }
 }
 
-function findNpmRoot(extDir: string): string | undefined {
+export function findNpmRoot(extDir: string): string | undefined {
   let dir = dirname(extDir);
-  while (dir !== "/" && dir !== ".") {
+  for (;;) {
     if (dir.endsWith("node_modules")) return dirname(dir);
-    dir = dirname(dir);
+    const parent = dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
   }
-  return undefined;
 }
 
 async function findExtensionDir(): Promise<string | undefined> {

--- a/tests/decompress-tool.test.ts
+++ b/tests/decompress-tool.test.ts
@@ -80,7 +80,7 @@ test("decompress default writes content to an auto-generated file (no context bl
   const text = (res.content[0] as any).text as string;
 
   assert.match(text, /written to/, "result reports a file path");
-  assert.match(text, /acp-decompress\/b1-\d+\.txt/, "auto-generated path under ~/.cache/pi/acp-decompress");
+  assert.match(text, /acp-decompress[\\/]b1-\d+\.txt/, "auto-generated path under ~/.cache/pi/acp-decompress");
   assert.match(text, /stays compressed/, "tells model the block stays compressed");
   assert.match(text, /Preview:/, "includes a head preview");
   // Crucially: the full long content is NOT in the tool result (it's in the file).

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { checkForUpdate } from "../src/update.js";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { checkForUpdate, findNpmRoot } from "../src/update.js";
 
 // Opt-out must short-circuit BEFORE any network/filesystem touch. We assert this
 // by making global fetch throw if it is ever reached.
@@ -34,4 +36,13 @@ test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matc
     await withFetchGuard(() => checkForUpdate(true));
   }
   delete process.env.ACP_AUTO_UPDATE;
+});
+
+test("findNpmRoot locates the package root when nested under node_modules", () => {
+  const ext = join(homedir(), "x", "node_modules", "billion-context-pi");
+  assert.equal(findNpmRoot(ext), join(homedir(), "x"));
+});
+
+test("findNpmRoot terminates when no node_modules ancestor exists (no Windows infinite loop)", { timeout: 2000 }, () => {
+  assert.equal(findNpmRoot(homedir()), undefined);
 });

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -71,9 +71,9 @@ test("idle watchdog escalates to SIGKILL when the child ignores SIGTERM", async 
 });
 
 test("poke resets the idle timer (continuous output never triggers)", async () => {
-  const h = setup({ idleMs: 25 });
+  const h = setup({ idleMs: 200 });
   for (let i = 0; i < 10; i++) {
-    await sleep(15);
+    await sleep(50);
     h.watchdog.poke();
   }
   assert.equal(h.kills.length, 0, "no kill while output keeps flowing");


### PR DESCRIPTION
Tested billion-context-pi on a Windows 10 VM (Node 22, Pi 0.84.1). `typecheck` and `build` pass clean; 117/119 tests pass. The 2 failing tests and a latent auto-update bug are fixed here.

## 1. `src/update.ts` — findNpmRoot infinite loop on Windows (product bug)

`findNpmRoot` walked up the dir tree with a POSIX-only termination guard `while (dir !== "/" && dir !== ".")`. On Windows the drive root (`C:\`) is a `dirname` fixed point (`path.dirname("C:\\") === "C:\\"`) that never matches `"/"`, so when the extension lived **outside** a `node_modules` dir the loop spun forever, hanging the auto-update check.

Reproduced on the VM:
- `pi install npm:billion-context-pi` (under node_modules) → returns in 1 iteration — safe, which is why auto-update worked for the normal install (it auto-upgraded 0.1.27 → 0.1.29 during testing).
- `pi install ./local-source` / a source tree (no node_modules ancestor) → **infinite loop**, stuck at `C:\`.

Fix: terminate on the `dirname === dir` fixed point instead of the POSIX root. Works on every platform. `findNpmRoot` is now exported and covered by two regression tests (termination + node_modules discovery).

## 2. `tests/watchdog.test.ts` — poke test timing (test fix)

`poke resets the idle timer` poked every 15ms against `idleMs: 25` — a 10ms margin too tight for Windows' ~15.6ms `setTimeout` granularity, so `sleep(15)` could slip past the idle timer and the test saw spurious kills (2 on the VM). Widened to `idleMs: 200`, poke every 50ms. The watchdog code itself (`src/delegate-watchdog.ts` `poke()`) is correct.

## 3. `tests/decompress-tool.test.ts` — path separator (test fix)

The auto-generated path assertion matched only forward slashes (`/acp-decompress\/b1-\d+\.txt/`). Windows `path.join` produces backslashes, so the regex failed even though the file write worked. Now accepts both separators (`[\\/]`).

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ 115/115 (host Linux), incl. the 2 new findNpmRoot regression tests
- On the Windows VM: the 2 originally-failing tests now pass with these changes; auto-update was empirically confirmed working (installed 0.1.27 auto-upgraded to 0.1.29).
