### PR TITLE
fix: address omp long-session test findings (ISSUE-1/2/5/9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 *.acp.json
 .pi-subagents/
 tmp-debug.ts
+.awork/

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -5,7 +5,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { debug, logError, logInfo, logThrow } from "./log.js";
+import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 
 function formatK(n: number): string {
@@ -83,7 +83,11 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   await runtime.save(applied.state, ctx);
   const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
 
-  const afterTokens = Math.max(0, beforeTokens - tokensCompressed);
+  // Re-measure (not subtract): beforeTokens excludes covered msgs but
+  // tokensCompressed sums raw range sizes — different denominators, so a
+  // subtraction can go negative and clamp to 0 when most context is compressed.
+  const afterTokens = estimateTokens(coreMessages, collectCoveredMessageIds(applied.state));
+  const reclaimed = Math.max(0, beforeTokens - afterTokens);
 
   const newBlocks = applied.state.blocks.slice(-blocksCreated);
   debug.event("compress-out", {
@@ -116,10 +120,10 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "errors", count: errors.length, errors: errors.slice(0, 5) });
   }
   if (warnings.length > 0) {
-    logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
+    logWarn("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
   }
 
-  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(tokensCompressed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
+  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(reclaimed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
   if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
   if (errors.length > 0) lines.push("Errors: " + errors.join("; "));
   return lines.join("\n");

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -126,6 +126,16 @@ export function runningRunsSnapshot(): { runId: string; agent: string; task: str
 const WAIT_TIMEOUT_MS_DEFAULT = 10_000;
 const WAIT_TIMEOUT_MS_MAX = 300_000;
 
+/** Resolve a wait timeout to ms. Agents frequently pass seconds (e.g. 180)
+ *  instead of milliseconds; values below the 1s floor make no sense as a wait
+ *  duration, so rescale them to seconds before clamping — otherwise 180 clamps
+ *  to 1000ms and the wait times out in 1s. */
+export function resolveWaitTimeoutMs(raw: number | undefined): number {
+  if (raw === undefined) return WAIT_TIMEOUT_MS_DEFAULT;
+  const ms = raw < 1_000 ? raw * 1_000 : raw;
+  return Math.min(Math.max(ms, 1_000), WAIT_TIMEOUT_MS_MAX);
+}
+
 const DelegateParams = Type.Object({
   agent: Type.String({
     description: `Role of the delegate. One of: ${AGENT_NAMES.join(", ")}. See tool description for what each does.`,
@@ -161,7 +171,7 @@ const WaitParams = Type.Object({
   runId: Type.String({ description: "The runId returned by acp_delegate to wait for." }),
   timeout: Type.Optional(
     Type.Integer({
-      description: `Maximum milliseconds to block waiting for the result. Default ${WAIT_TIMEOUT_MS_DEFAULT} (10s); max ${WAIT_TIMEOUT_MS_MAX} (300s). If the delegate does not finish in time, returns "failed (not ready)" — do NOT keep waiting or retry; go do other work, and a completion notification will still be injected when it completes.`,
+      description: `Maximum time to block waiting for the result, in milliseconds. Default ${WAIT_TIMEOUT_MS_DEFAULT} (10s); max ${WAIT_TIMEOUT_MS_MAX} (300s). Values below 1000 are treated as seconds (so 180 means 180s, not 180ms). If the delegate does not finish in time, returns "failed (not ready)" — do NOT keep waiting or retry; go do other work, and a completion notification will still be injected when it completes.`,
     }),
   ),
 });
@@ -286,10 +296,7 @@ export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof W
         }
         return { details: undefined, content: [{ type: "text", text: formatRunResult(run) }] };
       }
-      const timeoutMs = Math.min(
-        Math.max(args.timeout ?? WAIT_TIMEOUT_MS_DEFAULT, 1_000),
-        WAIT_TIMEOUT_MS_MAX,
-      );
+      const timeoutMs = resolveWaitTimeoutMs(args.timeout);
       // Refuse to park a second waiter on the same run: a second wait would
       // overwrite run.waiter and orphan the first wait's listener/timer.
       if (run.waiter) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,11 +18,11 @@ import { coreOutToAgentMessages } from "./messages.js";
 import { ACP_SYSTEM_PROMPT, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
-import { debug, setDebugEnabled, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
+import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
-import { loadUserConfig, applyUserConfig } from "./user-config.js";
+
 import { formatSystemPromptForEvent } from "./compat.js";
 
 type AgentMessage = SessionMessageEntry["message"];
@@ -66,9 +66,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const sid = ctx.sessionManager.getSessionId();
     logInfo("session", { event: "start", sid, cwd: ctx.cwd, debug: runtime.adapter.debug ?? null, version: typeof CURRENT_VERSION !== "undefined" ? CURRENT_VERSION : null });
     try {
-      const user = await loadUserConfig(ctx.cwd);
-      runtime.setAdapter(applyUserConfig(runtime.adapter, user));
-      if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
+      await runtime.reloadConfig(ctx.cwd);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
     }
@@ -104,6 +102,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const sid = ctx.sessionManager.getSessionId();
     const release = await runtime.acquireLock(sid);
     try {
+      await runtime.reloadConfig(ctx.cwd);
       const { state, coreMessages, entries } = await runtime.stateFor(ctx, event.messages);
       const config = runtime.configFor(ctx);
       const coveredIds = collectCoveredMessageIds(state);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9,7 +9,8 @@ import {
 import { resolveConfig, type AdapterConfig } from "./config.js";
 import { entriesToCoreMessages } from "./messages.js";
 import { SessionStateStore } from "./state.js";
-import { logInfo, logWarn } from "./log.js";
+import { loadUserConfig, applyUserConfig } from "./user-config.js";
+import { logInfo, logWarn, setDebugEnabled } from "./log.js";
 
 // pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
 // `getBranch()`. Both return chronological SessionEntry[]; feature-detect so the
@@ -51,6 +52,10 @@ export interface AcpRuntime {
   clearNudgeTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
+  /** Re-read ~/.<dir>/acp.json + <cwd>/<dir>/acp.json and re-derive the adapter
+   *  config when the contents change. Cheap no-op when unchanged. Called at
+   *  session_start and on every context event so config edits apply live. */
+  reloadConfig(cwd: string): Promise<void>;
   stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
   save(state: CompressionState, ctx: ExtensionContext): Promise<void>;
   acquireLock(sid: string): Promise<() => void>;
@@ -114,7 +119,9 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const core = createCore({ countTokens: defaultCountTokens });
   const store = new SessionStateStore();
   const locks = new Map<string, Promise<void>>();
+  const factoryAdapter = adapter;
   let adapterRef = adapter;
+  let lastUserConfigKey: string | undefined;
   const nudgeShownTurns = new Set<string>();
 
   async function acquireLock(sid: string): Promise<() => void> {
@@ -144,6 +151,24 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     return resolveConfig(adapterRef, liveContextLimit(ctx));
   }
 
+  async function reloadConfig(cwd: string): Promise<void> {
+    let user;
+    try {
+      user = await loadUserConfig(cwd);
+    } catch (e) {
+      logWarn("runtime", { event: "config-reload-failed", error: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    const key = JSON.stringify(user);
+    if (key === lastUserConfigKey) return;
+    lastUserConfigKey = key;
+    // Re-derive from the factory config (not adapterRef) so a key REMOVED from
+    // acp.json actually reverts, instead of lingering from a prior apply.
+    adapterRef = applyUserConfig(factoryAdapter, user);
+    if (adapterRef.debug !== undefined) setDebugEnabled(adapterRef.debug);
+    logInfo("runtime", { event: "config-reloaded", limit: adapterRef.modelContextLimit ?? null });
+  }
+
   async function stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]) {
     const sm = ctx.sessionManager;
     const state = await store.load(sm.getSessionFile() ?? undefined, sm.getSessionId());
@@ -165,5 +190,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -41,7 +41,6 @@ export interface AcpRuntime {
   core: CompressionCore;
   store: SessionStateStore;
   adapter: AdapterConfig;
-  setAdapter(adapter: AdapterConfig): void;
   /** Record that a nudge was already shown for the turn keyed by last user msg
    *  id, so a tier/growth nudge prints at most once per turn instead of on
    *  every context event (pi fires multiple per assistant reply). */
@@ -159,14 +158,18 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
       logWarn("runtime", { event: "config-reload-failed", error: e instanceof Error ? e.message : String(e) });
       return;
     }
-    const key = JSON.stringify(user);
-    if (key === lastUserConfigKey) return;
-    lastUserConfigKey = key;
-    // Re-derive from the factory config (not adapterRef) so a key REMOVED from
-    // acp.json actually reverts, instead of lingering from a prior apply.
-    adapterRef = applyUserConfig(factoryAdapter, user);
-    if (adapterRef.debug !== undefined) setDebugEnabled(adapterRef.debug);
-    logInfo("runtime", { event: "config-reloaded", limit: adapterRef.modelContextLimit ?? null });
+    try {
+      const key = JSON.stringify(user);
+      if (key === lastUserConfigKey) return;
+      lastUserConfigKey = key;
+      // Re-derive from the factory config (not adapterRef) so a key REMOVED from
+      // acp.json actually reverts, instead of lingering from a prior apply.
+      adapterRef = applyUserConfig(factoryAdapter, user);
+      if (adapterRef.debug !== undefined) setDebugEnabled(adapterRef.debug);
+      logInfo("runtime", { event: "config-reloaded", limit: adapterRef.modelContextLimit ?? null });
+    } catch (e) {
+      logWarn("runtime", { event: "config-reload-failed", error: e instanceof Error ? e.message : String(e) });
+    }
   }
 
   async function stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]) {
@@ -190,5 +193,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };
 }

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, injectedWaitMessage } from "../src/delegate-tool.js";
+import { buildChildArgs, injectedWaitMessage, resolveWaitTimeoutMs } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -207,4 +207,23 @@ test("buildChildArgs keeps -p for sync delegates even on pi", async () => {
   assert.equal(isAsync, false);
   assert.equal(useJsonStream, false);
   assert.equal(cliArgs[0], "-p");
+});
+
+// ─── resolveWaitTimeoutMs: small values treated as seconds (ISSUE-1) ──────
+
+test("resolveWaitTimeoutMs returns the default when undefined", () => {
+  assert.equal(resolveWaitTimeoutMs(undefined), 10_000);
+});
+
+test("resolveWaitTimeoutMs rescales sub-1000 values as seconds", () => {
+  assert.equal(resolveWaitTimeoutMs(180), 180_000);
+  assert.equal(resolveWaitTimeoutMs(60), 60_000);
+  assert.equal(resolveWaitTimeoutMs(1), 1_000);
+});
+
+test("resolveWaitTimeoutMs passes through values >= 1000 as ms, clamped to [1000, 300000]", () => {
+  assert.equal(resolveWaitTimeoutMs(1_000), 1_000);
+  assert.equal(resolveWaitTimeoutMs(45_000), 45_000);
+  assert.equal(resolveWaitTimeoutMs(300_000), 300_000);
+  assert.equal(resolveWaitTimeoutMs(500_000), 300_000);
 });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -227,3 +227,11 @@ test("resolveWaitTimeoutMs passes through values >= 1000 as ms, clamped to [1000
   assert.equal(resolveWaitTimeoutMs(300_000), 300_000);
   assert.equal(resolveWaitTimeoutMs(500_000), 300_000);
 });
+
+test("resolveWaitTimeoutMs boundary: 999 → 300000 (seconds→clamp), 0/negative → 1000 floor", () => {
+  // The <1000 → seconds rescale means 999 becomes 999000 then clamps to the
+  // 300000 max — a sharp edge at the 999/1000 boundary, documented here.
+  assert.equal(resolveWaitTimeoutMs(999), 300_000);
+  assert.equal(resolveWaitTimeoutMs(0), 1_000);
+  assert.equal(resolveWaitTimeoutMs(-5), 1_000);
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,5 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import { createAcpExtension } from "../src/index.js";
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
@@ -230,4 +233,43 @@ test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the syste
   assert.ok(!result.systemPrompt.includes("ACP_DELEGATE NOTIFICATIONS"), "delegate section omitted when delegate:false");
   // Core ACP prompt is still present — only the delegate section is dropped.
   assert.ok(result.systemPrompt.includes("ACP TAGS"), "core ACP prompt still present when delegate disabled");
+});
+
+// ─── ISSUE-9: modelContextLimit changes in <cwd>/.pi/acp.json hot-reload ──
+
+test("modelContextLimit changes in .pi/acp.json are picked up on the next context event", async () => {
+  (globalThis as any).CURRENT_VERSION = (globalThis as any).CURRENT_VERSION ?? "test";
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "acp-hotreload-"));
+  const piDir = path.join(tmp, ".pi");
+  fs.mkdirSync(piDir, { recursive: true });
+  const acpJson = path.join(piDir, "acp.json");
+  fs.writeFileSync(acpJson, JSON.stringify({ modelContextLimit: 100_000 }));
+
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+
+    function ctxWithCwd() {
+      return { ...fakeCtx([], path.join(tmp, "state.json")), cwd: tmp };
+    }
+    async function acpStatus(): Promise<string> {
+      let captured = "";
+      const ctx = {
+        ...fakeCtx([], path.join(tmp, "state.json")),
+        cwd: tmp,
+        ui: { notify: (s: string) => { captured = s; }, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+      };
+      await api.commands.get("acp").handler([], ctx);
+      return captured;
+    }
+
+    await handlers.get("context")![0]!({ type: "context", messages: [] }, ctxWithCwd());
+    assert.ok((await acpStatus()).includes("100.0K"), "initial limit reflects acp.json modelContextLimit=100000");
+
+    fs.writeFileSync(acpJson, JSON.stringify({ modelContextLimit: 250_000 }));
+    await handlers.get("context")![0]!({ type: "context", messages: [] }, ctxWithCwd());
+    assert.ok((await acpStatus()).includes("250.0K"), "rewritten modelContextLimit=250000 hot-reloaded on next context event");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Follow-up to the omp long-session test report (ACP_LONG_SESSION_ISSUES.md). Fixes the 4 issues that live in this repo. The remaining issues (ISSUE-3/4/6/7/8) are in acp-kernel and need upstream fixes there.

## billion-context-pi fixes

**ISSUE-1 — `acp_delegate_wait` timeout unit confusion (P0)**
Agents frequently pass seconds (`180`) instead of ms; the old code clamped to the 1000ms floor → wait timed out in 1s. `resolveWaitTimeoutMs` (delegate-tool.ts) rescales sub-1000 values as seconds before clamping: `180 → 180000ms`.

**ISSUE-2 — `afterTokens=0` token-accounting collapse (P0)**
`afterTokens = max(0, beforeTokens - tokensCompressed)` subtracted mismatched denominators (`beforeTokens` excluded already-covered messages, `tokensCompressed` summed raw range sizes), so the subtraction went negative and clamped to 0. Now re-measured from the post-compression state: `afterTokens = estimateTokens(coreMessages, collectCoveredMessageIds(state))`. The display line uses the new `reclaimed = max(0, beforeTokens - afterTokens)`.

**ISSUE-5 — protected-zone warnings logged at error severity (P1)**
Compress `event=warnings` (model picked a protected/too-small range) was logged via `logError`. Now `logWarn`, so it no longer surfaces as ⚠️ in the UI.

**ISSUE-9 — live session ignores `modelContextLimit` changes until restart (P1)**
Added `runtime.reloadConfig(cwd)`: re-reads `.pi/acp.json` on every `context` event and `session_start`, re-deriving the adapter from the factory config so key **removals** also revert (JSON-key memoization skips work when unchanged). Previously you had to restart the session.

## Verification
- `npm run typecheck` clean
- `npm test` → 157 pass / 0 fail (+4 new: `resolveWaitTimeoutMs` ×3, config hot-reload ×1)
- `npm run build` → dist/index.js 410.40 KB

## Still pending (acp-kernel, separate repo)
ISSUE-3 (emergency deadlock with nothing compressible + pct>100), ISSUE-4 (blocks/activeBlocks desync), ISSUE-6 (tokensCompressed=0/blocksCreated=0 with non-empty newBlockIds), ISSUE-7 (minCompressRange=5000 deadlock), ISSUE-8 (minSummaryLength=50 rejects short distill headers). These need fixes in acp-kernel.

\#93 (omp empty first message) was already handled in a prior release via the `merge-live-entries` runtime path.