### PR TITLE
release v0.1.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.29",
+	"version": "0.1.30",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.29",
+			"version": "0.1.30",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.29",
+	"version": "0.1.30",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/tests/user-config.test.ts
+++ b/tests/user-config.test.ts
@@ -1,4 +1,4 @@
-import { test } from "node:test";
+import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
@@ -15,6 +15,20 @@ async function writeConfig(dir: string, data: object): Promise<string> {
   await fs.writeFile(filePath, JSON.stringify(data), "utf8");
   return filePath;
 }
+
+let savedHome: string | undefined;
+let hookHome: string;
+
+before(async () => {
+  savedHome = process.env.HOME;
+  hookHome = await fs.mkdtemp(path.join(os.tmpdir(), "acp-home-"));
+  process.env.HOME = hookHome;
+});
+
+after(async () => {
+  process.env.HOME = savedHome;
+  await fs.rm(hookHome, { recursive: true, force: true });
+});
 
 test("loadUserConfig returns empty object when no config files exist", async () => {
   const cwd = path.join(os.tmpdir(), `acp-test-${Date.now()}`);


### PR DESCRIPTION
## Release v0.1.30

Incremental release on top of v0.1.29, shipping the merged features:
- **omp compat layer** (#102) — supports string[] system prompts / OMP host
- **e2e docker regression suite** (#103)
- **always-on logging** (#99, already in v0.1.29) — errors/warnings/lifecycle events log even when `debug` is off

### Version bump
- `billion-context-pi`: `0.1.29` → `0.1.30`
- `acp-kernel`: stays at `0.0.17` (already latest on npm; no kernel release needed this round)

### Bonus: test-hygiene fix (prereq commit)
While preparing this release I found the local pre-flight failed because `~/.pi/acp.json` (with `{debug:true}`) leaked into `tests/user-config.test.ts`. The earlier isolation in c797aad only covered 2 explicit "global config" tests; the other `loadUserConfig` tests still read the real global config. Added a file-level `before`/`after` hook that isolates `HOME` to an empty temp dir for the whole suite, so all tests are now deterministic regardless of the machine's `~/.pi/acp.json`. Verified: 150 tests pass with real `~/.pi/acp.json` present.

### Pre-flight
- `npm run typecheck` ✅
- `npm test` ✅ (150 pass / 0 fail)
- `npm run build` ✅ (dist 408 KB)

### Commits
1. `test: isolate HOME for all user-config tests`
2. `release v0.1.30`

⚠️ Merge is human-only (AGENTS.md §4). On merge, CI auto-publishes `0.1.30` to npm.