### PR TITLE
release v0.1.34 — bump acp-kernel to 0.0.19 (fixed 50K nudge growth)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.33",
+	"version": "0.1.34",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.33",
+			"version": "0.1.34",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.18",
+				"acp-kernel": "0.0.19",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3224,9 +3224,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.18",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.18.tgz",
-			"integrity": "sha512-V9QLaUvutOr3eSYuDMPfjkK3jUKexueiLsU2kEFpXUu6jeALjHACPZbYSYDxxpE1OkRDaD1XXxcjV+Q/t6v4NQ==",
+			"version": "0.0.19",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.19.tgz",
+			"integrity": "sha512-Ul13wjjP9bWYPBaUPyap4jeD4GpUJ1/sofWyJA/PxaEIOV9QmRDOvAJRAV436dojodgCpBv9UygyaJ7eiq4LuA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.33",
+	"version": "0.1.34",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.18",
+		"acp-kernel": "0.0.19",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
# release v0.1.34 — bump acp-kernel to 0.0.19 (fixed 50K nudge growth)

## Summary

Bumps `acp-kernel` from `0.0.18` to **`0.0.19`** and billion-context-pi from
`0.1.33` to **`0.1.34`**. No source changes — billion-context-pi inherits the
kernel's nudge config and bundles it inline (tsup does not mark acp-kernel external).

## What 0.0.19 brings

acp-kernel [v0.0.19](https://github.com/ranxianglei/acp-kernel/pull/61) pins the nudge
growth threshold to a **fixed 50,000 tokens**. Previously `resolveAdaptiveGrowth`
returned `5% of context (clamped 20K–50K)`, so sub-1M-context models got smaller
thresholds and nudges fired too eagerly, driving over-compression. Now every model
uses the same 50K growth threshold.

The change in the kernel (`src/config.ts`):

```diff
- growthFloor: Math.max(20000, Math.round(modelContextLimit * 0.05)),
+ growthFloor: 50000,
```

(`growthCap` is already 50000, so `resolveAdaptiveGrowth` now always returns 50000.)

## Changes in this PR (per AGENTS.md §5 — single release commit, two version fields)

```
"version": "0.1.33" → "0.1.34"
"acp-kernel": "0.0.18" → "0.0.19"
```

Plus `package-lock.json` refreshed against the real 0.0.19 tarball. No source changes.

## Verification

- typecheck (`tsc --noEmit`): clean
- tests (`node --import tsx --test tests/*.test.ts`): 165 pass / 0 fail
- build (`tsup`): success, dist/index.js self-contained (acp-kernel inlined)

## Merge → auto-publish

Merging this PR triggers `release.yml`, which detects the `2026-08-12_release-v*`
branch, tags `v0.1.34`, and publishes to npm `latest`. PR merge is human-only.
