### PR TITLE
fix: use CONFIG_DIR_NAME for log/subagent/update paths (omp)

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, mkdirSync, statSync, renameSync, existsSync } from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 
 const MAX_BYTES = 10 * 1024 * 1024;
 
@@ -8,7 +9,7 @@ const ENV_DEBUG =
   process.env.ACP_DEBUG === "1" || process.env.ACP_DEBUG === "true";
 
 function resolveLogFile(): string {
-  return process.env.ACP_LOG_FILE ?? path.join(homedir(), ".pi", "acp.log");
+  return process.env.ACP_LOG_FILE ?? path.join(homedir(), CONFIG_DIR_NAME, "acp.log");
 }
 
 let runtimeDebug: boolean | null = null;

--- a/src/setup-subagent-tools.ts
+++ b/src/setup-subagent-tools.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, stat, copyFile, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import { debug, logError, logWarn } from "./log.js";
 
 const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
@@ -22,7 +23,7 @@ export function resolveAgentDir(): string {
   const configured = process.env.PI_CODING_AGENT_DIR;
   if (configured === "~") return homedir();
   if (configured?.startsWith("~/")) return join(homedir(), configured.slice(2));
-  return configured || join(homedir(), ".pi", "agent");
+  return configured || join(homedir(), CONFIG_DIR_NAME, "agent");
 }
 
 export interface SetupResult {

--- a/src/update.ts
+++ b/src/update.ts
@@ -3,6 +3,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
 import { homedir } from "node:os";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import { debug, logInfo, logWarn } from "./log.js";
 
 declare const CURRENT_VERSION: string;
@@ -11,7 +12,7 @@ const PACKAGE_NAME = "billion-context-pi";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
-const THROTTLE_FILE = join(homedir(), ".pi", "agent", ".billion-context-pi-update-check");
+const THROTTLE_FILE = join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-context-pi-update-check");
 
 // Guards against concurrent checks: the context event fires on every LLM call,
 // so several can race past the throttle read before any writes the timestamp.


### PR DESCRIPTION
## Problem

Three files hardcode `~/.pi` for paths that should honor the host's config dir. `user-config.ts` already imports `CONFIG_DIR_NAME` and resolves the config dir correctly; these three were missed during the omp-compat work (#88 / #102):

- `src/log.ts` — log file fallback (`~/.pi/acp.log`)
- `src/setup-subagent-tools.ts` — `resolveAgentDir()` default (`~/.pi/agent`)
- `src/update.ts` — update-check throttle file (`~/.pi/agent/.billion-context-pi-update-check`)

Under omp, `CONFIG_DIR_NAME` resolves to `.omp`, so these paths point at `~/.pi/...` instead of `~/.omp/...`:

- **log file** defaults to `~/.pi/acp.log` under omp (workaround: `ACP_LOG_FILE`).
- **throttle file** writes under `~/.pi/agent/`, creating a spurious `~/.pi/` tree under omp.
- **`resolveAgentDir()`** falls back to `~/.pi/agent`, so the session-start step that injects ACP tools into the host's builtin subagents (`ensureSubagentAcpTools`, which reads `settings.json` from the agent dir) can't find omp's `~/.omp/agent/settings.json` and silently no-ops. **This is a path-correctness gap only** — see the caveat below.

## What this PR does *not* fix

`acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel` are **not usable under omp**, for a reason *unrelated* to config-dir paths: omp's extension runtime does not adopt tools that an extension registers inside the `session_start` handler. The delegate family is registered there (in the `session_start` hook in `index.ts`), whereas the always-available `compress` / `decompress` / `search_context` / `acp_status` are registered synchronously at load and do show up under omp. Fixing the config dir here does not change that. This PR only ensures that the paths which *are* used under omp land in `~/.omp/` rather than `~/.pi/`.

## Fix

Swap the hardcoded `".pi"` for `CONFIG_DIR_NAME` in all three files, mirroring `user-config.ts`. No behavior change under Pi (`CONFIG_DIR_NAME === ".pi"`).

`@earendil-works/pi-coding-agent` is already in tsup's `external` list and `user-config.ts` already imports `CONFIG_DIR_NAME` from it at runtime, so this is consistent with the established pattern (and resolves against the host — `.omp` under omp).

## Verification

- `npm run typecheck` ✅
- `npm test` — no new failures. Existing `tests/log.test.ts` and `tests/setup-subagent-tools.test.ts` are unaffected (the former always sets `ACP_LOG_FILE`; the latter passes an explicit path and never hits `resolveAgentDir()`).

## Out of scope (possible follow-ups)

- `resolveAgentDir()` largely duplicates the host's exported `getAgentDir()` (which already handles `PI_CODING_AGENT_DIR` via `expandTildePath` + `CONFIG_DIR_NAME`). Replacing the body with `getAgentDir()` would be DRY but is a behavior change (drops the custom `~` / `~/` slicing), so left out to keep this PR surgical.
- Making `acp_delegate` work under omp — would require a delegate-registration strategy that survives omp's extension runtime; separate investigation, not a path fix.
- `src/config.ts` JSDoc still reads `~/.pi/acp.log` / `~/.pi/acp.json` — illustrative under Pi, left untouched.

## Scope

No version bump (non-release branch). No comments added (per AGENTS.md §3). Branch name matches `YYYY-MM-DD_short-title`.
