### PR TITLE
release v0.1.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.32",
+	"version": "0.1.33",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.32",
+			"version": "0.1.33",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.32",
+	"version": "0.1.33",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.33

小版本发布，纳入今日合入的 4 个 omp / Windows / delegate 修复：

| PR | 作者 | 内容 |
|----|------|------|
| #111 | @CaelumSea | 用 `CONFIG_DIR_NAME` 替换硬编码 `".pi"`（omp 路径适配，Pi 下零行为变化） |
| #112 | @CaelumSea | Windows 下隔离 home 目录（仅测试改动，修 `USERPROFILE` 泄漏） |
| #114 | @miaomiaozii | Windows 下 spawn delegate 不走 shell（修 node 装在带空格路径时 execPath 被截断；POSIX 零变化） |
| #115 | @Tyan66666 | 修 delegate 最终回答仅经 `text_end` 到达时 `.out` 文件丢失（正常流式下字节相同，回归安全） |

### 本次改动
- `billion-context-pi`: `0.1.32 → 0.1.33`（patch；本项目一贯的 0.1.x 节奏）
- `acp-kernel`: 维持 `0.0.18`（本次无内核升级）
- 仅 2 个文件：`package.json` + `package-lock.json`

### 联合回归预检（4 PR 合入后的 master + 本次版本 bump）
- `npm run typecheck` ✅
- `npm test` ✅ 165 pass / 0 fail
- `npm run build` ✅ dist/index.js 413KB

### 发布说明
合并后 CI 自动发布到 npm（AGENTS.md §6）。acp-kernel 未变，无需跨仓库发布顺序。