### PR TITLE
fix(tokens): dedup defaultCountTokens, correct stale comments

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -87,9 +87,10 @@ function bar(value: number, total: number, width: number = 20): string {
 async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
-  // Use pi's real context usage (anchored on provider usage) instead of a
-  // chars/4 estimate — matches the footer percentage and the nudge decision
-  // the context transform computes.
+  // Use pi's real context usage (anchored on provider usage) instead of the
+  // kernel's defaultCountTokens heuristic (chars/4 for non-CJK, 1:1 for CJK)
+  // — matches the footer percentage and the nudge decision the context
+  // transform computes.
   const realUsage = ctx.getContextUsage?.();
   const tokenCount = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n"));
 
@@ -99,10 +100,11 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   const limit = config.modelContextLimit;
   // displayTotal must reflect the REAL context size (what the footer shows),
   // not just the sum of message-text categories. contextBreakdown only
-  // classifies message text via chars/4 and never sees pi's system prompt
-  // or tool schemas, so summing its fields undercounts. Split the gap into
-  // the real system prompt (measured) and the rest (tool schemas + the
-  // inevitable chars/4-vs-real-tokenizer drift).
+  // classifies message text via defaultCountTokens (chars/4 for non-CJK, 1:1
+  // for CJK) and never sees pi's system prompt or tool schemas, so summing
+  // its fields undercounts. Split the gap into the real system prompt
+  // (measured) and the rest (tool schemas + the inevitable heuristic-vs-
+  // real-tokenizer drift).
   const classified = bd ? bd.system + bd.tool + bd.summaries + bd.code + bd.text : 0;
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;

--- a/src/search-index.ts
+++ b/src/search-index.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ExtensionContext, SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
-import { blockDocs, messageDocs, type SearchDoc, type MessageInput, type MessageRole } from "acp-kernel";
+import { blockDocs, defaultCountTokens, messageDocs, type SearchDoc, type MessageInput, type MessageRole } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import type { CompressionState } from "acp-kernel";
 
@@ -41,10 +41,10 @@ function buildMessageOwnerMap(state: CompressionState): Map<string, string> {
 }
 
 function estimateTokens(text: string): number {
-    if (typeof text !== "string" || !text) return 0;
-    const cjk = text.match(/[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]/g);
-    const cjkCount = cjk?.length ?? 0;
-    return cjkCount + Math.ceil((text.length - cjkCount) / 4);
+    // Delegate to the kernel's CJK-aware counter rather than keeping a local
+    // regex copy in sync. Callers coalesce text to a non-empty string, and
+    // defaultCountTokens also handles "" → 0.
+    return defaultCountTokens(text);
 }
 
 function toRole(entry: SessionMessageEntry): MessageRole | null {


### PR DESCRIPTION
## What
- `src/search-index.ts`: replace the locally-duplicated `defaultCountTokens` regex with a delegation to the kernel's imported `defaultCountTokens`.
- `src/commands.ts`: correct two stale comments that called the counter "chars/4" — it is actually CJK-aware (1:1 for CJK chars, chars/4 for non-CJK).

## Why
**search-index.ts** had a verbatim copy of the kernel's `defaultCountTokens` regex (`[\u4e00-\u9fff\u3040-\u30ff\uac00-\ud7af]` counted 1:1, remainder chars/4). Identical to the kernel today, but a drift bomb: if the kernel heuristic ever changes, this copy diverges silently and the search index's token estimates fall out of sync with the rest of the pipeline. Delegating to the imported function removes the sync burden.

**commands.ts** comments described the counter as "chars/4" and "chars/4-vs-real-tokenizer drift". Misleading — `defaultCountTokens` counts CJK characters 1:1 (not 4:1), so Chinese/Japanese/Korean text is NOT underestimated 4×. Corrected to name `defaultCountTokens` and its real behavior, so readers don't assume CJK content is severely undercounted.

## Context
Found during the acp-kernel tokenizer-consistency review (kernel PR #56 `fix(recommend): use ctx.countTokens`). billion-context-pi's per-message counting is already consistent with the kernel (all paths use `defaultCountTokens`); this PR closes a drift risk and fixes misleading docs.

## Out of scope
- **acp-kernel version bump** (pinned `acp-kernel@0.0.17`): deferred until kernel PR #56 merges and publishes, then a separate release branch bumps it (pi CI `npm ci` requires the published version).
- **Dual-currency design** (`tokenCount` from real provider usage vs per-message heuristic): intentional — the footer/nudge anchor on real usage. Not touched.

## Verification
- `tsc --noEmit`: clean
- `node --import tsx --test tests/*.test.ts`: 153/153 pass
- `scripts/ci/check-pr.sh`: passed (branch name + version)
