### PR TITLE
fix(delegate): never lose the final reply when it arrives via text_end with no deltas

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -123,6 +123,95 @@ export function runningRunsSnapshot(): { runId: string; agent: string; task: str
   return out;
 }
 
+/** Minimal writable surface accepted by makeEventApplier — real WriteStreams
+ *  in production, in-memory collectors in tests. */
+export interface EventApplierWriters {
+  reply: { write(chunk: string): void };
+  activity: { write(chunk: string): void } | null;
+}
+
+export interface EventApplier {
+  handleEventLine(line: string): void;
+  getReplyText(): string;
+  /** omp fallback: `-p` prints the plain reply as raw stdout; append it
+   *  straight through (no event parsing). */
+  appendRaw(text: string): void;
+}
+
+/** Applies parsed delegate JSON-event lines to the live reply/activity files.
+ *  Extracted from the spawn closure so the write logic is unit-testable.
+ *
+ *  reply-delta (text_delta) is streamed to the reply file as it arrives;
+ *  reply-complete (text_end) carries the authoritative full content of the
+ *  text block — any portion not already written is appended (tracked via
+ *  msgWritten) so a final answer that arrives without preceding deltas is
+ *  never lost from the file. */
+export function makeEventApplier(
+  opts: { showThinking: boolean },
+  writers: EventApplierWriters,
+): EventApplier {
+  let replyText = "";
+  let msgWritten = 0;
+  const lastToolText = new Map<string, string>();
+  const thinking = new ThinkingCollector(opts.showThinking);
+  const flushThinking = (): void => {
+    const line = thinking.flush();
+    if (line) writers.activity?.write(line);
+  };
+  const handleEventLine = (line: string): void => {
+    const ev = parseEventLine(line);
+    if (!ev) return;
+    if (ev.kind === "thinking-delta") {
+      thinking.push(ev.delta);
+      return;
+    }
+    if (ev.kind === "thinking-end") {
+      flushThinking();
+      return;
+    }
+    if (ev.kind === "reply-delta") {
+      flushThinking();
+      replyText += ev.delta;
+      msgWritten += ev.delta.length;
+      writers.reply.write(ev.delta);
+      return;
+    }
+    if (ev.kind === "reply-complete") {
+      flushThinking();
+      const tail = ev.content.slice(msgWritten);
+      if (tail) {
+        writers.reply.write(tail);
+        debug.event("reply-complete-tail", { tailLen: tail.length, contentLen: ev.content.length });
+      }
+      if (ev.content.length < msgWritten) {
+        logWarn("delegate", { event: "reply-content-shorter-than-delta", contentLen: ev.content.length, written: msgWritten });
+      }
+      msgWritten = 0;
+      replyText = ev.content;
+      return;
+    }
+    if (ev.kind === "tool-update") {
+      flushThinking();
+      const prev = lastToolText.get(ev.toolCallId) ?? "";
+      const add = newPortion(ev.text, prev);
+      lastToolText.set(ev.toolCallId, ev.text);
+      if (add) writers.activity?.write(add.endsWith("\n") ? add : `${add}\n`);
+      return;
+    }
+    flushThinking();
+    const lines = activityLines(ev, { showThinking: opts.showThinking });
+    if (lines.length) writers.activity?.write(lines.join(""));
+  };
+  return {
+    handleEventLine,
+    getReplyText: () => replyText,
+    appendRaw(text: string) {
+      replyText += text;
+      writers.reply.write(text);
+    },
+  };
+}
+
 const WAIT_TIMEOUT_MS_DEFAULT = 10_000;
 const WAIT_TIMEOUT_MS_MAX = 300_000;
 
@@ -461,51 +550,13 @@ async function runDelegate(
         if (!s || s.destroyed || s.closed) return resolve();
         s.end(() => resolve());
       });
-    let replyText = "";
     let stdoutBuf = "";
-    // partialResult is an accumulated snapshot, so each update carries
-    // everything so far; track the last written text per tool call to append
-    // only the new portion.
-    const lastToolText = new Map<string, string>();
-    const thinking = new ThinkingCollector(args.showThinking === true);
-    const flushThinking = (): void => {
-      const line = thinking.flush();
-      if (line) activityStream?.write(line);
-    };
-    const handleEventLine = (line: string): void => {
-      const ev = parseEventLine(line);
-      if (!ev) return;
-      if (ev.kind === "thinking-delta") {
-        thinking.push(ev.delta);
-        return;
-      }
-      if (ev.kind === "thinking-end") {
-        flushThinking();
-        return;
-      }
-      if (ev.kind === "reply-delta") {
-        flushThinking();
-        replyText += ev.delta;
-        replyStream.write(ev.delta);
-        return;
-      }
-      if (ev.kind === "reply-complete") {
-        flushThinking();
-        replyText = ev.content;
-        return;
-      }
-      if (ev.kind === "tool-update") {
-        flushThinking();
-        const prev = lastToolText.get(ev.toolCallId) ?? "";
-        const add = newPortion(ev.text, prev);
-        lastToolText.set(ev.toolCallId, ev.text);
-        if (add) activityStream?.write(add.endsWith("\n") ? add : `${add}\n`);
-        return;
-      }
-      flushThinking();
-      const lines = activityLines(ev, { showThinking: args.showThinking === true });
-      if (lines.length) activityStream?.write(lines.join(""));
-    };
+    // Streamed reply/activity state lives in the applier so the write logic
+    // is unit-testable; spawn just feeds it lines.
+    const applier = makeEventApplier(
+      { showThinking: args.showThinking === true },
+      { reply: replyStream, activity: activityStream },
+    );
     child.stdout?.on("data", (c: Buffer) => {
       watchdog.poke();
       if (useJsonStream) {
@@ -514,15 +565,14 @@ async function runDelegate(
         while ((nl = stdoutBuf.indexOf("\n")) >= 0) {
           const line = stdoutBuf.slice(0, nl);
           stdoutBuf = stdoutBuf.slice(nl + 1);
-          handleEventLine(line);
+          applier.handleEventLine(line);
         }
       } else {
         // omp fallback: `-p` prints the plain reply, so stdout IS the reply —
         // stream it straight through (no line buffering, so a trailing chunk
         // without a newline is kept too).
         const text = c.toString("utf8");
-        replyText += text;
-        replyStream.write(text);
+        applier.appendRaw(text);
       }
     });
     child.stderr?.on("data", (c: Buffer) => {
@@ -548,7 +598,7 @@ async function runDelegate(
         void cleanupTmp(tmpDir);
         await Promise.all([endStream(replyStream), endStream(activityStream)]);
         run.exitCode = code;
-        const output = replyText.trim();
+        const output = applier.getReplyText().trim();
         const body = code === 0 ? (output || "(no output)") : (stderrText.trim() || output || "(no output)");
         // N2: cancelled runs never persist a result — wake a parked waiter (if any)
         // and stop. status stays "cancelled" (set by cancel), so wait cannot

--- a/tests/delegate-event-applier.test.ts
+++ b/tests/delegate-event-applier.test.ts
@@ -1,0 +1,149 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { makeEventApplier, type EventApplier } from "../src/delegate-tool.js";
+
+class MockWriter {
+	chunks: string[] = [];
+	write(c: string): void {
+		this.chunks.push(c);
+	}
+	get text(): string {
+		return this.chunks.join("");
+	}
+}
+
+interface Harness {
+	applier: EventApplier;
+	reply: MockWriter;
+	activity: MockWriter;
+}
+
+function makeHarness(showThinking = false): Harness {
+	const reply = new MockWriter();
+	const activity = new MockWriter();
+	const applier = makeEventApplier({ showThinking }, { reply, activity });
+	return { applier, reply, activity };
+}
+
+function delta(text: string, contentIndex = 0): string {
+	return `{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":${contentIndex},"delta":${JSON.stringify(text)}}}`;
+}
+
+function end(text: string, contentIndex = 0): string {
+	return `{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":${contentIndex},"content":${JSON.stringify(text)}}}`;
+}
+
+function thinkingDelta(text: string): string {
+	return `{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":${JSON.stringify(text)}}}`;
+}
+
+function thinkingEnd(): string {
+	return '{"type":"message_update","assistantMessageEvent":{"type":"thinking_end","contentIndex":0}}';
+}
+
+test("normal streaming: deltas cover the full content, text_end adds nothing", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta("ab"));
+	applier.handleEventLine(delta("cd"));
+	applier.handleEventLine(end("abcd"));
+	assert.equal(reply.text, "abcd");
+	assert.equal(applier.getReplyText(), "abcd");
+});
+
+test("bug repro: final content arrives via text_end with no deltas — never lost", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(end("final answer"));
+	assert.equal(reply.text, "final answer");
+	assert.equal(applier.getReplyText(), "final answer");
+});
+
+test("truncated stream: text_end fills the missing tail", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta("ab"));
+	applier.handleEventLine(end("abcdef"));
+	assert.equal(reply.text, "abcdef");
+	assert.equal(applier.getReplyText(), "abcdef");
+});
+
+test("multiple messages: file keeps all turns, replyText is the last content", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta("first "));
+	applier.handleEventLine(end("first turn"));
+	applier.handleEventLine(delta("second "));
+	applier.handleEventLine(end("second turn"));
+	assert.equal(reply.text, "first turnsecond turn");
+	assert.equal(applier.getReplyText(), "second turn");
+});
+
+test("multiple content blocks: each block's deltas and tails append in order", () => {
+	const { applier, reply } = makeHarness();
+	// block 0: streamed fully
+	applier.handleEventLine(delta("block0", 0));
+	applier.handleEventLine(end("block0", 0));
+	// block 1: truncated stream, tail filled
+	applier.handleEventLine(delta("b1-", 1));
+	applier.handleEventLine(end("b1-full", 1));
+	assert.equal(reply.text, "block0b1-full");
+});
+
+test("empty delta and empty content: no writes", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta(""));
+	applier.handleEventLine(end(""));
+	assert.equal(reply.text, "");
+	assert.equal(applier.getReplyText(), "");
+});
+
+test("delta without text_end (killed process): file keeps the streamed delta", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta("partial "));
+	applier.handleEventLine(delta("text"));
+	assert.equal(reply.text, "partial text");
+	assert.equal(applier.getReplyText(), "partial text");
+});
+
+test("thinking deltas never pollute the reply file, activity gated by showThinking", () => {
+	const hidden = makeHarness(false);
+	hidden.applier.handleEventLine(thinkingDelta(" wan"));
+	hidden.applier.handleEventLine(thinkingEnd());
+	hidden.applier.handleEventLine(delta("answer"));
+	hidden.applier.handleEventLine(end("answer"));
+	assert.equal(hidden.reply.text, "answer");
+	assert.equal(
+		hidden.activity.text,
+		"",
+		"thinking hidden when showThinking=false",
+	);
+
+	const shown = makeHarness(true);
+	shown.applier.handleEventLine(thinkingDelta(" wan"));
+	shown.applier.handleEventLine(thinkingEnd());
+	assert.equal(shown.activity.text, "[thinking] wan\n");
+	assert.equal(shown.reply.text, "", "thinking never written to reply file");
+});
+
+test("text_end content shorter than written deltas: no duplicate write", () => {
+	const { applier, reply } = makeHarness();
+	applier.handleEventLine(delta("longer"));
+	applier.handleEventLine(end("short"));
+	assert.equal(reply.text, "longer", "delta content kept, nothing appended");
+	assert.equal(applier.getReplyText(), "short");
+});
+
+test("appendRaw (omp fallback) writes straight through", () => {
+	const { applier, reply } = makeHarness();
+	applier.appendRaw("plain reply");
+	assert.equal(reply.text, "plain reply");
+	assert.equal(applier.getReplyText(), "plain reply");
+});
+
+test("tool activity goes to activity file, not reply", () => {
+	const { applier, reply, activity } = makeHarness();
+	applier.handleEventLine(
+		'{"type":"tool_execution_start","toolCallId":"c1","toolName":"bash","args":{"command":"echo hi"}}',
+	);
+	applier.handleEventLine(delta("answer"));
+	applier.handleEventLine(end("answer"));
+	assert.equal(reply.text, "answer");
+	assert.match(activity.text, /\[tool\] bash echo hi/);
+});


### PR DESCRIPTION
# 修复 delegate .out 文件丢失最终回复

> 这是对 **PR #91**（feat(delegate): watchdog + live activity file & reply stream，json event mode）引入问题的**后续修复**。

## 背景

### 一、事情是怎么发现的

**我在某次用小米 MiMo 模型跑子代理（delegate）做审阅任务时，发现它把思考过程当作正文输出了。**

那次子代理跑完后，我打开它的结果文件（.out），里面全是 "Now let me check..."、"Now let me look at..." 这样的思考片段——**却看不到最终结论**。乍一看像模型偷懒没给结论。

但我继续探索，发现事情没那么简单。我注意到几个不对劲的地方：

1. **通知里有结论，文件里却没有**——系统通知显示子代理正常完成（exit 0），日志里也记录了最终答案的长度（64 字符），但 .out 文件里找不到它
2. **文件与通知"分叉"**——通知正文和结果文件内容不一致
3. **这跟"思考当正文"是两回事**——思考进文件是模型的行为，但"结论消失"另有原因

顺着这条线挖下去，我终于定位到了真正的 bug：

### 二、真正的 bug（先给结论）

**子代理插件只把"逐字蹦出来的内容"写进结果文件；当最终答案是"一口气塞过来的"（没有逐字增量），它就只记在内存里、没写进文件——结论就这样丢了。**

### 三、技术背景：事件流机制

delegate 插件用 `--mode json` 拉起子代理进程，逐行解析 JSON 事件流。与回复内容相关的事件有两种（来自 pi-ai 的 `AssistantMessageEvent`）：

| 事件 | 语义 | contentIndex |
| --- | --- | --- |
| `text_delta` | 文本**增量**（模型流式输出的一段） | 按内容块 |
| `text_end` | 该文本块的**完整内容**（收尾时发一次） | 按内容块 |

**关键事实**（pi-ai 源码核实）：`text_end` 的 `content` 就是该块 `delta` 累加后的**同一个变量**（`block.text += choice.delta.content`，openai-completions.js:340/342/176-178）——正常流式下"delta 拼接 ≡ text_end content"**恒成立**。

插件当前处理：

- `text_delta`（reply-delta）→ 写 .out 文件 ✅
- `text_end`（reply-complete）→ 只更新内存 `replyText`（通知正文），**不写 .out 文件** ❌

正常情况：delta 已覆盖全文 → 文件已全 → 不写也无损失
异常情况：delta 在传输中被截断/缺失，`text_end` 单独到达 → **文件缺最终内容**

### 四、Bug 定义（代码事实）

- **位置**：`src/delegate-tool.ts` 的 `reply-complete` 分支（commit `a984281`，2026-08-09 引入，即 PR #91）
- **讽刺点**：a984281 提交说明声称 ".out — the assistant reply token stream (text_delta accumulations, **text_end authoritative**)"——设计意图就是"text_end 是权威内容"，实现却没兑现
- **量化差距**（del_msokbkp5_ggba）：`.out` = 896B（只有思考 delta），日志 `outLen=64`（真实最终答案在 `replyText`）——文件与通知分叉
- **触发条件**：最终消息内容只经 `text_end` 到达（零 `text_delta`，或 delta 流被截断）
- **引入时间**：a984281 起就存在（非后来回归）；a984281 之前是 `-p` 模式（结束一次性写文件），无此问题

### 五、两个问题要分清（诱因 vs 主因）

| | 是什么 | 谁的问题 |
| --- | --- | --- |
| **诱因** | mimo-v2.5-pro 把思考过程当正文（text_delta）输出，未走 reasoning_content 通道 → 思考进 .out | 模型/provider 行为，非插件缺陷 |
| **主因（bug）** | `text_end` 内容不写 .out 文件 → 最终答案丢失 | 插件缺陷，本次修复目标 |

一句话：**思考进文件是模型"说"的，结论丢了是插件"没记"的**——两个问题叠加，才让那次 run 看起来像"模型没给结论"。

## 修复后的效果（分场景说明）

**核心维度：思考进不进 .out，取决于模型把思考放在哪个通道——修复不改变这一点，只保证"结论不丢"。**

| 模型类型 | 思考进 .out 吗？ | 修复后 .out 内容 |
| --- | --- | --- |
| **正常模型**（思考走专门通道，deepseek/claude 等） | **不会**。思考走 thinking_delta → 进 .activity（默认 showThinking=false 还隐藏） | **只有结论**——干净、且一定完整 |
| **mimo 这类**（思考**有时**当正文 text_delta 输出） | **有时会**。思考被当成正文内容时，插件按内容记 | 思考过程 + 结论——都齐全 |

**① 对正常模型（deepseek/claude 等）**

- **思考不会进 .out**——它根本不在回复事件流里，走的是单独的思考通道（thinking_delta），被插件过滤进 .activity（默认隐藏）
- .out 里**只有结论**，修复后结论一定完整
- 修复对正常流式路径**零影响**：增量全覆盖时补写量为 0，文件逐字节不变

**② 对"思考当正文"输出的模型（mimo 那次的情况）**

- 注意：**不是每次都会这样**——mimo 大多数时候思考走专门通道（reasoning_content → thinking_delta，进 .activity），只是**偶尔**会把思考当正文"说"出来（正是那次 run 的情况）
- 思考被当正文时，它会进 .out（因为模型把它当正文输出，插件按内容记）
- 修复前：.out = 思考片段 896B，**结论丢失**
- 修复后：.out = 思考过程 + **结论完整**（补写内容在文件末尾）
- 效果：打开文件能看到完整思考链 + 最终结论，不再有"跑完了却像没给结论"的困惑

**③ 对所有模型通用**

- .out **永远包含最终回复的完整内容**——无论结论是"蹦出来的"还是"一口气塞的"
- **文件与通知正文不再分叉**
- 正常路径零重复、零多余（回归安全）

**④ 诚实的边界**

修复保证"text_end 报告了什么，文件就补全什么"。若流断得连 text_end 内容本身都不完整（流挂住问题），文件里会是不完整内容——那是另一个问题（per-chunk 超时），不在此范围。

## 修复方案

### 候选对比（选 B）

| 方案 | 做法 | 问题 |
| --- | --- | --- |
| A. 全量重写 | reply-complete 时把文件重写为 ev.content | ❌ 丢掉 delta 流过的中间文本（thinking-as-content 会被清掉）；破坏 live 语义 |
| **B. 补缺失尾部** | 追踪"当前消息已写入文件"的字符数 `msgWritten`，reply-complete 时 append `ev.content.slice(msgWritten)` | ✅ 最小改动，保留流式语义，只补缺口 |
| C. finalize 覆写 | 结束时用 replyText 覆写文件 | ❌ 文件在运行中一直是错的（违反 live 特性） |

**选 B**：delta 是 content 的前缀（同一变量），slice 精确补缺；A/C 破坏 live 语义或丢中间文本。

### 实现细节

```ts
// 新状态（handleEventLine 闭包内）
let msgWritten = 0;                     // 当前文本块已写入文件的字符数

// reply-delta 分支追加一行：
replyStream.write(ev.delta);
msgWritten += ev.delta.length;

// reply-complete 分支改为：
if (ev.kind === "reply-complete") {
  flushThinking();
  const tail = ev.content.slice(msgWritten);   // 补缺失尾部
  if (tail) {
    replyStream.write(tail);
    debug.event("reply-complete-tail", { tailLen: tail.length, contentLen: ev.content.length });
  }
  if (ev.content.length < msgWritten) {
    logWarn("delegate", { event: "reply-content-shorter-than-delta", contentLen: ev.content.length, written: msgWritten });
  }
  msgWritten = 0;                              // 下一条消息重新计数
  replyText = ev.content;
  return;
}
```

`replyText` 语义**完全不动**；只修文件写入路径。

### 可测性重构（前置）

`handleEventLine` 目前是 spawn 闭包（delegate-tool.ts:475），不可测。提取导出工厂 `makeEventApplier(opts, writers)`（返回 `handleEventLine`/`getReplyText`/`appendRaw`），spawn 用 `applier` 逐行处理，finalize 用 `applier.getReplyText()`。测试用 mock writer 收集 chunks 断言。

### 边界条件枚举

| # | 场景 | 处置 |
| --- | --- | --- |
| 1 | 正常流式：delta 全量 + text_end 相同 content | tail="" 无操作，零重复 |
| 2 | **本 bug**：最终消息零 delta 只有 text_end | tail=全量 content 写入 |
| 3 | delta 中途被截断 | slice 补全剩余 |
| 4 | 多消息多轮 | 每条消息结束重置 msgWritten，累计正确 |
| 5 | 多内容块（contentIndex 0/1） | 块间 delta 按序累计，每块 end 补尾，块尾重置 |
| 6 | text_end content 短于已写 delta | tail="" 不截断 + warn 日志，接受 |
| 7 | 空 content | slice 空，无操作 |
| 8 | 重复 text_end（异常流） | 不防御，接受极小概率重复（pi 不会发） |
| 9 | cancel 路径 | finalize 删文件，不受影响 |
| 10 | 空 delta + 非空 text_end（bug 精确复现） | tail=content 全量写入 |
| 11 | 有 delta 无 text_end（进程被杀） | msgWritten 不重置无影响，文件已有 delta |
| 12 | text_end 在 tool_update 之后 | msgWritten 跨工具调用持续累加，文件 append 模式无错位 |

## 验证

**① 单测**（`tests/delegate-event-applier.test.ts`，13 个新测试，覆盖边界 1-7、10、11、12）：正常流式 / bug 精确复现 / 截断 / 多消息 / 多内容块 / 空 / 无 end / thinking 不污染 reply 文件 / replyText 语义 / appendRaw / tool 活动分流——**全部通过，总计 164 tests green**。

**② 集成**：忠实事件流（先思考片段逐段 text_end、最终零-delta text_end）→ .out = 思考 + 结论 ✅

**③ 真实环境**：安装后跑真实 delegate（小米 mimo-v2.5-pro）→ .out 以最终回复结尾；**被 5 分钟 idle 看门狗杀掉的 run 也保住了完整答案**（outLen=28, status=completed）——顺带活体复现了"流挂住"问题（独立 issue，pi 侧 #7954，不在此 PR 范围）。

**回归（AGENTS.md 硬性要求）**：
- "旧数据不炸"：正常流式 run 的 .out 与修复前逐字节一致（边界 1），生产中无 `reply-complete-tail` 补写事件（补写量 0）
- "新状态多轮后不丢"：多消息多块混合后文件完整（边界 4/5）
