### PR TITLE
fix(windows): isolate home-dir env in user-config tests

### DIFF
--- a/tests/user-config.test.ts
+++ b/tests/user-config.test.ts
@@ -16,17 +16,33 @@ async function writeConfig(dir: string, data: object): Promise<string> {
   return filePath;
 }
 
-let savedHome: string | undefined;
+type HomeEnv = { HOME: string | undefined; USERPROFILE: string | undefined };
+
+function snapshotHome(): HomeEnv {
+  return { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+}
+
+function setHome(dir: string): void {
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+}
+
+function restoreHome(env: HomeEnv): void {
+  process.env.HOME = env.HOME;
+  process.env.USERPROFILE = env.USERPROFILE;
+}
+
+let savedHome: HomeEnv;
 let hookHome: string;
 
 before(async () => {
-  savedHome = process.env.HOME;
+  savedHome = snapshotHome();
   hookHome = await fs.mkdtemp(path.join(os.tmpdir(), "acp-home-"));
-  process.env.HOME = hookHome;
+  setHome(hookHome);
 });
 
 after(async () => {
-  process.env.HOME = savedHome;
+  restoreHome(savedHome);
   await fs.rm(hookHome, { recursive: true, force: true });
 });
 
@@ -43,15 +59,15 @@ test("loadUserConfig reads global config from home directory", async () => {
   const tmpHome = path.join(os.tmpdir(), `acp-test-home-${Date.now()}`);
   await fs.mkdir(tmpCwd, { recursive: true });
   await fs.mkdir(tmpHome, { recursive: true });
-  const savedHome = process.env.HOME;
-  process.env.HOME = tmpHome;
+  const savedHome = snapshotHome();
+  setHome(tmpHome);
   try {
     await writeConfig(tmpHome, { debug: true, autoUpdate: false });
     const config = await loadUserConfig(tmpCwd);
     assert.equal(config.debug, true);
     assert.equal(config.autoUpdate, false);
   } finally {
-    process.env.HOME = savedHome;
+    restoreHome(savedHome);
     await fs.rm(tmpCwd, { recursive: true, force: true });
     await fs.rm(tmpHome, { recursive: true, force: true });
   }
@@ -75,8 +91,8 @@ test("loadUserConfig project config overrides global config", async () => {
   const tmpHome = path.join(os.tmpdir(), `acp-test-override-home-${Date.now()}`);
   await fs.mkdir(tmpCwd, { recursive: true });
   await fs.mkdir(tmpHome, { recursive: true });
-  const savedHome = process.env.HOME;
-  process.env.HOME = tmpHome;
+  const savedHome = snapshotHome();
+  setHome(tmpHome);
   try {
     await writeConfig(tmpHome, { debug: true, modelContextLimit: 200_000 });
     await writeConfig(tmpCwd, { debug: false });
@@ -84,7 +100,7 @@ test("loadUserConfig project config overrides global config", async () => {
     assert.equal(config.debug, false, "project debug overrides global");
     assert.equal(config.modelContextLimit, 200_000, "global modelContextLimit preserved");
   } finally {
-    process.env.HOME = savedHome;
+    restoreHome(savedHome);
     await fs.rm(tmpCwd, { recursive: true, force: true });
     await fs.rm(tmpHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Context

`d19538a` (v0.1.30) added `before`/`after` HOME isolation to `tests/user-config.test.ts`. This PR completes it for Windows — no behavior change on Linux/macOS.

## Problem

The `d19538a` isolation only sets `HOME`, but production code (`src/user-config.ts`) resolves the home dir via `os.homedir()`, which on Windows reads `USERPROFILE` and **ignores `HOME`**:

```
baseline:                              C:\Users\DeRant Vilmon Ram
process.env.USERPROFILE = 'ZZFAKE_UP'  ->  ZZFAKE_UP
process.env.HOME       = 'ZZFAKE_HOME' ->  C:\Users\DeRant Vilmon Ram   (unchanged)
```

So on Windows the two global-config tests still resolve to the real `%USERPROFILE%` — they read/write the real `~/.pi/acp.json` instead of the temp dir, polluting the user environment and racing concurrent runs. On Linux `os.homedir() === HOME`, so CI stays green and the gap is invisible.

## Fix

Add `snapshotHome` / `setHome` / `restoreHome` helpers that manage **both** `HOME` and `USERPROFILE`, and route the existing `before`/`after` hook plus the two per-test save/restore sites through them. Setting `USERPROFILE` is a no-op on POSIX (`os.homedir()` reads `HOME` there), so the same code is correct cross-platform.

## Verification

On Windows (node 24): `153 pass / 0 fail` — 2 of 153 failed before. `npm run typecheck` clean.

## Scope

No version bump (non-release branch). Production code (`src/user-config.ts`) unchanged — `os.homedir()` is correct as-is; only the test isolation leaked.

## Out of scope

A `windows-latest` CI matrix entry would surface such regressions automatically, but that's a maintainer-level CI decision, so intentionally left out of this PR.
