### PR TITLE
release v0.1.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.30",
+	"version": "0.1.31",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.30",
+			"version": "0.1.31",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.30",
+	"version": "0.1.31",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.31 (patch).

## Since v0.1.30

- **PR #107** `fix(messages): honor kernel body mutations in back-conversion (emergency truncate)` — `patchRefTag` was discarding `emergencyTruncateNode` body edits on large tool-results, so oversized content still hit the model and provider aborted near ~90% usage. Now honors `core.text` body mutations. Includes the dual-agent-review MEDIUM fix: strip only tag + one separator newline (was greedily over-stripping, false-positive rebuild on bodies with leading newlines).

## Changes

- `package.json`: `version` 0.1.30 → 0.1.31
- `package-lock.json`: version bump (auto)
- acp-kernel unchanged (0.0.17)

## Pre-flight

- `npm run typecheck` ✅
- `npm test` → 153 pass ✅
- `npm run build` ✅ (419 KB)

Merge to trigger CI auto-publish. 🤖 This PR is human-merge-only.