### PR TITLE
fix(omp): match truncated tool results

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -100,7 +100,7 @@ function stringifyArgs(args: unknown): string {
   return safeStringify(args);
 }
 
-function extractText(content: unknown): string {
+export function extractText(content: unknown): string {
   if (typeof content === "string") return content.replace(REF_TAG, "");
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
@@ -111,6 +111,20 @@ function extractText(content: unknown): string {
     }
   }
   return parts.join("\n");
+}
+
+const TRUNCATION_MARKER = "[truncated for context space]";
+
+export function matchesStoredText(stored: string, visible: string): boolean {
+  const marker = `...${TRUNCATION_MARKER} — original ~`;
+  const markerStart = visible.indexOf(marker);
+  if (markerStart < 2 || visible.slice(markerStart - 2, markerStart) !== "\n\n") return false;
+  const suffixMarker = " tokens]...\n\n";
+  const suffixStart = visible.indexOf(suffixMarker, markerStart + marker.length);
+  if (suffixStart < 0 || !/^\d+$/.test(visible.slice(markerStart + marker.length, suffixStart))) return false;
+  const prefix = visible.slice(0, markerStart - 2);
+  const suffix = visible.slice(suffixStart + suffixMarker.length);
+  return prefix.length > 0 && suffix.length > 0 && stored.startsWith(prefix) && stored.endsWith(suffix);
 }
 
 function allToolCalls(content: unknown): { name: string; id: string; arguments?: unknown }[] {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,7 +7,7 @@ import {
   type Config,
 } from "acp-kernel";
 import { resolveConfig, type AdapterConfig } from "./config.js";
-import { entriesToCoreMessages } from "./messages.js";
+import { entriesToCoreMessages, extractText, matchesStoredText } from "./messages.js";
 import { SessionStateStore } from "./state.js";
 import { logInfo, logWarn } from "./log.js";
 
@@ -103,10 +103,23 @@ function sameMessage(a: AgentMessage, b: AgentMessage): boolean {
   const cb = (b as { content?: unknown }).content;
   if (ca === undefined || cb === undefined) return false;
   try {
-    return JSON.stringify(ca) === JSON.stringify(cb);
+    if (JSON.stringify(ca) === JSON.stringify(cb)) return true;
+    if (ra === "toolResult" && sameNonTextBlocks(ca, cb) && matchesStoredText(extractText(ca), extractText(cb))) return true;
+    return false;
   } catch (e) {
     logWarn("runtime", { event: "message-compare-failed", error: e instanceof Error ? e.message : String(e) });
     return a === b;
+  }
+}
+
+function sameNonTextBlocks(a: unknown, b: unknown): boolean {
+  const nonText = (blocks: unknown[]): unknown[] => blocks.filter((block) => (block as { type?: string }).type !== "text");
+  try {
+    const na = Array.isArray(a) ? nonText(a) : [];
+    const nb = Array.isArray(b) ? nonText(b) : [];
+    return JSON.stringify(na) === JSON.stringify(nb);
+  } catch {
+    return false;
   }
 }
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createAcpExtension } from "../src/index.js";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
 // so we can invoke them with a fake ExtensionContext and assert the wiring works.
@@ -183,6 +187,102 @@ test("omp live message keeps the same entry id once persisted (stable refs acros
   assert.ok(r2);
   assert.equal(r2.messages.length, 2, "both persisted and live messages must survive");
 });
+
+test("omp matches emergency-truncated tool results before compression", async (t) => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const dir = await mkdtemp(join(tmpdir(), "pai-acp-omp-truncation-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const stateFile = join(dir, "session.json");
+  const originalText = "This large tool output must retain its persisted identity. ".repeat(130);
+  const truncatedText = `${originalText.slice(0, 2000)}\n\n...[truncated for context space] — original ~1500 tokens]...\n\n${originalText.slice(-2000)}`;
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+  const persisted = [
+    { type: "message", id: "e1", parentId: null, timestamp: "", message: { role: "toolResult", toolName: "read", toolCallId: "call-read", content: [{ type: "text", text: originalText }], timestamp: Date.now() } },
+    ...["two", "three", "four", "five", "six", "seven"].map((n, index) => userMsg(`e${index + 2}`, filler(n))),
+  ];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const liveMessages = [
+    { role: "toolResult", toolName: "read", toolCallId: "call-read", content: [{ type: "text", text: truncatedText }], timestamp: Date.now() },
+    ...["two", "three", "four", "five", "six", "seven"].map((n) => ({ role: "user", content: [{ type: "text", text: filler(n) }], timestamp: Date.now() })),
+  ];
+  const transformed = await handlers.get("context")![0]!({ type: "context", messages: liveMessages }, ctx);
+  const targetRef = transformed.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
+  const result = await compressTool.execute("tc-omp-truncation", { content: [{ startId: targetRef, endId: targetRef, summary: "This large tool result was emergency-truncated in provider context and is now safely compressed from the original entry." }] }, undefined, undefined, ctx);
+  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+});
+
+test("omp does not collapse distinct multimodal user messages with identical text (images survive)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as unknown as ExtensionAPI);
+
+  const persistedImage = { type: "image", mimeType: "image/png", data: "persisted-image-payload" };
+  const liveImage = { type: "image", mimeType: "image/png", data: "live-image-payload" };
+  const persisted = [
+    {
+      type: "message",
+      id: "e1",
+      parentId: null,
+      timestamp: "",
+      message: { role: "user", content: [{ type: "text", text: "what is this?" }, persistedImage], timestamp: Date.now() },
+    },
+  ];
+  const liveMessages = [{ role: "user", content: [{ type: "text", text: "what is this?" }, liveImage], timestamp: Date.now() }];
+  const ctx = {
+    ...fakeCtx(persisted, "/tmp/nonexistent-pai-acp-omp-images.session.json"),
+    sessionManager: {
+      getBranch: () => persisted,
+      getSessionId: () => "test-session",
+      getSessionFile: () => "/tmp/nonexistent-pai-acp-omp-images.session.json",
+    },
+  };
+
+  const result = await handlers.get("context")![0]!({ type: "context", messages: liveMessages }, ctx);
+  assert.ok(result, "handler must not throw");
+  assert.equal(result.messages.length, 1, "the live multimodal message must survive the transform");
+  const content = result.messages[0].content;
+  const imageBlocks = content.filter((b: { type?: string; data?: string }) => b.type === "image");
+  assert.equal(imageBlocks.length, 1, "exactly one image block must survive");
+  assert.equal(imageBlocks[0]!.data, "live-image-payload", "the LIVE image payload must survive, not the persisted one");
+  assert.ok(!content.some((b: { type?: string; data?: string }) => b.data === "persisted-image-payload"), "persisted image must not replace the live one");
+});
+
+test("omp does not collapse distinct multimodal tool results with identical text (images survive)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as unknown as ExtensionAPI);
+
+  const persistedImage = { type: "image", mimeType: "image/png", data: "persisted-image-payload" };
+  const liveImage = { type: "image", mimeType: "image/png", data: "live-image-payload" };
+  const persisted = [
+    {
+      type: "message",
+      id: "e1",
+      parentId: null,
+      timestamp: "",
+      message: { role: "toolResult", toolName: "read", toolCallId: "call-read", content: [{ type: "text", text: "same tool output" }, persistedImage], timestamp: Date.now() },
+    },
+  ];
+  const liveMessages = [{ role: "toolResult", toolName: "read", toolCallId: "call-read", content: [{ type: "text", text: "same tool output" }, liveImage], timestamp: Date.now() }];
+  const ctx = {
+    ...fakeCtx(persisted, "/tmp/nonexistent-pai-acp-omp-toolresult-images.session.json"),
+    sessionManager: {
+      getBranch: () => persisted,
+      getSessionId: () => "test-session",
+      getSessionFile: () => "/tmp/nonexistent-pai-acp-omp-toolresult-images.session.json",
+    },
+  };
+
+  const result = await handlers.get("context")![0]!({ type: "context", messages: liveMessages }, ctx);
+  assert.ok(result, "handler must not throw");
+  assert.equal(result.messages.length, 1, "the live multimodal tool result must survive the transform");
+  const content = result.messages[0].content;
+  const imageBlocks = content.filter((b: { type?: string; data?: string }) => b.type === "image");
+  assert.equal(imageBlocks.length, 1, "exactly one image block must survive");
+  assert.equal(imageBlocks[0]!.data, "live-image-payload", "the LIVE image payload must survive, not the persisted one");
+  assert.ok(!content.some((b: { type?: string; data?: string }) => b.data === "persisted-image-payload"), "persisted image must not replace the live one");
+});
+
 test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { entriesToCoreMessages, coreOutToAgentMessages } from "../src/messages.js";
+import { entriesToCoreMessages, coreOutToAgentMessages, matchesStoredText } from "../src/messages.js";
 import type { CoreMessage } from "acp-kernel";
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 
@@ -352,6 +352,12 @@ test("coreOutToAgentMessages honors kernel-truncated body for string-content too
   assert.ok(msg.content.includes("[truncated for context space]"), "truncated body present");
   assert.ok(!msg.content.includes("Y".repeat(100)), "full original not emitted");
   assert.ok(msg.content.includes("m00004"), "ref tag preserved");
+});
+
+test("truncation matching requires the OMP marker", () => {
+  assert.equal(matchesStoredText("a\nb", "a\nb"), false);
+  assert.equal(matchesStoredText("a\nb", "a\nb\nc"), false);
+  assert.equal(matchesStoredText("a\nb", "a\n\nb"), false);
 });
 
 test("coreOutToAgentMessages returns original unchanged when no ref tag is present", () => {


### PR DESCRIPTION
## Why
OMP can emergency-truncate large tool results before the adapter merges live provider messages with persisted session entries. The truncated content no longer matched the persisted result exactly, causing it to receive a temporary `live-*` identity and making its displayed ACP ref unavailable to later compression.

## What
- recognize OMP's `[truncated for context space]` marker and validate its token-count envelope
- match truncated tool results to persisted entries through retained prefix and suffix text
- preserve exact content identity for ordinary, user, and multimodal tool-result messages
- require non-text blocks to remain identical during truncation fallback
- add isolated regressions for truncated results, stable refs, multimodal content, and marker-required matching

## Test Plan
- [x] `node --import tsx --test tests/integration.test.ts tests/messages.test.ts` (35/35 passed)
- [x] `npm run typecheck`
- [x] `git diff --check`