### PR TITLE
release v0.1.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.31",
+			"version": "0.1.32",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.17",
+				"acp-kernel": "0.0.18",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3224,9 +3224,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.17",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.17.tgz",
-			"integrity": "sha512-Mu7CIU1jo79cqHV6tZ8OgZe9ed4HBctVUsoSLKK3SStpkExZw7O3lcUTJLXNqyViuYA83gVH4Z8t43hn89qDDg==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz",
+			"integrity": "sha512-V9QLaUvutOr3eSYuDMPfjkK3jUKexueiLsU2kEFpXUu6jeALjHACPZbYSYDxxpE1OkRDaD1XXxcjV+Q/t6v4NQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.17",
+		"acp-kernel": "0.0.18",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Release `billion-context-pi` **v0.1.32** — bumps bundled `acp-kernel` 0.0.17 → **0.0.18**.

## Changes

Two-field version bump per AGENTS.md §5 (billion-context-pi release commit bumps both its own version AND the `acp-kernel` dependency):

```diff
   "name": "billion-context-pi",
-  "version": "0.1.31",
+  "version": "0.1.32",
   ...
-  "acp-kernel": "0.0.17",
+  "acp-kernel": "0.0.18",
```

`package-lock.json` refreshed via `npm install` (resolves the real published `acp-kernel@0.0.18` from npmjs.org).

## What's in acp-kernel 0.0.18

Bug-fix release bundling 4 merged PRs (no API changes, zero adapter code changes needed):

| acp-kernel PR | Type | Summary |
|---------------|------|---------|
| #52 | fix | `hide-consumed` per-block — stops summary leak in batched compress calls |
| #54 | fix | T2/T3 distillation nudge warns that span raw messages are absorbed |
| #55 | fix | overlap → warn+skip instead of aborting the whole batch (ISSUE-42) |
| #56 | fix | `recommend` uses `ctx.countTokens` instead of hardcoded chars/4 |

**Not included**: acp-kernel #57 (nudge overhaul) remains open and intentionally excluded; will ship in a later version.

## Pre-flight (local)

- `npm run typecheck` ✅ clean
- `npm test` ✅ 153 pass / 0 fail
- `npm run build` ✅ 412.25 KB (kernel inlined, self-contained)

## Verification

- `npm view acp-kernel version` → `0.0.18` ✅ (published)
- Lockfile resolves `https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz` ✅
- Zero source changes — adapter fully compatible with 0.0.18.

---

Refs: dog/billion-context-pi#26. After merge, CI will tag `v0.1.32` and publish to npm. Verify with:
```
npm view billion-context-pi version   # expect 0.1.32
```
