### PR TITLE
fix(omp): rebuild refs before compression

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -57,10 +57,19 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {
   const ranges = args.content ?? [];
   if (ranges.length === 0) return "No ranges provided.";
-  const { state, coreMessages } = await runtime.stateFor(ctx);
+  const { state: initialState, coreMessages } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
-
-  const beforeTokens = estimateTokens(coreMessages, collectCoveredMessageIds(state));
+  const estimatedTokens = estimateTokens(coreMessages, collectCoveredMessageIds(initialState));
+  const realUsage = ctx.getContextUsage?.();
+  const turn = runtime.core.processTurn({
+    messages: coreMessages,
+    state: initialState,
+    config,
+    tokenCount: realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : estimatedTokens,
+  });
+  const state = turn.state;
+  const messages = turn.messages;
+  const beforeTokens = estimateTokens(messages, collectCoveredMessageIds(state));
   const summaryMaxChars = args.summaryMaxChars;
   const topLevelTopic = args.topic;
 
@@ -70,13 +79,13 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     spans: ranges.map((r) => ({ span: `${r.startId}..${r.endId}`, summaryLen: r.summary.length, summary: r.summary, topic: r.topic ?? topLevelTopic ?? null })),
     blocksBefore: state.blocks.length,
     activeBefore: state.blocks.filter((b) => b.active).length,
-    beforeMsgCount: coreMessages.length,
+    beforeMsgCount: messages.length,
     beforeTokens,
   });
 
   const applied = runtime.core.applyCompression({
     ranges: ranges.map((r) => ({ startRef: r.startId, endRef: r.endId, summary: r.summary, topic: r.topic ?? topLevelTopic, summaryMaxChars, compressCallId: toolCallId })),
-    messages: coreMessages,
+    messages,
     state,
     config,
   });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -110,6 +110,21 @@ function sameMessage(a: AgentMessage, b: AgentMessage): boolean {
   }
 }
 
+function pruneOrphanRefs(state: CompressionState, messages: ReturnType<typeof entriesToCoreMessages>): void {
+  const retainedRawIds = new Set(messages.map((message) => message.id));
+  for (const block of state.blocks) {
+    for (const rawId of [...block.directMessageIds, ...block.effectiveMessageIds]) retainedRawIds.add(rawId);
+  }
+  for (const [rawId, ref] of Object.entries(state.messageRefs.byRaw)) {
+    if (retainedRawIds.has(rawId)) continue;
+    delete state.messageRefs.byRaw[rawId];
+    if (state.messageRefs.byRef[ref] === rawId) delete state.messageRefs.byRef[ref];
+  }
+  for (const [ref, rawId] of Object.entries(state.messageRefs.byRef)) {
+    if (!retainedRawIds.has(rawId)) delete state.messageRefs.byRef[ref];
+  }
+}
+
 export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const core = createCore({ countTokens: defaultCountTokens });
   const store = new SessionStateStore();
@@ -157,7 +172,9 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     // messages about to be sent, including the not-yet-persisted tail) with the
     // persisted branch records on the omp path only.
     const merged = isPiHost(sm) || !liveMessages || liveMessages.length === 0 ? entries : mergeLiveEntries(entries, liveMessages);
-    return { state, coreMessages: entriesToCoreMessages(merged), entries: merged };
+    const coreMessages = entriesToCoreMessages(merged);
+    if (liveMessages === undefined) pruneOrphanRefs(state, coreMessages);
+    return { state, coreMessages, entries: merged };
   }
 
   async function save(state: CompressionState, ctx: ExtensionContext) {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFile, rm } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
@@ -183,6 +184,44 @@ test("omp live message keeps the same entry id once persisted (stable refs acros
   assert.ok(r2);
   assert.equal(r2.messages.length, 2, "both persisted and live messages must survive");
 });
+
+test("acp_status refs remain usable by the next compress call", async () => {
+  const { api } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-status-compress.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const originalText = "This range is reported by acp_status and must remain addressable by compress. ".repeat(130);
+  const persisted = [userMsg("e1", originalText), ...["two", "three", "four", "five", "six", "seven"].map((n, index) => userMsg(`e${index + 2}`, `filler ${n} `.repeat(400)))];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const statusTool = api.tools.find((tool: { name: string }) => tool.name === "acp_status")!;
+  const status = await statusTool.execute("tc-status", {}, undefined, undefined, ctx);
+  const targetRef = status.content[0].text.match(/m\d{5}/)![0];
+  const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
+  const result = await compressTool.execute("tc-status-compress", { content: [{ startId: targetRef, endId: targetRef, summary: "This range was selected by acp_status and is now safely compressed from the original entry." }] }, undefined, undefined, ctx);
+  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+});
+
+test("omp rebuilds refs after stale live state before status compression", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-stale-live.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const longText = "This stale live state must be rebuilt against the current persisted branch. ".repeat(130);
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+  const texts = [longText, filler("two"), filler("three"), filler("four"), filler("five"), filler("six"), filler("seven")];
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const liveMessages = texts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() }));
+  await handlers.get("context")![0]!({ type: "context", messages: liveMessages }, ctx);
+  persisted = texts.map((text, index) => userMsg(`e${index + 1}`, text));
+  const statusTool = api.tools.find((tool: { name: string }) => tool.name === "acp_status")!;
+  const status = await statusTool.execute("tc-stale-live-status", {}, undefined, undefined, ctx);
+  const targetRef = status.content[0].text.match(/m\d{5}/)![0];
+  assert.equal(targetRef, "m00001", status.content[0].text);
+  const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
+  const result = await compressTool.execute("tc-stale-live-compress", { content: [{ startId: targetRef, endId: targetRef, summary: "This stale live range was rebuilt against stable persisted entries and is now safely compressed." }] }, undefined, undefined, ctx);
+  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+});
 test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);
@@ -221,6 +260,18 @@ test("context handler persists state so a second call is idempotent on the same 
   const tag1 = ((first.messages[0] as any).content as any[]).find((b: any) => b.type === "text" && b.text.startsWith("[m"));
   const tag2 = ((second.messages[0] as any).content as any[]).find((b: any) => b.type === "text" && b.text.startsWith("[m"));
   assert.equal(tag1?.text, tag2?.text, "refs stable across calls (loaded from persisted state)");
+});
+
+test("empty live context preserves refs created for an unpersisted message", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-empty-live.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const ctx = fakeCtx([], stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [{ role: "user", content: "live-only" }] }, ctx);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+  const state = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(state.messageRefs.byRaw["live-0"], "m00001");
 });
 
 test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the system prompt", () => {


### PR DESCRIPTION
## Why

Long-running OMP sessions can retain stale `live-*` ACP refs after context reshaping. `acp_status` may then report refs that no longer resolve to the current persisted branch, causing `compress` to report:

`Total compressible content too small (0 chars across 1 range(s), min 5000)`

## What

- Rebuild the current ref/message view with `processTurn` before compression.
- Prune orphan refs when rebuilding a persisted full-branch view.
- Preserve refs referenced by compression blocks.
- Keep orphan cleanup out of ordinary context transforms, including explicit empty `event.messages` arrays.
- Add regressions for status-to-compress continuity, stale live state, and empty live contexts.

## Validation

- `npm run typecheck`
- `npm test` — 168 tests passed
- `npm run build`
- Final review: Standards — no findings
- Final review: Spec — no findings