### PR TITLE
fix(windows): spawn delegates without a shell

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -1,6 +1,7 @@
 import {
   spawn,
   type ChildProcess,
+  type SpawnOptions,
 } from "node:child_process";
 import { createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, mkdtemp, writeFile, rm, appendFile } from "node:fs/promises";
@@ -27,6 +28,15 @@ const ASYNC_TIMEOUT_MS = 30 * 60_000;
 const KILL_GRACE_MS = 10_000;
 const RESULT_SUMMARY_CHARS = 500;
 const OUT_DIR = join(tmpdir(), "acp-delegate");
+
+export function delegateSpawnOptions(cwd: string, env: NodeJS.ProcessEnv): SpawnOptions {
+  return {
+    cwd,
+    env,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: false,
+  };
+}
 
 /** ACP context-management tools that every restricted delegate must retain
  *  so it can manage its own context under billion-context-pi. */
@@ -410,12 +420,11 @@ async function runDelegate(
   debug.event("delegate-spawn", { agent: args.agent, runId, cwd, async: isAsync, useJsonStream, cliArgs });
   logInfo("delegate", { event: "spawn", agent: args.agent, runId, cwd, async: isAsync, useJsonStream, mode: ctx.mode, parentDepth });
 
-  const child = spawn(process.execPath, [process.argv[1]!, ...cliArgs], {
-    cwd,
-    env: childEnv,
-    stdio: ["pipe", "pipe", "pipe"],
-    shell: process.platform === "win32",
-  }) as ChildProcess;
+  const child = spawn(
+    process.execPath,
+    [process.argv[1]!, ...cliArgs],
+    delegateSpawnOptions(cwd, childEnv),
+  ) as ChildProcess;
   child.stdin?.once("error", (e: Error) => {
     debug.event("delegate-stdin-error", { runId: "pre-spawn", error: String(e) });
     logError("delegate", { event: "stdin-error", runId, error: String(e) });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, injectedWaitMessage } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -14,6 +14,13 @@ function mockCtx(host: "pi" | "omp" = "pi"): ExtensionContext {
 
 const RESTRICTED_ROLES = ["reviewer", "researcher", "planner", "oracle"] as const;
 const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"];
+
+test("delegate spawn bypasses the shell for Windows executable paths", () => {
+  const options = delegateSpawnOptions("C:\\workspace", { TEST: "1" });
+  assert.equal(options.shell, false);
+  assert.equal(options.cwd, "C:\\workspace");
+  assert.deepEqual(options.stdio, ["pipe", "pipe", "pipe"]);
+});
 
 /** Parse the --tools value from cliArgs, or null if absent. */
 function getToolsValue(cliArgs: string[]): string | null {


### PR DESCRIPTION
## Summary

- spawn delegated Pi processes directly instead of routing `process.execPath` through a shell
- centralize the child spawn options so the no-shell behavior is regression-tested

## Problem

On Windows, Node is commonly installed at a path containing spaces, such as:

```text
C:\Program Files\nodejs\node.exe
```

`delegate-tool.ts` currently enables `shell` on Windows. The shell then splits that executable path at the first space, so every `acp_delegate` run exits with:

```text
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

No shell features are needed here: the executable and argument array are already passed separately to `spawn`.

## Fix

Always use `shell: false` for delegated child processes. This lets Node invoke `process.execPath` directly and preserves paths containing spaces.

## Validation

- `node --import tsx --test --test-name-pattern='delegate spawn bypasses the shell' tests/delegate-tool.test.ts` — pass
- `npm run typecheck` — pass
- `npm run build` — pass
- Windows end-to-end smoke test through a fresh Pi process and a synchronous `oracle` delegate — `LOCAL_DELEGATE_OK`, exit 0
- Full suite on Windows: 152 pass, 2 pre-existing `user-config` HOME-isolation failures; the same 2 failures reproduce on unmodified `upstream/master` and are addressed separately by #112
