### PR TITLE
fix(omp): stabilize live message references

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -13,7 +13,9 @@ type AnyMessage = {
   summary?: string;
 };
 
-const REF_TAG = new RegExp("^(?:\x3cacp\\s[^>]*\x3em\\d{5}\x3c/acp\x3e|\\[m\\d{1,5}\\])\\s?\\n?");
+const REF_TAG_SOURCE = "(?:\x3cacp\\s[^>]*\x3em\\d{5}\x3c/acp\x3e|\\[m\\d{1,5}\\])";
+const REF_TAG = new RegExp(`^${REF_TAG_SOURCE}\\s?\\n?`);
+const TRAILING_REF_TAG = new RegExp(`\\n*${REF_TAG_SOURCE}\\s*$`);
 
 export function entriesToCoreMessages(entries: SessionEntry[]): CoreMessage[] {
   const out: CoreMessage[] = [];
@@ -100,17 +102,69 @@ function stringifyArgs(args: unknown): string {
   return safeStringify(args);
 }
 
-function extractText(content: unknown): string {
-  if (typeof content === "string") return content.replace(REF_TAG, "");
+export function extractText(content: unknown): string {
+  if (typeof content === "string") return stripRefTag(content);
   if (!Array.isArray(content)) return "";
   const parts: string[] = [];
   for (const block of content) {
     const b = block as { type?: string; text?: string };
-    if (b.type === "text" && typeof b.text === "string") {
-      parts.push(b.text.replace(REF_TAG, ""));
-    }
+    if (b.type === "text" && typeof b.text === "string") parts.push(stripRefTag(b.text));
   }
   return parts.join("\n");
+}
+
+function stripRefTag(text: string): string {
+  return text.replace(REF_TAG, "").replace(TRAILING_REF_TAG, "");
+}
+export function messageIdentity(message: unknown): string {
+  return JSON.stringify(normalizeIdentityValue(message, true));
+}
+
+export function messageRef(message: unknown): string | undefined {
+  if (message === null || typeof message !== "object" || !("content" in message)) return undefined;
+  const content = message.content;
+  const texts = typeof content === "string"
+    ? [content]
+    : Array.isArray(content)
+      ? content.flatMap((block) => {
+          const value = block as { type?: string; text?: string };
+          return value.type === "text" && typeof value.text === "string" ? [value.text] : [];
+        })
+      : [];
+  for (const text of texts) {
+    const tag = text.match(REF_TAG)?.[0] ?? text.match(TRAILING_REF_TAG)?.[0];
+    const ref = tag?.match(/m\d{1,5}/)?.[0];
+    if (ref) return ref;
+  }
+  return undefined;
+}
+
+function normalizeIdentityValue(value: unknown, message = false): unknown {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => {
+      if (!item || typeof item !== "object") return [normalizeIdentityValue(item)];
+      const block = item as { type?: unknown; text?: unknown };
+      if (block.type === "text" && typeof block.text === "string") {
+        const stripped = stripRefTag(block.text);
+        if (block.text !== stripped && stripped === "") return [];
+      }
+      return [normalizeIdentityValue(item)];
+    });
+  }
+  if (value === null || typeof value !== "object") return value;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    if (message && key === "timestamp") continue;
+    const item = (value as Record<string, unknown>)[key];
+    if (message && key === "content" && typeof item === "string") {
+      out[key] = [{ text: stripRefTag(item), type: "text" }];
+    } else if (key === "text" && typeof item === "string" && (value as { type?: unknown }).type === "text") {
+      out[key] = stripRefTag(item);
+    } else {
+      out[key] = normalizeIdentityValue(item);
+    }
+  }
+  return out;
 }
 
 function allToolCalls(content: unknown): { name: string; id: string; arguments?: unknown }[] {
@@ -248,9 +302,9 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
   let injected = false;
   for (let i = newBlocks.length - 1; i >= 0; i--) {
     const b = newBlocks[i] as { type?: string; text?: string };
-    if (b?.type === "text" && typeof b.text === "string") {
+    if (b?.type === "text" && typeof b.text === "string" && b.text.length > 0) {
       const baseText = b.text.replace(/\n*$/, "");
-      newBlocks[i] = { ...b, text: baseText.length > 0 ? `${baseText}\n\n${tag}` : tag };
+      newBlocks[i] = { ...b, text: `${baseText}\n\n${tag}` };
       injected = true;
       break;
     }
@@ -290,8 +344,8 @@ function peelRefTagBlocks(blocks: unknown[]): unknown[] {
   for (const block of blocks) {
     const b = block as { type?: string; text?: string };
     if (b?.type === "text" && typeof b.text === "string") {
-      const stripped = b.text.replace(REF_TAG, "");
-      if (stripped.length > 0) out.push({ ...b, text: stripped });
+      const stripped = stripRefTag(b.text);
+      if (stripped.length > 0 || b.text.length === 0) out.push({ ...b, text: stripped });
     } else {
       out.push(block);
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7,13 +7,10 @@ import {
   type Config,
 } from "acp-kernel";
 import { resolveConfig, type AdapterConfig } from "./config.js";
-import { entriesToCoreMessages } from "./messages.js";
-import { SessionStateStore } from "./state.js";
+import { entriesToCoreMessages, messageIdentity, messageRef } from "./messages.js";
+import { SessionStateStore, type LiveRefOrigin } from "./state.js";
 import { logInfo, logWarn } from "./log.js";
 
-// pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
-// `getBranch()`. Both return chronological SessionEntry[]; feature-detect so the
-// adapter runs under either host (omp's runner silently swallows the TypeError).
 type SessionEntrySource = {
   buildContextEntries?: () => SessionEntry[];
   getBranch?: () => SessionEntry[];
@@ -28,9 +25,6 @@ export function readContextEntries(sm: ExtensionContext["sessionManager"]): Sess
   return [];
 }
 
-// True only on pi: `--mode json` event streaming (used by async delegates) is a
-// pi feature. omp (oh-my-pi) has no json mode, so delegates must fall back to
-// `-p` there — same detection as readContextEntries above.
 export function isPiHost(sm: ExtensionContext["sessionManager"]): boolean {
   const source = sm as unknown as SessionEntrySource;
   return typeof source.buildContextEntries === "function";
@@ -41,13 +35,8 @@ export interface AcpRuntime {
   store: SessionStateStore;
   adapter: AdapterConfig;
   setAdapter(adapter: AdapterConfig): void;
-  /** Record that a nudge was already shown for the turn keyed by last user msg
-   *  id, so a tier/growth nudge prints at most once per turn instead of on
-   *  every context event (pi fires multiple per assistant reply). */
   markNudgeShown(turnKey: string): void;
   nudgeShownFor(turnKey: string): boolean;
-  /** Clear per-turn nudge tracking. Called on session_start so the Set does not
-   *  grow unbounded across sessions in a long-lived Pi process. */
   clearNudgeTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
@@ -56,54 +45,87 @@ export interface AcpRuntime {
   acquireLock(sid: string): Promise<() => void>;
 }
 
-// omp fires the context event before the current user message is persisted to
-// the session branch (its agent-loop emits message_end only after
-// prepareProviderCall → transformContext), so getBranch() lags one message
-// behind. Merge event.messages — the exact messages about to be sent,
-// including the not-yet-persisted tail — with the persisted branch records:
-// matching messages keep their stable entry id (so kernel refs survive once
-// the message is persisted on the next turn), unmatched tail messages get
-// `live-N` ids until they are persisted.
-function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[]): SessionEntry[] {
+function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: CompressionState, origins: LiveRefOrigin[]): SessionEntry[] {
   const persisted = entries.filter((e): e is SessionMessageEntry => e.type === "message");
+  const matched = matchPersistedSuffix(persisted, live);
+  const prior = matchOrigins(origins, live);
   const out: SessionEntry[] = [];
-  let p = 0;
-  let unmatched = 0;
+  const nextOrigins: LiveRefOrigin[] = [];
+  const usedIds = new Set<string>();
   for (let i = 0; i < live.length; i++) {
     const msg = live[i]!;
-    let matched: SessionMessageEntry | undefined;
-    let j = p;
-    while (j < persisted.length && persisted[j]!.message.role !== msg.role) j++;
-    if (j < persisted.length && sameMessage(persisted[j]!.message, msg)) {
-      matched = persisted[j]!;
-      p = j + 1;
+    const entry = matched[i];
+    const origin = prior[i];
+    if (entry) {
+      if (origin) migrateLiveRefs(state, origin.rawId, entry.id);
+      else migrateTaggedRef(state, msg, entry.id);
+      out.push(entry);
+      continue;
     }
-    if (matched) {
-      out.push(matched);
-    } else {
-      unmatched++;
-      out.push({
-        type: "message",
-        id: `live-${i}`,
-        parentId: null,
-        timestamp: String(msg.timestamp ?? Date.now()),
-        message: msg,
-      });
-    }
+    const id = origin?.rawId ?? nextLiveId(state, usedIds, i);
+    usedIds.add(id);
+    out.push({ type: "message", id, parentId: null, timestamp: String(msg.timestamp ?? Date.now()), message: msg });
+    nextOrigins.push({ rawId: id, identity: messageIdentity(msg) });
   }
+  origins.splice(0, origins.length, ...nextOrigins);
+  const unmatched = live.length - matched.length;
   if (unmatched > 0) logInfo("runtime", { event: "merge-live-entries", live: live.length, unmatched });
   return out;
 }
 
+function matchOrigins(origins: LiveRefOrigin[], live: AgentMessage[]): Array<LiveRefOrigin | undefined> {
+  for (let start = 0; start < origins.length; start++) {
+    const count = origins.length - start;
+    if (count > live.length) continue;
+    if (origins.slice(start).every((origin, index) => origin.identity === messageIdentity(live[index]!))) {
+      return [...origins.slice(start), ...Array<undefined>(live.length - count)];
+    }
+  }
+  return Array<undefined>(live.length);
+}
+
+function nextLiveId(state: CompressionState, used: Set<string>, index: number): string {
+  let id = `live-${index}`;
+  let suffix = index;
+  while (used.has(id) || state.messageRefs.byRaw[id] !== undefined) id = `live-${++suffix}`;
+  return id;
+}
+
+function migrateTaggedRef(state: CompressionState, message: AgentMessage, stableId: string): void {
+  const ref = messageRef(message);
+  const rawId = ref ? state.messageRefs.byRef[ref] : undefined;
+  if (rawId?.startsWith("live-")) migrateLiveRefs(state, rawId, stableId);
+}
+
+function migrateLiveRefs(state: CompressionState, liveId: string, stableId: string): void {
+  const rootId = liveId.split("#", 1)[0]!;
+  if (!rootId.startsWith("live-")) return;
+  for (const [rawId, ref] of Object.entries(state.messageRefs.byRaw)) {
+    if (rawId !== rootId && !rawId.startsWith(`${rootId}#`)) continue;
+    const stableRawId = `${stableId}${rawId.slice(rootId.length)}`;
+    if (state.messageRefs.byRaw[stableRawId] === undefined) {
+      state.messageRefs.byRaw[stableRawId] = ref;
+      state.messageRefs.byRef[ref] = stableRawId;
+    } else if (state.messageRefs.byRef[ref] === rawId) {
+      delete state.messageRefs.byRef[ref];
+    }
+    delete state.messageRefs.byRaw[rawId];
+  }
+}
+
+function matchPersistedSuffix(persisted: SessionMessageEntry[], live: AgentMessage[]): SessionMessageEntry[] {
+  for (let start = 0; start < persisted.length; start++) {
+    const count = persisted.length - start;
+    if (count > live.length) continue;
+    const suffix = persisted.slice(start);
+    if (suffix.every((entry, index) => sameMessage(entry.message, live[index]!))) return suffix;
+  }
+  return [];
+}
+
 function sameMessage(a: AgentMessage, b: AgentMessage): boolean {
-  const ra = (a as { role?: string }).role;
-  const rb = (b as { role?: string }).role;
-  if (ra !== rb) return false;
-  const ca = (a as { content?: unknown }).content;
-  const cb = (b as { content?: unknown }).content;
-  if (ca === undefined || cb === undefined) return false;
   try {
-    return JSON.stringify(ca) === JSON.stringify(cb);
+    return messageIdentity(a) === messageIdentity(b);
   } catch (e) {
     logWarn("runtime", { event: "message-compare-failed", error: e instanceof Error ? e.message : String(e) });
     return a === b;
@@ -120,20 +142,13 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
     let release!: () => void;
-    const next = new Promise<void>((resolve) => {
-      release = () => {
-        locks.delete(sid);
-        resolve();
-      };
-    });
+    const next = new Promise<void>((resolve) => { release = () => { locks.delete(sid); resolve(); }; });
     locks.set(sid, prev.then(() => next));
     await prev;
     return release;
   }
 
   function liveContextLimit(ctx: ExtensionContext): number {
-    // Prefer pi's reported context window (matches what the footer shows) over
-    // ctx.model.contextWindow, which can be stale or unset for some providers.
     const usage = ctx.getContextUsage?.();
     if (usage?.contextWindow && usage.contextWindow > 0) return usage.contextWindow;
     const m = ctx.model as { contextWindow?: number } | undefined;
@@ -146,18 +161,17 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
 
   async function stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]) {
     const sm = ctx.sessionManager;
-    const state = await store.load(sm.getSessionFile() ?? undefined, sm.getSessionId());
+    const sessionFile = sm.getSessionFile() ?? undefined;
+    const sessionId = sm.getSessionId();
+    const state = await store.load(sessionFile, sessionId);
     const entries = readContextEntries(sm);
-    // omp fires the context event BEFORE the current user message is persisted
-    // to the session branch (its agent-loop emits message_end only after
-    // prepareProviderCall → transformContext), so getBranch() lags one message
-    // behind and the current prompt would be dropped from the rebuilt context.
-    // pi appends user messages to the session before the LLM call, so its
-    // buildContextEntries() is always current. Merge event.messages (the exact
-    // messages about to be sent, including the not-yet-persisted tail) with the
-    // persisted branch records on the omp path only.
-    const merged = isPiHost(sm) || !liveMessages || liveMessages.length === 0 ? entries : mergeLiveEntries(entries, liveMessages);
-    return { state, coreMessages: entriesToCoreMessages(merged), entries: merged };
+    if (!isPiHost(sm) && liveMessages && liveMessages.length > 0) {
+      const origins = store.getLiveRefOrigins(sessionFile, sessionId);
+      const merged = mergeLiveEntries(entries, liveMessages, state, origins);
+      store.setLiveRefOrigins(sessionFile, sessionId, origins);
+      return { state, coreMessages: entriesToCoreMessages(merged), entries: merged };
+    }
+    return { state, coreMessages: entriesToCoreMessages(entries), entries };
   }
 
   async function save(state: CompressionState, ctx: ExtensionContext) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -5,24 +5,43 @@ import { logError, logWarn } from "./log.js";
 
 const STATE_SUFFIX = ".acp.json";
 
+export interface LiveRefOrigin {
+  rawId: string;
+  identity: string;
+}
+
+interface StateCacheSlot {
+  state: CompressionState;
+  liveRefOrigins: LiveRefOrigin[];
+}
+
 function stateFileFor(sessionFile: string | undefined): string | null {
   if (sessionFile) return sessionFile + STATE_SUFFIX;
   return null;
 }
 
-export class SessionStateStore {
-  private cache: CompressionState | null = null;
-  private loadedKey: string | null = null;
+function cacheKey(sessionFile: string | undefined, sessionId: string): string {
+  return sessionFile ? `file:${sessionFile}` : `session:${sessionId}`;
+}
 
-  async load(sessionFile: string | undefined, _sessionId: string): Promise<CompressionState> {
+export class SessionStateStore {
+  private cache = new Map<string, StateCacheSlot>();
+
+  async load(sessionFile: string | undefined, sessionId: string): Promise<CompressionState> {
     const file = stateFileFor(sessionFile);
-    if (file && this.loadedKey === file && this.cache) return this.cache;
+    const key = cacheKey(sessionFile, sessionId);
+    const cached = this.cache.get(key);
+    if (cached) return cached.state;
     let state = createInitialState();
+    let liveRefOrigins: LiveRefOrigin[] = [];
     if (file) {
       try {
         const raw = await fs.readFile(file, "utf8");
-        const parsed = JSON.parse(raw) as CompressionState;
-        if (parsed && Array.isArray(parsed.blocks)) state = mergeInitialState(parsed);
+        const parsed = JSON.parse(raw) as CompressionState & { liveRefOrigins?: unknown };
+        if (parsed && Array.isArray(parsed.blocks)) {
+          state = mergeInitialState(parsed);
+          liveRefOrigins = parseLiveRefOrigins(parsed.liveRefOrigins);
+        }
       } catch (e) {
         const code = (e as NodeJS.ErrnoException).code;
         if (code !== "ENOENT") {
@@ -30,37 +49,53 @@ export class SessionStateStore {
         }
       }
     }
-    this.cache = state;
-    this.loadedKey = file;
+    this.cache.set(key, { state, liveRefOrigins });
     return state;
   }
 
-  async save(state: CompressionState, sessionFile: string | undefined, _sessionId: string): Promise<void> {
+  async save(state: CompressionState, sessionFile: string | undefined, sessionId: string): Promise<void> {
     const file = stateFileFor(sessionFile);
     if (!file) return;
-    this.cache = state;
-    this.loadedKey = file;
+    const key = cacheKey(sessionFile, sessionId);
+    const liveRefOrigins = this.cache.get(key)?.liveRefOrigins ?? [];
+    this.cache.set(key, { state, liveRefOrigins });
     const dir = path.dirname(file);
     await fs.mkdir(dir, { recursive: true }).catch((e: unknown) => {
       logError("state", { event: "save-mkdir-failed", dir, error: e instanceof Error ? e.message : String(e) });
     });
     const tmp = path.join(dir, `.acp-tmp-${path.basename(file)}`);
     try {
-      await fs.writeFile(tmp, JSON.stringify(state), "utf8");
+      await fs.writeFile(tmp, JSON.stringify({ ...state, liveRefOrigins }), "utf8");
       await fs.rename(tmp, file);
     } catch (e) {
       logError("state", { event: "save-failed", file, error: e instanceof Error ? e.message : String(e) });
     }
   }
 
+  getLiveRefOrigins(sessionFile: string | undefined, sessionId: string): LiveRefOrigin[] {
+    return [...(this.cache.get(cacheKey(sessionFile, sessionId))?.liveRefOrigins ?? [])];
+  }
+
+  setLiveRefOrigins(sessionFile: string | undefined, sessionId: string, origins: LiveRefOrigin[]): void {
+    const key = cacheKey(sessionFile, sessionId);
+    const slot = this.cache.get(key);
+    if (slot) this.cache.set(key, { state: slot.state, liveRefOrigins: [...origins] });
+  }
+
   invalidate(): void {
-    this.cache = null;
-    this.loadedKey = null;
+    this.cache.clear();
   }
 }
 
-// Persisted state may predate new fields; fill any gaps so acp-kernel always sees
-// a complete CompressionState (forward-compatible load).
+function parseLiveRefOrigins(value: unknown): LiveRefOrigin[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is LiveRefOrigin => {
+    if (!item || typeof item !== "object") return false;
+    const origin = item as { rawId?: unknown; identity?: unknown };
+    return typeof origin.rawId === "string" && typeof origin.identity === "string";
+  });
+}
+
 function mergeInitialState(parsed: CompressionState): CompressionState {
   const fresh = createInitialState();
   return {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { rm, readFile } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
@@ -113,7 +114,8 @@ test("context handler works under omp (oh-my-pi) where sessionManager exposes ge
 test("omp context handler keeps the current (not-yet-persisted) user message: branch lags event.messages by one", async () => {
   const { api, handlers } = captureApi();
   createAcpExtension({ modelContextLimit: 200_000 })(api as any);
-
+  const stateFile = "/tmp/nonexistent-pai-acp-omp-lag.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
   // Simulate omp's real timing: the branch only holds the PREVIOUS turn's
   // messages (the current user message is persisted only after the LLM call,
   // in message_end, which omp emits AFTER transformContext → emitContext).
@@ -123,11 +125,11 @@ test("omp context handler keeps the current (not-yet-persisted) user message: br
     { role: "user", content: [{ type: "text", text: "SECOND MESSAGE" }], timestamp: Date.now() },
   ];
   const ctx = {
-    ...fakeCtx(persisted, "/tmp/nonexistent-pai-acp-omp-lag.session.json"),
+    ...fakeCtx(persisted, stateFile),
     sessionManager: {
       getBranch: () => persisted,
       getSessionId: () => "test-session",
-      getSessionFile: () => "/tmp/nonexistent-pai-acp-omp-lag.session.json",
+      getSessionFile: () => stateFile,
     },
   };
 
@@ -183,6 +185,121 @@ test("omp live message keeps the same entry id once persisted (stable refs acros
   assert.ok(r2);
   assert.equal(r2.messages.length, 2, "both persisted and live messages must survive");
 });
+
+test("omp migrates tagged live refs to stable entry ids", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-identity.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const texts = ["This tagged message must retain its stable persisted identity. ".repeat(130), "filler two ".repeat(400)];
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const first = await handlers.get("context")![0]!({ type: "context", messages: texts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() })) }, ctx);
+  const targetRef = first.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  persisted = texts.map((text, index) => userMsg(`e${index + 1}`, text));
+  await handlers.get("context")![0]!({ type: "context", messages: first.messages }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, targetRef);
+  assert.equal(saved.messageRefs.byRaw["live-0"], undefined);
+});
+
+test("omp matches a persisted context suffix before assigning live refs", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-suffix.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const texts = ["This suffix message must retain its persisted identity. ".repeat(130), "filler two ".repeat(400)];
+  const persisted = [userMsg("older", "This older branch message is absent from provider context."), ...texts.map((text, index) => userMsg(`e${index + 1}`, text))];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const transformed = await handlers.get("context")![0]!({ type: "context", messages: texts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() })) }, ctx);
+  const targetRef = transformed.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, targetRef);
+  assert.equal(saved.messageRefs.byRaw["live-0"], undefined);
+});
+
+test("omp rejects a non-contiguous persisted subsequence", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-gap.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const persisted = [userMsg("e1", "A"), userMsg("gap", "X"), userMsg("e2", "B")];
+  const ctx = fakeCtx(persisted, stateFile);
+  const result = await handlers.get("context")![0]!({ type: "context", messages: [
+    { role: "user", content: "A", timestamp: 1 },
+    { role: "user", content: "B", timestamp: 2 },
+  ] }, ctx);
+  const firstRef = result.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, undefined);
+  assert.equal(saved.messageRefs.byRaw["live-0"], firstRef);
+});
+
+test("omp migrates a live ref after the provider context evicts its prefix", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-shifted-live-ref.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const first = await handlers.get("context")![0]!({ type: "context", messages: ["A", "B", "C"].map((text) => ({ role: "user", content: text, timestamp: Date.now() })) }, ctx);
+  const bRef = first.messages[1].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  persisted = [userMsg("eA", "A"), userMsg("eB", "B"), userMsg("eC", "C")];
+  await handlers.get("context")![0]!({ type: "context", messages: [first.messages[1], first.messages[2]] }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.eB, bRef);
+  assert.equal(saved.messageRefs.byRaw["live-1"], undefined);
+  assert.equal(saved.messageRefs.byRef[bRef], "eB");
+});
+type PersistedEntry = { type: "message"; id: string; parentId: null; timestamp: string; message: Record<string, unknown> };
+
+test("omp does not bind a different toolCallId with identical visible text to the persisted identity", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-toolcallid.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const toolResult = (toolCallId: string) => ({
+    role: "toolResult",
+    toolName: "bash",
+    toolCallId,
+    content: [{ type: "text", text: "done" }],
+    isError: false,
+    timestamp: Date.now(),
+  });
+  let persisted: PersistedEntry[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const first = await handlers.get("context")![0]!({ type: "context", messages: [toolResult("call-1")] }, ctx);
+  const targetRef = first.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  persisted = [{ type: "message", id: "e1", parentId: null, timestamp: "", message: toolResult("call-1") }];
+  await handlers.get("context")![0]!({ type: "context", messages: [toolResult("call-2")] }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, undefined, "a different toolCallId must not inherit the persisted identity");
+  assert.equal(saved.messageRefs.byRaw["live-0"], targetRef, "the live message keeps its own ref");
+});
+
+test("omp does not bind differing image content with identical visible text to the persisted identity", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-image.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const imgMsg = (data: string) => ({
+    role: "user",
+    content: [
+      { type: "text", text: "see" },
+      { type: "image", data, mimeType: "image/png" },
+    ],
+    timestamp: Date.now(),
+  });
+  let persisted: PersistedEntry[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  const first = await handlers.get("context")![0]!({ type: "context", messages: [imgMsg("img-1")] }, ctx);
+  const targetRef = first.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  persisted = [{ type: "message", id: "e1", parentId: null, timestamp: "", message: imgMsg("img-1") }];
+  await handlers.get("context")![0]!({ type: "context", messages: [imgMsg("img-2")] }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, undefined, "different image data must not inherit the persisted identity");
+  assert.equal(saved.messageRefs.byRaw["live-0"], targetRef, "the live message keeps its own ref");
+});
 test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);
@@ -214,6 +331,7 @@ test("context handler persists state so a second call is idempotent on the same 
   const entries = [userMsg("e1", "alpha"), userMsg("e2", "beta")];
   const ctx = fakeCtx(entries, "/tmp/nonexistent-pai-acp-it2.session.json");
 
+
   const first = await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
   const second = await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
 
@@ -221,6 +339,100 @@ test("context handler persists state so a second call is idempotent on the same 
   const tag1 = ((first.messages[0] as any).content as any[]).find((b: any) => b.type === "text" && b.text.startsWith("[m"));
   const tag2 = ((second.messages[0] as any).content as any[]).find((b: any) => b.type === "text" && b.text.startsWith("[m"));
   assert.equal(tag1?.text, tag2?.text, "refs stable across calls (loaded from persisted state)");
+});
+test("omp migrates assistant tool-call refs after prefix eviction", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-assistant-origin.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const assistant = (id: string) => ({ role: "assistant", content: [{ type: "toolCall", id, name: "read", arguments: { path: "x" } }], timestamp: Date.now() });
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  await handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, ctx);
+  const firstState = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  const ref = firstState.messageRefs.byRaw["live-0"];
+  assert.ok(ref, "assistant temporary ref must be assigned");
+  persisted = [userMsg("older", "evicted"), { type: "message", id: "e-assistant", parentId: null, timestamp: "", message: assistant("call-a") }];
+  await handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw["e-assistant"], ref);
+  assert.equal(saved.messageRefs.byRaw["live-0"], undefined);
+});
+
+test("omp migrates parallel assistant tool-call child refs after prefix eviction", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-parallel-origin.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const assistant = () => ({ role: "assistant", content: [
+    { type: "text", text: "parallel" },
+    { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a" } },
+    { type: "toolCall", id: "call-b", name: "write", arguments: { path: "b" } },
+  ], timestamp: Date.now() });
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const ctx = { ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } };
+  await handlers.get("context")![0]!({ type: "context", messages: [assistant()] }, ctx);
+  const first = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  const callARef = first.messageRefs.byRaw["live-0#call-a"];
+  const callBRef = first.messageRefs.byRaw["live-0#call-b"];
+  assert.ok(callARef && callBRef);
+  persisted = [{ type: "message", id: "e-assistant", parentId: null, timestamp: "", message: assistant() }];
+  await handlers.get("context")![0]!({ type: "context", messages: [assistant()] }, ctx);
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw["e-assistant#call-a"], callARef);
+  assert.equal(saved.messageRefs.byRaw["e-assistant#call-b"], callBRef);
+  assert.equal(saved.messageRefs.byRaw["live-0#call-a"], undefined);
+  assert.equal(saved.messageRefs.byRaw["live-0#call-b"], undefined);
+});
+
+test("omp reloads assistant origins before migrating after prefix eviction", async () => {
+  const stateFile = "/tmp/nonexistent-pai-acp-assistant-reload.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const assistant = (id: string) => ({ role: "assistant", content: [{ type: "toolCall", id, name: "read", arguments: { path: "x" } }], timestamp: Date.now() });
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const makeCtx = () => ({ ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } });
+  const first = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(first.api);
+  await first.handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, makeCtx());
+  const initial = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  const ref = initial.messageRefs.byRaw["live-0"];
+  assert.ok(ref);
+  const second = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(second.api);
+  persisted = [{ type: "message", id: "e-assistant", parentId: null, timestamp: "", message: assistant("call-a") }];
+  await second.handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, makeCtx());
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw["e-assistant"], ref);
+  assert.equal(saved.messageRefs.byRaw["live-0"], undefined);
+  assert.equal(saved.messageRefs.byRef[ref], "e-assistant");
+});
+
+test("omp preserves stable destination when migrating a colliding live ref", async () => {
+  const stateFile = "/tmp/nonexistent-pai-acp-collision.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const assistant = (id: string) => ({ role: "assistant", content: [{ type: "toolCall", id, name: "read", arguments: { path: "x" } }], timestamp: Date.now() });
+  let persisted: ReturnType<typeof userMsg>[] = [];
+  const makeCtx = () => ({ ...fakeCtx(persisted, stateFile), sessionManager: { getBranch: () => persisted, getSessionId: () => "test-session", getSessionFile: () => stateFile } });
+  const first = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(first.api);
+  await first.handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, makeCtx());
+  const initial = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  const liveRef = initial.messageRefs.byRaw["live-0"];
+  assert.ok(liveRef);
+  const stableRef = "m09999";
+  initial.messageRefs.byRaw["e-assistant"] = stableRef;
+  initial.messageRefs.byRef[stableRef] = "e-assistant";
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(`${stateFile}.acp.json`, JSON.stringify(initial), "utf8");
+  const second = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(second.api);
+  persisted = [{ type: "message", id: "e-assistant", parentId: null, timestamp: "", message: assistant("call-a") }];
+  await second.handlers.get("context")![0]!({ type: "context", messages: [assistant("call-a")] }, makeCtx());
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw["e-assistant"], stableRef);
+  assert.equal(saved.messageRefs.byRef[stableRef], "e-assistant");
+  assert.equal(saved.messageRefs.byRaw["live-0"], undefined);
+  assert.equal(saved.messageRefs.byRef[liveRef], undefined);
 });
 
 test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the system prompt", () => {

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { entriesToCoreMessages, coreOutToAgentMessages } from "../src/messages.js";
+import { entriesToCoreMessages, coreOutToAgentMessages, messageIdentity } from "../src/messages.js";
 import type { CoreMessage } from "acp-kernel";
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 
@@ -421,4 +421,14 @@ test("coreOutToAgentMessages drops pruned tool-call blocks when only some surviv
   const toolCalls = content.filter((b) => b.type === "toolCall");
   assert.equal(toolCalls.length, 2, "only 2 surviving tool-call blocks");
   assert.deepEqual(toolCalls.map((b) => b.id), ["call_a", "call_c"]);
+});
+
+test("message identity ignores tag-only text blocks but preserves original empty blocks", () => {
+  const image = { type: "image", data: "same", mimeType: "image/png" };
+  const tag = acpRef("m00042");
+  const taggedImage = { role: "user", content: [image, { type: "text", text: tag }], timestamp: 1 };
+  const imageOnly = { role: "user", content: [image], timestamp: 2 };
+  const emptyText = { role: "user", content: [image, { type: "text", text: "" }], timestamp: 3 };
+  assert.equal(messageIdentity(taggedImage), messageIdentity(imageOnly));
+  assert.notEqual(messageIdentity(emptyText), messageIdentity(imageOnly));
 });

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -81,3 +81,22 @@ test("invalidate forces a fresh read after save", async () => {
   assert.equal(reloaded.nextBlockId, 5);
   await rm(dir, { recursive: true, force: true });
 });
+
+test("live ref origins remain isolated across interleaved sessions", async () => {
+  const dir = await tempDir();
+  const fileA = path.join(dir, "a.session.json");
+  const fileB = path.join(dir, "b.session.json");
+  const store = new SessionStateStore();
+  const stateA = await store.load(fileA, "a");
+  const stateB = await store.load(fileB, "b");
+  store.setLiveRefOrigins(fileA, "a", [{ rawId: "live-1", identity: "A" }]);
+  store.setLiveRefOrigins(fileB, "b", [{ rawId: "live-0", identity: "B" }]);
+  await store.save(stateA, fileA, "a");
+  await store.save(stateB, fileB, "b");
+  store.invalidate();
+  await store.load(fileA, "a");
+  await store.load(fileB, "b");
+  assert.deepEqual(store.getLiveRefOrigins(fileA, "a"), [{ rawId: "live-1", identity: "A" }]);
+  assert.deepEqual(store.getLiveRefOrigins(fileB, "b"), [{ rawId: "live-0", identity: "B" }]);
+  await rm(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Why
OMP provider context can evict older prefixes before the current turn is persisted. The adapter previously matched messages by visible text or current live index, which could collapse distinct messages and leave temporary refs orphaned after persistence—especially for assistant tool calls that intentionally do not expose ACP tags.

## What
- Compare complete message identities while normalizing only leading/trailing ACP ref tags.
- Match only a contiguous persisted suffix against the provider context.
- Persist per-session live-ref origins and migrate temporary root/parallel tool-call refs to stable entry IDs across prefix eviction and runtime reloads.
- Preserve stable destination mappings during collisions and remove stale temporary reverse mappings.
- Isolate persisted origin caches by session/file and clean fixed test state before reuse.

## How
The adapter stores ordered `LiveRefOrigin` metadata alongside kernel state, keyed by session file or session ID. OMP merge aligns the longest prior-origin suffix with the current provider prefix, then migrates each matched temporary raw ID and its `#callId` children to the persisted entry ID. Assistant messages remain untagged to prevent model echo.

## Test Plan
- [x] `npm run typecheck`
- [x] `node --import tsx --test tests/messages.test.ts tests/state.test.ts tests/integration.test.ts` (47/47)
- [x] `npm test` (177/177 before rebase)
- [x] `npm run build` (before rebase)
- [x] Standards review: no findings
- [x] Spec review: no findings