### PR TITLE
fix(messages): honor kernel body mutations in back-conversion (emergency truncate)

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -225,6 +225,18 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
   // previous responses and echoes them, causing visible tag fragments in the terminal.
   // The model can still reference assistant messages by inferring refs from context.
   if (base.role === "assistant") return original;
+  // Honor kernel body mutations (emergency truncation of large tool-results,
+  // future rewrites): if core.text's body differs from the original text,
+  // rebuild from the kernel body — otherwise truncation never reaches the model.
+  const tagCore = tag.replace(/\s+$/, "");
+  let bodyStart = tagCore.length;
+  if (core.text && core.text.charAt(bodyStart) === "\n") bodyStart += 1;
+  const coreBody = core.text ? core.text.slice(bodyStart) : "";
+  const originalBody = extractText(base.content);
+  const trimEnd = (s: string): string => s.replace(/\s+$/, "");
+  if (coreBody && trimEnd(coreBody) !== trimEnd(originalBody)) {
+    return rebuildBodyFromCore(original, coreBody, tag);
+  }
   const rawBlocks = Array.isArray(base.content)
     ? base.content
     : typeof base.content === "string"
@@ -251,6 +263,26 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
     ...(original as object),
     content: [...peeled, { type: "text" as const, text: tag }],
   } as AgentMessage;
+}
+
+function rebuildBodyFromCore(
+  original: AgentMessage,
+  coreBody: string,
+  tag: string,
+): AgentMessage {
+  const base = original as AnyMessage;
+  const text = `${coreBody.replace(/\s+$/, "")}\n\n${tag}`;
+  if (typeof base.content === "string") {
+    return { ...(original as object), content: text } as AgentMessage;
+  }
+  if (Array.isArray(base.content)) {
+    const nonText = base.content.filter((b) => (b as { type?: string }).type !== "text");
+    return {
+      ...(original as object),
+      content: [...nonText, { type: "text" as const, text }],
+    } as AgentMessage;
+  }
+  return { ...(original as object), content: [{ type: "text" as const, text }] } as AgentMessage;
 }
 
 function peelRefTagBlocks(blocks: unknown[]): unknown[] {

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -291,6 +291,69 @@ test("coreOutToAgentMessages patches the ref tag onto original messages", () => 
   assert.equal(content.length, 1, "tag embedded in single text block, not separate");
 });
 
+test("coreOutToAgentMessages honors kernel-truncated body instead of original (emergency truncate)", () => {
+  const tag = acpRef("m00002", "13K", "tool:bash") + "\n";
+  const full = "X".repeat(50000);
+  const truncatedBody = "PREFIX".repeat(100) + "\n\n...[truncated for context space]...\n\nSUFFIX";
+  const original = msgEntry("t", toolResult("tc1", "bash", full)).message;
+  const originalById = new Map([["t", original]]);
+  const coreOut: CoreMessage[] = [
+    { id: "t", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc1", text: tag + truncatedBody },
+  ];
+
+  const out = coreOutToAgentMessages(coreOut, originalById);
+  const msg = out[0] as { role: string; toolCallId: string; toolName: string; content: Array<{ type: string; text: string }> };
+  assert.equal(msg.role, "toolResult", "role preserved");
+  assert.equal(msg.toolCallId, "tc1", "toolCallId preserved");
+  const text = msg.content.find((b) => b.type === "text")!.text;
+  assert.ok(text.includes("[truncated for context space]"), "truncation marker present in rebuilt body");
+  assert.ok(!text.includes("X".repeat(100)), "full original body not emitted");
+  assert.ok(text.includes("m00002"), "ref tag preserved");
+  assert.ok(text.length < full.length, "body is shorter than original");
+});
+
+test("coreOutToAgentMessages does NOT rebuild when non-truncated body starts with newlines (no false positive)", () => {
+  const tag = acpRef("m00003", "2", "tool:bash") + "\n";
+  const body = "\n\nbash output line";
+  const original = msgEntry("n", toolResult("tc3", "bash", body)).message;
+  const originalById = new Map([["n", original]]);
+  const coreOut: CoreMessage[] = [
+    { id: "n", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc3", text: tag + body },
+  ];
+
+  const out = coreOutToAgentMessages(coreOut, originalById);
+  const text = (out[0] as { content: Array<{ type: string; text: string }> }).content.find((b) => b.type === "text")!.text;
+  assert.ok(text.startsWith("\n\nbash output line"), "leading newlines preserved (no false rebuild)");
+  assert.ok(!text.includes("[truncated"), "no truncation marker on non-truncated message");
+  assert.ok(text.includes("m00003"), "ref tag still appended");
+});
+
+test("coreOutToAgentMessages honors kernel-truncated body for string-content tool results", () => {
+  const tag = acpRef("m00004", "13K", "tool:bash") + "\n";
+  const full = "Y".repeat(40000);
+  const truncatedBody = "PRE".repeat(80) + "\n\n...[truncated for context space]...\n\nEND";
+  const original = {
+    role: "toolResult",
+    toolCallId: "tc4",
+    toolName: "bash",
+    content: full,
+    isError: false,
+    timestamp: Date.now(),
+  };
+  const originalById = new Map([["s", original as SessionMessageEntry["message"]]]);
+  const coreOut: CoreMessage[] = [
+    { id: "s", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "tc4", text: tag + truncatedBody },
+  ];
+
+  const out = coreOutToAgentMessages(coreOut, originalById);
+  const msg = out[0] as { role: string; content: string };
+  assert.equal(msg.role, "toolResult");
+  assert.equal(typeof msg.content, "string", "string content preserved as string");
+  assert.ok(msg.content.includes("[truncated for context space]"), "truncated body present");
+  assert.ok(!msg.content.includes("Y".repeat(100)), "full original not emitted");
+  assert.ok(msg.content.includes("m00004"), "ref tag preserved");
+});
+
 test("coreOutToAgentMessages returns original unchanged when no ref tag is present", () => {
   const original = msgEntry("a", user("hello")).message;
   const originalById = new Map([["a", original]]);


### PR DESCRIPTION
## Problem

When the conversation approaches the context ceiling, `acp-kernel`'s `emergencyTruncateNode` **correctly** rewrites large tool-result bodies in `core.text` (prefix + `[truncated for context space]` marker + suffix). But Pi never received the truncation: `coreOutToAgentMessages` / `patchRefTag` rebuilt **every** message body from the **original** content and only lifted the ref-tag out of `core.text`. The truncated body was silently discarded.

**Symptoms:** oversized requests kept being sent; the provider aborted near the context ceiling (the `bcp-issue-emergency-truncate.md` repro — 9 large `cat` tool-outputs, usage climbs past 100% with zero relief, no `[truncated…]` markers ever reach the model or the session log).

## Root cause

`src/messages.ts` `patchRefTag` reads `core.text` only to extract the ref-tag, then reconstructs the body entirely from `original.content`. It never honors a body mutation made by the kernel.

## Fix

`patchRefTag` now compares `core.text`'s body (ref-tag stripped) against the original message text. When they differ — i.e. the kernel rewrote the body (emergency truncation today; future rewrites too) — it rebuilds the message from the **kernel body**, preserving role / toolCallId / toolName and non-text blocks, and re-appends the ref-tag (Pi end-of-text convention). Non-truncated messages (bodies equal) take the existing path unchanged.

acp-kernel is innocent — verified by E2E: `entriesToCoreMessages → core.processTurn → coreOutToAgentMessages` showed 7 truncation markers in the core-out and **0** in the rebuilt messages before this fix.

This also unblocks the related opencode-acp#288 fix path: `patchRefTag` was a meta-blocker that would have discarded any future kernel-side tool-result rewrite too.

## Test

New regression test `coreOutToAgentMessages honors kernel-truncated body instead of original (emergency truncate)` in `tests/messages.test.ts`: feeds a truncated `core.text` + full original tool-result, asserts the rebuilt message carries the `[truncated…]` marker, omits the original body, preserves role/toolCallId and the ref-tag, and is shorter than the original.

## Verification
- `npm run typecheck` ✅
- `npm test` → 151 pass ✅
- `npm run build` ✅ (409 KB)