### PR TITLE
fix: stop false emergencies (real context window) + preserve compressed summaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 *.acp.json
 .pi-subagents/
 tmp-debug.ts
+
+.awork/

--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,31 @@ export interface AdapterConfig {
 export const DEFAULT_TOOL_BASH_TIMEOUT = 60;
 export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000;
 
+export interface ContextUsageReading {
+  tokens?: number | null;
+  percent?: number | null;
+}
+
+/**
+ * Reconstruct the real model window from the provider's usage percent when the
+ * reading is reliable. percent = tokens / realWindow ⇒ realWindow = tokens /
+ * percent. Returns configuredLimit when the reading is absent or out of the
+ * trustworthy 5–100% band, so a modelContextLimit set smaller than the actual
+ * window no longer triggers false emergencies.
+ */
+export function resolveEffectiveContextLimit(
+  configuredLimit: number,
+  realUsage: ContextUsageReading | undefined,
+  tokenCount: number,
+): number {
+  const pct = realUsage?.percent;
+  if (typeof pct !== "number" || pct <= 0.05 || pct > 1 || tokenCount <= 0) {
+    return configuredLimit;
+  }
+  const realWindow = Math.round(tokenCount / pct);
+  return realWindow > 0 ? realWindow : configuredLimit;
+}
+
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;
   const envLimitNum = envLimit ? Number(envLimit) : NaN;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {
 import type { CoreMessage, NudgeDecision, CompressionBlock } from "acp-kernel";
 import { renderNudgeText } from "acp-kernel";
 import type { AdapterConfig } from "./config.js";
+import { resolveEffectiveContextLimit } from "./config.js";
 import { createRuntime, type AcpRuntime } from "./runtime.js";
 import { makeCompressTool } from "./compress-tool.js";
 import { makeDecompressTool } from "./decompress-tool.js";
@@ -115,6 +116,10 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const realUsage = ctx.getContextUsage?.();
       const estimated = estimateTokens(coreMessages, coveredIds);
       const tokenCount = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : estimated;
+      const effectiveLimit = resolveEffectiveContextLimit(config.modelContextLimit, realUsage, tokenCount);
+      const effectiveConfig = effectiveLimit !== config.modelContextLimit
+        ? { ...config, modelContextLimit: effectiveLimit }
+        : config;
 
       debug.event("context-in", {
         sid,
@@ -125,12 +130,12 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         estimatedTokens: estimated,
         realTokens: realUsage?.tokens ?? null,
         realPercent: realUsage?.percent ?? null,
-        limit: config.modelContextLimit,
+        limit: effectiveConfig.modelContextLimit,
         blocksBefore: state.blocks.length,
         activeBefore: state.blocks.filter((b) => b.active).length,
       });
 
-      const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
+      const turn = runtime.core.processTurn({ messages: coreMessages, state, config: effectiveConfig, tokenCount });
       await runtime.save(turn.state, ctx);
 
       logInfo("turn", {
@@ -138,8 +143,8 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         inMsgs: coreMessages.length,
         outMsgs: turn.messages.length,
         tokens: tokenCount,
-        pct: realUsage?.percent ?? (config.modelContextLimit > 0 ? Math.round((tokenCount / config.modelContextLimit) * 100) : null),
-        limit: config.modelContextLimit,
+        pct: realUsage?.percent ?? (effectiveConfig.modelContextLimit > 0 ? Math.round((tokenCount / effectiveConfig.modelContextLimit) * 100) : null),
+        limit: effectiveConfig.modelContextLimit,
         nudge: turn.nudge?.shouldInject ? (turn.nudge.breakdown?.emergencyOverride === 1 ? "emergency" : "active") : "idle",
         nudgeReason: turn.nudge?.reason ?? null,
         blocks: turn.state.blocks.length,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -139,7 +139,12 @@ export function coreOutToAgentMessages(
   const emittedSplit = new Set<string>();
 
   for (const core of coreOut) {
-    if (core.id.startsWith("acp_summary_")) continue;
+    if (core.id.startsWith("acp_summary_")) {
+      // Kernel prune replaced covered msgs with this summary; emit it (as user
+      // text) — dropping it caused amnesia for compressed sections + re-fetch.
+      out.push({ role: "user", content: [{ type: "text", text: core.text ?? "" }] } as AgentMessage);
+      continue;
+    }
 
     const hashIdx = core.id.indexOf("#");
     if (hashIdx < 0) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveConfig, type AdapterConfig } from "../src/config.js";
+import { resolveConfig, resolveEffectiveContextLimit, type AdapterConfig } from "../src/config.js";
 
 const EMPTY: AdapterConfig = {};
 
@@ -45,4 +45,22 @@ test("resolveConfig ignores a non-positive ACP_MODEL_CONTEXT_LIMIT and falls thr
     if (prev === undefined) delete process.env.ACP_MODEL_CONTEXT_LIMIT;
     else process.env.ACP_MODEL_CONTEXT_LIMIT = prev;
   }
+});
+
+test("resolveEffectiveContextLimit reconstructs the real window from provider percent", () => {
+  // 36072 tokens at 13.26% ⇒ real window ≈ 272000 (the acp.log scenario).
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: 0.1326 }, 36_072), 272_036);
+  assert.equal(resolveEffectiveContextLimit(80_000, { tokens: 70_000, percent: 0.2574 }, 70_000), 271_950);
+});
+
+test("resolveEffectiveContextLimit falls back to configured when reading is unreliable", () => {
+  assert.equal(resolveEffectiveContextLimit(80_000, undefined, 36_072), 80_000, "no reading");
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: null }, 36_072), 80_000, "null percent");
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: 0.03 }, 36_072), 80_000, "percent below 5% band");
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: 1.5 }, 220_000), 80_000, "percent above 100% (overflow, skip)");
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: 0.5 }, 0), 80_000, "zero tokenCount");
+});
+
+test("resolveEffectiveContextLimit accepts exactly 100%", () => {
+  assert.equal(resolveEffectiveContextLimit(80_000, { percent: 1 }, 200_000), 200_000);
 });

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -363,14 +363,19 @@ test("coreOutToAgentMessages returns original unchanged when no ref tag is prese
   assert.equal(out[0], original, "un-tagged message returned by reference, untouched");
 });
 
-test("coreOutToAgentMessages filters out synthetic summary messages (compress-as-anchor)", () => {
+test("coreOutToAgentMessages emits synthetic summary messages as user text (no amnesia)", () => {
   const originalById = new Map<string, SessionMessageEntry["message"]>();
   const coreOut: CoreMessage[] = [
     { id: "acp_summary_b0", role: "system", contentType: "text", text: "[Compressed conversation section]\nbody" },
   ];
 
   const out = coreOutToAgentMessages(coreOut, originalById);
-  assert.equal(out.length, 0, "synthetic summary messages should be filtered out");
+  assert.equal(out.length, 1, "synthetic summary is emitted, not dropped");
+  const msg = out[0] as { role: string; content: Array<{ type: string; text?: string }> };
+  assert.equal(msg.role, "user", "summary projected as user text");
+  const text = Array.isArray(msg.content) ? (msg.content.find((b) => b.type === "text")?.text ?? "") : "";
+  assert.ok(text.includes("[Compressed conversation section]"), "summary header retained");
+  assert.ok(text.includes("body"), "summary body retained");
 });
 
 test("coreOutToAgentMessages reconstructs parallel tool-call assistant message from split core messages", () => {


### PR DESCRIPTION
## Root cause of the death-loop (from acp.log analysis)

The configured `modelContextLimit` (80K) was ~3.4× smaller than the model's real window (272K, derived from `realUsage.percent`). The nudge computes fullness as `tokenCount / modelContextLimit`, so it entered emergency at 64K tokens — only **23.5% of the real window** — and stayed in emergency continuously, thrashing the model with compression nudges it could not satisfy (protected zone / too-small ranges). At peak the nudge's own pct hit **270%** while the provider showed 81%.

## Fixes

**1. Derive the real window from the provider's usage percent** (`src/index.ts`, `src/config.ts`)
`realUsage.percent = tokens / realWindow ⇒ realWindow = tokens / percent`. When the reading is in a trustworthy 5–100% band, use it as `modelContextLimit` for the nudge decision. The nudge now matches the footer the user sees; a misconfigured limit no longer causes false emergencies.

**2. Stop dropping compressed summaries** (`src/messages.ts`)
`coreOutToAgentMessages` previously `continue`d past every `acp_summary_*` message — the kernel's prune node replaces covered messages with these placeholders, and dropping them gave the model **total amnesia for compressed sections**, driving re-fetch feedback loops that inflated context. Now emitted as user-role text.

## Not in this PR (blocked)
- **emergencyNothingLeft adapter wiring**: read `nudge.breakdown.emergencyNothingLeft` (from acp-kernel #53) to withhold the urgent nudge when nothing is legally compressible. Blocked on acp-kernel #53 merge + a version bump (field absent in bundled 0.0.17).
- **biggest-reclaim-tier-first nudge arbitration**: separate acp-kernel change.

## Verification
typecheck clean, 156/156 tests pass (+3 new for `resolveEffectiveContextLimit`; updated the old "filters out summary" test to assert emission). Build 410 KB.