### PR TITLE
release v0.1.35: acp-kernel 0.0.20 + user-facing compression config

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,237 @@
+# Configuration
+
+[English](./CONFIGURATION.md) | [中文](./CONFIGURATION.zh-CN.md)
+
+**billion-context-pi** works out of the box with no configuration — it reads your model's context window automatically and applies sensible defaults. This document is the complete reference for the optional JSON configuration file (`acp.json`) and the environment variables that let you tune behavior.
+
+Configuration is layered: environment variables take the highest precedence, followed by the project config file, then the global config file, and finally the built-in defaults.
+
+---
+
+## Config file locations
+
+Settings are read from JSON files named `acp.json`. The global file applies to every project; a project file overrides the global one on a **per-field** basis (individual keys you do not set in the project file still fall back to the global value).
+
+| Scope | Path | Applies to |
+|-------|------|------------|
+| **Global** | `~/.pi/acp.json` | All projects on this machine |
+| **Project** | `<project>/.pi/acp.json` | The current project only (overrides global per-field) |
+
+> **Precedence:** Environment variable &gt; Project file &gt; Global file &gt; Built-in default.
+
+Files are loaded at session start. Missing files, malformed JSON, and unknown keys are silently ignored — the extension never fails to start because of a config issue. Only the documented keys are read; everything else is discarded.
+
+---
+
+## Quick start
+
+Create `~/.pi/acp.json` (or `<project>/.pi/acp.json`) and drop in whichever keys you want to change. Every field below is optional — omit a key to keep its default.
+
+```json
+{
+  "debug": false,
+  "autoUpdate": true,
+  "modelContextLimit": 200000,
+  "toolBashDefaultTimeout": 60,
+  "toolOutputMaxBytes": 200000,
+
+  "delegate": {
+    "enabled": true,
+    "displayUsage": "separate"
+  },
+
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000
+  }
+}
+```
+
+A minimal config enabling only debug logging:
+
+```json
+{
+  "debug": true
+}
+```
+
+---
+
+## Parameter Reference
+
+### Status legend
+
+| Status | Meaning |
+|--------|---------|
+| 🟢 **ACTIVE** | Fully supported, documented, and recommended for use. |
+
+All keys below are currently **ACTIVE**.
+
+### Summary
+
+**Top-level keys**
+
+| Key | Type | Default | Status | Description |
+|-----|------|---------|--------|-------------|
+| `debug` | boolean | `false` | 🟢 ACTIVE | Enable verbose debug-level events in the log. |
+| `autoUpdate` | boolean | `true` | 🟢 ACTIVE | Check npm for a newer version on startup and auto-install it. |
+| `modelContextLimit` | number | *(auto)* | 🟢 ACTIVE | Override the context limit (in tokens). |
+| `toolBashDefaultTimeout` | number | `60` | 🟢 ACTIVE | Default `bash` tool timeout in seconds when the model omits it. |
+| `toolOutputMaxBytes` | number | `200000` | 🟢 ACTIVE | Hard byte cap on tool result text. |
+
+**Delegate keys**
+
+| Key | Type | Default | Status | Description |
+|-----|------|---------|--------|-------------|
+| `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | Enable the `acp_delegate` tools and their system-prompt section. |
+| `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | Controls how delegate sub-agent token usage is reported. |
+
+**Compression keys**
+
+| Key | Type | Default | Status | Description |
+|-----|------|---------|--------|-------------|
+| `compress.maxContextLimit` | number \| string | `"75%"` | 🟢 ACTIVE | Context threshold that triggers forced compression nudges. |
+| `compress.emergencyThresholdPercent` | number \| string | `"95%"` | 🟢 ACTIVE | Context threshold that triggers emergency truncation. |
+| `compress.nudgeGrowthTokens` | number | `50000` | 🟢 ACTIVE | Token growth step for soft compression nudges. |
+
+**Environment variables**
+
+| Variable | Effect |
+|----------|--------|
+| `ACP_AUTO_UPDATE` | Set to `0` / `false` to disable auto-update (overrides `autoUpdate`). |
+| `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit (takes highest precedence). |
+| `ACP_DEBUG` | Set to `1` / `true` to enable debug logging. |
+| `ACP_LOG_FILE` | Override the log file path (default `~/.pi/acp.log`). |
+
+> **Only the documented keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three compression thresholds form a three-tier escalation: growth-driven soft nudges → forced nudges at `compress.maxContextLimit` → emergency truncation at `compress.emergencyThresholdPercent`.
+
+---
+
+## General
+
+### `debug`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** 🟢 ACTIVE
+- **Description:** Enable verbose **debug-level** events in the log file (default `~/.pi/acp.log`). The always-on log (session/turn/compress/delegate lifecycle events, all errors and warnings) is written regardless of this setting; `debug` only adds extra diagnostics such as full field dumps and per-turn internals. Also enabled by the environment variable `ACP_DEBUG=1` (or `ACP_DEBUG=true`).
+
+### `autoUpdate`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** 🟢 ACTIVE
+- **Description:** On Pi startup, check the npm registry for a newer version of `billion-context-pi` and auto-install it. Set to `false` to avoid all startup network calls. Can also be disabled via the `ACP_AUTO_UPDATE` environment variable (`ACP_AUTO_UPDATE=0` or `ACP_AUTO_UPDATE=false`), which overrides this setting.
+
+### `modelContextLimit`
+
+- **Type:** `number`
+- **Default:** *(auto)* — the model's `contextWindow` read live each turn
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the context limit, in tokens. By default the limit is read from the active model's `ctx.model.contextWindow` on every turn, so it stays correct when you switch models. Set an explicit value for deterministic test runs or headless/non-interactive sessions where the model metadata may be unavailable. The `ACP_MODEL_CONTEXT_LIMIT` environment variable takes precedence over this value.
+
+### `toolBashDefaultTimeout`
+
+- **Type:** `number`
+- **Default:** `60`
+- **Status:** 🟢 ACTIVE
+- **Description:** The number of seconds injected into the `bash` tool when the model omits the `timeout` parameter. Pi has **no** built-in default timeout of its own, so without this guard a command the model forgets to time out can hang for thousands of seconds. On timeout the model is guided to re-run the command with a larger `timeout`. Set to `0` to disable this guard and restore Pi's unbounded behavior.
+
+### `toolOutputMaxBytes`
+
+- **Type:** `number`
+- **Default:** `200000`
+- **Status:** 🟢 ACTIVE
+- **Description:** A hard byte cap (~200 KB, roughly 5000 lines) applied to tool result text via the `tool_result` hook. It stops runaway output that Pi's own caps cannot catch (for example, from tools Pi does not cap). When the cap fires, the oversized text is head-truncated with a notice telling the model how to see the full output. Set lower (e.g. `8192`) for a tighter context budget, or set to `0` to disable the cap entirely.
+
+---
+
+## Delegate
+
+The `delegate` sub-object controls the `acp_delegate` sub-agent tool family (`acp_delegate`, `acp_delegate_wait`, `acp_delegate_cancel`) and how their token usage is reported.
+
+> **Backward compatibility:** For convenience, `delegate` accepts both an object and a boolean shorthand:
+> - `delegate: true` is treated as `delegate: { enabled: true }`.
+> - The legacy flat top-level `displayUsage` key is still accepted as an alias for `delegate.displayUsage`. Prefer the nested `delegate.displayUsage` form.
+
+### `delegate.enabled`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** 🟢 ACTIVE
+- **Description:** Enable the `acp_delegate` tools (`acp_delegate`, `acp_delegate_wait`, `acp_delegate_cancel`) and the system-prompt section that describes them. Set to `false` to skip registering them entirely — for example, if you use a different sub-agent extension, or when running headless where async result injection adds no value.
+
+### `delegate.displayUsage`
+
+- **Type:** string enum `"merged" | "separate"`
+- **Default:** `"separate"`
+- **Status:** 🟢 ACTIVE
+- **Description:** Controls how delegate sub-agent token usage is reported back to the main session. `"separate"` (default) tracks delegate tokens in a separate accumulator — the main session totals stay clean and delegate usage shows as its own block in `acp_status` (excluded from main totals). `"merged"` folds delegate token usage into the tool-result `usage` field so it is counted as part of the main session totals. Only meaningful when `delegate.enabled` is `true`.
+
+---
+
+## Compression Tuning
+
+The `compress` sub-object groups the three thresholds that form a **three-tier escalation** for context management. They control *when* the model is nudged to compress and *when* large outputs are forcibly truncated to keep the session alive. Lower thresholds mean the extension compresses earlier and more aggressively.
+
+The flow is:
+
+1. **Growth-driven soft nudges** (0–75%) — governed by `compress.nudgeGrowthTokens`.
+2. **Forced nudges** (75–95%) — once usage crosses `compress.maxContextLimit`, nudges fire regardless of the growth gate. These are lossless.
+3. **Emergency truncation** (95%+) — once usage crosses `compress.emergencyThresholdPercent`, large tool outputs are truncated to prevent context overflow. This is lossy.
+
+### `compress.maxContextLimit`
+
+- **Type:** `number | string`
+- **Default:** `0.75` (or `"75%"`)
+- **Status:** 🟢 ACTIVE
+- **Description:** The context-usage threshold that triggers **forced compression** nudges. Once usage reaches this level, nudges fire on every turn, bypassing the growth-gate and cadence checks that normally throttle them. Accepts a ratio (`0.75`) or a percent string (`"75%"`). A lower value makes the extension compress earlier and more aggressively. Maps to the kernel setting `nudge.maxContextLimitPct`.
+
+### `compress.emergencyThresholdPercent`
+
+- **Type:** `number | string`
+- **Default:** `0.95` (or `"95%"`)
+- **Status:** 🟢 ACTIVE
+- **Description:** The context-usage threshold that triggers **emergency truncation** of large tool outputs to keep the session alive when context is nearly full. Accepts a ratio (`0.95`) or a percent string (`"95%"`). This value **must be greater than or equal to** `compress.maxContextLimit`, otherwise the escalation order breaks. Maps to the kernel settings `nudge.emergencyThresholdPct` and `truncate.threshold`.
+
+### `compress.nudgeGrowthTokens`
+
+- **Type:** `number`
+- **Default:** `50000`
+- **Status:** 🟢 ACTIVE
+- **Description:** The token-growth threshold that controls the cadence of **soft** compression nudges. A soft nudge fires roughly every time this many tokens of new compressible content accumulate. A lower value means the model is nudged to compress more often; a higher value means less frequent nudges. This only governs *growth-driven* nudges — once usage crosses `compress.maxContextLimit`, forced nudges take over regardless of this setting. Maps to the kernel settings `nudge.growthFloor` and `nudge.growthCap`.
+
+---
+
+## Environment Variables
+
+Environment variables take precedence over the JSON config files. They are useful for one-off overrides, CI runs, and headless sessions where you want to avoid editing config files.
+
+### `ACP_AUTO_UPDATE`
+
+- **Type:** string flag
+- **Default:** *(unset — auto-update follows the `autoUpdate` config)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Set to `0` or `false` to **disable** auto-update (same effect as `"autoUpdate": false`). Leave unset to honor the config. This is the recommended way to disable startup network calls in locked-down environments without modifying `acp.json`.
+
+### `ACP_MODEL_CONTEXT_LIMIT`
+
+- **Type:** integer (tokens)
+- **Default:** *(unset — limit follows `modelContextLimit`, then the live model context window)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the context limit, in tokens. **Takes the highest precedence** — overrides the `modelContextLimit` config value. Useful for forcing a specific limit in test harnesses and headless runs where model metadata is unavailable or unreliable.
+
+### `ACP_DEBUG`
+
+- **Type:** string flag
+- **Default:** *(unset — debug logging follows the `debug` config)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Set to `1` or `true` to enable debug-level logging. Equivalent to setting `"debug": true` in the config, but applied without editing a file. The always-on lifecycle/error/warning events are written regardless.
+
+### `ACP_LOG_FILE`
+
+- **Type:** string (file path)
+- **Default:** `~/.pi/acp.log`
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the path to the log file. By default, structured logs are written to `~/.pi/acp.log` (the file rotates to `~/.pi/acp.log.old` at 10 MB). Point this at a different location to keep per-project or per-run logs separate.

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -1,0 +1,237 @@
+# 配置参考
+
+[English](./CONFIGURATION.md) | [中文](./CONFIGURATION.zh-CN.md)
+
+**billion-context-pi** 开箱即用，无需任何配置——它会自动读取模型的上下文窗口并应用合理的默认值。本文档是可选 JSON 配置文件（`acp.json`）和环境变量的完整参考，用于调整行为。
+
+配置是分层的：环境变量优先级最高，其次是项目配置文件，再次是全局配置文件，最后是内置默认值。
+
+---
+
+## 配置文件位置
+
+配置从名为 `acp.json` 的 JSON 文件中读取。全局文件对所有项目生效；项目文件以**逐字段**方式覆盖全局文件（在项目文件中未设置的键仍然回退到全局值）。
+
+| 范围 | 路径 | 生效范围 |
+|------|------|----------|
+| **全局** | `~/.pi/acp.json` | 本机所有项目 |
+| **项目** | `<项目>/.pi/acp.json` | 仅当前项目（逐字段覆盖全局） |
+
+> **优先级：** 环境变量 &gt; 项目文件 &gt; 全局文件 &gt; 内置默认值。
+
+文件在会话启动时加载。缺失文件、格式错误的 JSON、未知键都会被静默忽略——扩展绝不会因为配置问题而无法启动。只有文档中列出的键会被读取，其余一律丢弃。
+
+---
+
+## 快速开始
+
+创建 `~/.pi/acp.json`（或 `<项目>/.pi/acp.json`），放入你想修改的键即可。以下每个字段都是可选的——省略某个键则保持其默认值。
+
+```json
+{
+  "debug": false,
+  "autoUpdate": true,
+  "modelContextLimit": 200000,
+  "toolBashDefaultTimeout": 60,
+  "toolOutputMaxBytes": 200000,
+
+  "delegate": {
+    "enabled": true,
+    "displayUsage": "separate"
+  },
+
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000
+  }
+}
+```
+
+仅开启调试日志的最小配置：
+
+```json
+{
+  "debug": true
+}
+```
+
+---
+
+## 参数总览
+
+### 状态说明
+
+| 状态 | 含义 |
+|------|------|
+| 🟢 **ACTIVE** | 完全支持、已文档化、推荐使用。 |
+
+以下所有键当前均为 **ACTIVE**。
+
+### 总览
+
+**顶层键**
+
+| 键 | 类型 | 默认值 | 状态 | 说明 |
+|----|------|--------|------|------|
+| `debug` | boolean | `false` | 🟢 ACTIVE | 开启日志中的详细调试事件。 |
+| `autoUpdate` | boolean | `true` | 🟢 ACTIVE | 启动时检查 npm 并自动安装更新。 |
+| `modelContextLimit` | number | *(自动)* | 🟢 ACTIVE | 覆盖上下文窗口大小（token 数）。 |
+| `toolBashDefaultTimeout` | number | `60` | 🟢 ACTIVE | 模型省略 `timeout` 时注入 bash 工具的默认超时秒数。 |
+| `toolOutputMaxBytes` | number | `200000` | 🟢 ACTIVE | 工具返回文本的硬性字节上限。 |
+
+**delegate 键**
+
+| 键 | 类型 | 默认值 | 状态 | 说明 |
+|----|------|--------|------|------|
+| `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | 启用 `acp_delegate` 工具及其系统提示部分。 |
+| `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | 控制 delegate 子代理的 token 用量如何报回主会话。 |
+
+**compress 键**
+
+| 键 | 类型 | 默认值 | 状态 | 说明 |
+|----|------|--------|------|------|
+| `compress.maxContextLimit` | number \| string | `"75%"` | 🟢 ACTIVE | 触发强制压缩 nudge 的上下文阈值。 |
+| `compress.emergencyThresholdPercent` | number \| string | `"95%"` | 🟢 ACTIVE | 触发紧急截断的上下文阈值。 |
+| `compress.nudgeGrowthTokens` | number | `50000` | 🟢 ACTIVE | 软压缩 nudge 的 token 增长步长。 |
+
+**环境变量**
+
+| 变量 | 效果 |
+|------|------|
+| `ACP_AUTO_UPDATE` | 设为 `0` / `false` 禁用自动更新（覆盖 `autoUpdate`）。 |
+| `ACP_MODEL_CONTEXT_LIMIT` | 覆盖上下文窗口大小（优先级最高）。 |
+| `ACP_DEBUG` | 设为 `1` / `true` 开启调试日志。 |
+| `ACP_LOG_FILE` | 覆盖日志文件路径（默认 `~/.pi/acp.log`）。 |
+
+> **只有文档中列出的键才会从 `acp.json` 读取。** 其他调优参数（`preserveRecentMessages`、`protectedTools`）是代码级别的，不开放给用户。三个压缩阈值构成三级递进：基于增长的软 nudge → 越过 `compress.maxContextLimit` 后的强制 nudge → 越过 `compress.emergencyThresholdPercent` 后的紧急截断。
+
+---
+
+## 通用
+
+### `debug`
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **状态：** 🟢 ACTIVE
+- **说明：** 在日志文件（默认 `~/.pi/acp.log`）中开启详细的**调试级**事件。无论此设置如何，常驻日志（会话/轮次/压缩/delegate 生命周期事件，所有错误和警告）始终写入；`debug` 只添加额外的诊断信息，如完整字段转储和逐轮内部数据。也可通过环境变量 `ACP_DEBUG=1`（或 `ACP_DEBUG=true`）开启。
+
+### `autoUpdate`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** 🟢 ACTIVE
+- **说明：** Pi 启动时检查 npm 是否有更新版本的 `billion-context-pi` 并自动安装。设为 `false` 可避免启动时的所有网络请求。也可通过 `ACP_AUTO_UPDATE` 环境变量（`ACP_AUTO_UPDATE=0` 或 `ACP_AUTO_UPDATE=false`）禁用，该变量优先于此配置。
+
+### `modelContextLimit`
+
+- **类型：** `number`
+- **默认值：** *(自动)* —— 每轮实时读取模型的 `contextWindow`
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖上下文窗口大小（token 数）。默认每轮从活跃模型的 `ctx.model.contextWindow` 读取，切换模型时自动保持正确。在模型元数据可能不可用的测试或无头/非交互会话中，可设置显式值。环境变量 `ACP_MODEL_CONTEXT_LIMIT` 优先于此值。
+
+### `toolBashDefaultTimeout`
+
+- **类型：** `number`
+- **默认值：** `60`
+- **状态：** 🟢 ACTIVE
+- **说明：** 当模型省略 `timeout` 参数时注入 `bash` 工具的超时秒数。Pi **没有**内置默认超时，因此若缺少此保护，模型忘记设置超时的命令可能会挂起数千秒。超时后模型被引导以更大的 `timeout` 重新运行。设为 `0` 可禁用此保护，恢复 Pi 的无限制行为。
+
+### `toolOutputMaxBytes`
+
+- **类型：** `number`
+- **默认值：** `200000`
+- **状态：** 🟢 ACTIVE
+- **说明：** 通过 `tool_result` 钩子对工具返回文本施加的硬性字节上限（约 200KB，约 5000 行）。它拦截 Pi 自身上限无法覆盖的失控输出（例如 Pi 不做限制的工具）。触发上限时，超长文本会被头部截断，并附带提示告知模型如何查看完整输出。设小一些（如 `8192`）可收紧上下文预算，设为 `0` 则完全禁用。
+
+---
+
+## Delegate
+
+`delegate` 子对象控制 `acp_delegate` 子代理工具族（`acp_delegate`、`acp_delegate_wait`、`acp_delegate_cancel`）及其 token 用量的报告方式。
+
+> **向后兼容：** 为方便使用，`delegate` 同时接受对象和布尔简写：
+> - `delegate: true` 等同于 `delegate: { enabled: true }`。
+> - 遗留的顶层平铺 `displayUsage` 键仍被接受，作为 `delegate.displayUsage` 的别名。推荐使用嵌套形式 `delegate.displayUsage`。
+
+### `delegate.enabled`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** 🟢 ACTIVE
+- **说明：** 启用 `acp_delegate` 工具（`acp_delegate`、`acp_delegate_wait`、`acp_delegate_cancel`）及其对应的系统提示部分。设为 `false` 可完全跳过注册——例如你使用了其他子代理扩展，或者在无头环境下运行时异步结果注入没有意义。
+
+### `delegate.displayUsage`
+
+- **类型：** 字符串枚举 `"merged" | "separate"`
+- **默认值：** `"separate"`
+- **状态：** 🟢 ACTIVE
+- **说明：** 控制 delegate 子代理的 token 用量如何报回主会话。`"separate"`（默认）将 delegate token 记入独立累加器——主会话总量保持干净，delegate 用量在 `acp_status` 中单独显示一块（不计入主总量）。`"merged"` 将 delegate token 用量并入工具返回的 `usage` 字段，算作主会话总量的一部分。仅在 `delegate.enabled` 为 `true` 时有意义。
+
+---
+
+## 压缩调优
+
+`compress` 子对象包含三个阈值，构成上下文管理的**三级递进**。它们控制模型*何时*被 nudge 压缩，以及大输出*何时*被强制截断以维持会话存活。阈值越低，扩展压缩得越早、越激进。
+
+流程如下：
+
+1. **基于增长的软 nudge**（0–75%）——由 `compress.nudgeGrowthTokens` 控制。
+2. **强制 nudge**（75–95%）——当用量越过 `compress.maxContextLimit` 时，无论增长门控如何都会触发 nudge。此阶段无损。
+3. **紧急截断**（95%+）——当用量越过 `compress.emergencyThresholdPercent` 时，截断大型工具输出以防止上下文溢出。此阶段有损。
+
+### `compress.maxContextLimit`
+
+- **类型：** `number | string`
+- **默认值：** `0.75`（或 `"75%"`）
+- **状态：** 🟢 ACTIVE
+- **说明：** 触发**强制压缩** nudge 的上下文用量阈值。用量达到此水平后，每轮都会触发 nudge，绕过通常限制频率的增长门控和节奏检查。接受比例值（`0.75`）或百分比字符串（`"75%"`）。值越低，扩展压缩得越早、越激进。映射到内核设置 `nudge.maxContextLimitPct`。
+
+### `compress.emergencyThresholdPercent`
+
+- **类型：** `number | string`
+- **默认值：** `0.95`（或 `"95%"`）
+- **状态：** 🟢 ACTIVE
+- **说明：** 触发**紧急截断**的上下文用量阈值——在上下文即将满时截断大型工具输出以维持会话存活。接受比例值（`0.95`）或百分比字符串（`"95%"`）。此值**必须大于等于** `compress.maxContextLimit`，否则递进顺序会被破坏。映射到内核设置 `nudge.emergencyThresholdPct` 和 `truncate.threshold`。
+
+### `compress.nudgeGrowthTokens`
+
+- **类型：** `number`
+- **默认值：** `50000`
+- **状态：** 🟢 ACTIVE
+- **说明：** 控制**软**压缩 nudge 频率的 token 增长阈值。每当积累约这么多新可压缩内容时，触发一次软 nudge。值越低模型被 nudge 压缩的频率越高；值越低频率越低。此设置只控制*基于增长的* nudge——用量越过 `compress.maxContextLimit` 后，强制 nudge 接管，不受此设置影响。映射到内核设置 `nudge.growthFloor` 和 `nudge.growthCap`。
+
+---
+
+## 环境变量
+
+环境变量优先于 JSON 配置文件。适用于一次性覆盖、CI 运行，以及不想编辑配置文件的无头会话。
+
+### `ACP_AUTO_UPDATE`
+
+- **类型：** 字符串标志
+- **默认值：** *(未设置——自动更新遵循 `autoUpdate` 配置)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 设为 `0` 或 `false` 可**禁用**自动更新（等效于 `"autoUpdate": false`）。不设置则遵循配置。这是在不修改 `acp.json` 的情况下禁用启动网络请求的推荐方式，适用于受限环境。
+
+### `ACP_MODEL_CONTEXT_LIMIT`
+
+- **类型：** 整数（token 数）
+- **默认值：** *(未设置——窗口大小遵循 `modelContextLimit`，再回退到实时模型上下文窗口)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖上下文窗口大小（token 数）。**优先级最高**——覆盖 `modelContextLimit` 配置值。适用于在模型元数据不可用或不可靠的测试框架和无头运行中强制指定窗口大小。
+
+### `ACP_DEBUG`
+
+- **类型：** 字符串标志
+- **默认值：** *(未设置——调试日志遵循 `debug` 配置)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 设为 `1` 或 `true` 开启调试级日志。等效于配置中设 `"debug": true`，但无需编辑文件。常驻的生命周期/错误/警告事件无论此设置如何都会写入。
+
+### `ACP_LOG_FILE`
+
+- **类型：** 字符串（文件路径）
+- **默认值：** `~/.pi/acp.log`
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖日志文件路径。默认情况下，结构化日志写入 `~/.pi/acp.log`（文件在 10MB 时轮转为 `~/.pi/acp.log.old`）。指向不同位置可为每个项目或每次运行保留独立日志。

--- a/README.md
+++ b/README.md
@@ -148,7 +148,10 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
   "modelContextLimit": 200000,
   "delegate": true,
   "toolBashDefaultTimeout": 60,
-  "toolOutputMaxBytes": 200000
+  "toolOutputMaxBytes": 200000,
+  "maxContextLimit": "75%",
+  "emergencyThresholdPercent": "95%",
+  "nudgeGrowthTokens": 50000
 }
 ```
 
@@ -160,8 +163,11 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 | `delegate` | `true` | Enable the `acp_delegate` tools (delegate/wait/cancel) and their system-prompt section. Set `false` to skip registering them (e.g. you use a different sub-agent extension, or run headless where async injection adds no value). |
 | `toolBashDefaultTimeout` | `60` | Seconds injected into the `bash` tool when the model omits `timeout`. Pi has **no** default of its own, so without this a forgotten timeout can hang for thousands of seconds. On timeout the model is guided to re-run with a larger `timeout`. `0` restores Pi's unbounded behavior. |
 | `toolOutputMaxBytes` | `200000` | Hard byte cap on tool result text (~5000 lines at ~40 B/line; applied via the `tool_result` hook). Stops runaway output that Pi's own 50KB/2000-line cap can't catch (e.g. tools Pi doesn't cap). When it fires the model is told how to see the full output — for `bash` the full output is in its temp file (`BashToolDetails.fullOutputPath`); set lower (e.g. `8192`) for a tighter context budget, or `0` to disable. |
+| `maxContextLimit` | `"75%"` | Context usage threshold that triggers **forced compression** nudges (bypasses growth-gate + cadence). Accepts a ratio (`0.75`) or percent string (`"75%"`). Lower = compress earlier / more aggressively. Maps to kernel `nudge.maxContextLimitPct`. |
+| `emergencyThresholdPercent` | `"95%"` | Context usage threshold that triggers **emergency truncation** of large tool outputs to keep the session alive. Accepts a ratio (`0.95`) or percent string (`"95%"`). Must be ≥ `maxContextLimit`. Maps to kernel `nudge.emergencyThresholdPct` + `truncate.threshold`. |
+| `nudgeGrowthTokens` | `50000` | Token growth step for soft compression nudges. A nudge fires roughly every time this many tokens become compressible. Lower = compress more often; higher = compress less often. Maps to kernel `nudge.growthFloor` + `nudge.growthCap`. |
 
-> **Only these six keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`, nudge thresholds) are code-level and not user-overridable.
+> **Only these nine keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three nudge thresholds (`maxContextLimit`, `emergencyThresholdPercent`, `nudgeGrowthTokens`) form a three-tier escalation: growth-driven soft nudges → forced nudges at `maxContextLimit` → emergency truncation at `emergencyThresholdPercent`.
 
 ### Environment variables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,7 +147,10 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
   "modelContextLimit": 200000,
   "delegate": true,
   "toolBashDefaultTimeout": 60,
-  "toolOutputMaxBytes": 200000
+  "toolOutputMaxBytes": 200000,
+  "maxContextLimit": "75%",
+  "emergencyThresholdPercent": "95%",
+  "nudgeGrowthTokens": 50000
 }
 ```
 
@@ -159,8 +162,11 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 | `delegate` | `true` | 启用 `acp_delegate` 工具(delegate/wait/cancel)及其系统提示词段落。设为 `false` 则不注册这些工具(例如你用了别的子代理扩展,或跑 headless 场景异步注入没有意义)。 |
 | `toolBashDefaultTimeout` | `60` | 当模型未指定 `timeout` 时注入 `bash` 工具的超时秒数。Pi **本身没有默认超时**,不加这个,一次遗漏的超时可能挂起几千秒。超时后会提示模型用更大的 `timeout` 重跑。设为 `0` 恢复 Pi 的无界行为。 |
 | `toolOutputMaxBytes` | `200000` | 工具结果文本硬上限(字节,约 5000 行 @ ~40 字节/行,通过 `tool_result` hook 应用)。用于兜住 Pi 自身 50KB/2000 行截断管不到的输出(例如 Pi 未加限制的工具)。触发截断时会告诉模型如何查看完整输出——对 `bash`,完整输出在其临时文件(`BashToolDetails.fullOutputPath`)中;设更小(如 `8192`)可更省上下文,设 `0` 关闭。 |
+| `maxContextLimit` | `"75%"` | 上下文使用率达到此值时触发**强制压缩** nudge(绕过增长门控 + 频率限制)。支持比例(`0.75`)或百分比字符串(`"75%"`)。调小 → 更早/更激进压缩。映射到内核 `nudge.maxContextLimitPct`。 |
+| `emergencyThresholdPercent` | `"95%"` | 上下文使用率达到此值时触发**紧急截断**,硬截断大块工具输出以保住会话。支持比例(`0.95`)或百分比字符串(`"95%"`)。必须 ≥ `maxContextLimit`。映射到内核 `nudge.emergencyThresholdPct` + `truncate.threshold`。 |
+| `nudgeGrowthTokens` | `50000` | 软压缩 nudge 的增长步长(token)。大约每积累这么多可压缩 token 就触发一次 nudge。调小 → 压得更频繁;调大 → 压得更少。映射到内核 `nudge.growthFloor` + `nudge.growthCap`。 |
 
-> **只有这六个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`、nudge 阈值)是代码级的,不向用户开放。
+> **只有这九个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`)是代码级的,不向用户开放。三个 nudge 阈值(`maxContextLimit`、`emergencyThresholdPercent`、`nudgeGrowthTokens`)构成三级触发:增长驱动的软 nudge → `maxContextLimit` 强制 nudge → `emergencyThresholdPercent` 紧急截断。
 
 ### 环境变量
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.35",
+	"version": "0.1.36",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.35",
+			"version": "0.1.36",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.19",
+				"acp-kernel": "0.0.21",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.19",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.19.tgz",
-			"integrity": "sha512-Ul13wjjP9bWYPBaUPyap4jeD4GpUJ1/sofWyJA/PxaEIOV9QmRDOvAJRAV436dojodgCpBv9UygyaJ7eiq4LuA==",
+			"version": "0.0.21",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.21.tgz",
+			"integrity": "sha512-BSBQzBle5LdiRseXXcDIah6QmdrE4JgrKvz1Y33yOaxIGFkLgaztoOC4QqPYSBxg4yTJLSvEcHWzvVhuc6AseQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.35",
+	"version": "0.1.36",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.19",
+		"acp-kernel": "0.0.21",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,36 @@
 import { defaultConfig, type Config } from "acp-kernel";
 
+/** Delegate sub-agent configuration. */
+export interface DelegateConfig {
+  /** Enable acp_delegate tools (delegate/wait/cancel) and their system-prompt
+   *  section. Default: true. Set `enabled: false` to skip registering them. */
+  enabled?: boolean;
+  /** How delegate usage is reported back to the main session.
+   *  "separate" (default) — delegate tokens tracked in a separate accumulator;
+   *  main session totals stay clean, delegate usage shows as its own block in
+   *  acp_status (excluded from main totals).
+   *  "merged" — delegate token usage folded into the tool-result usage field,
+   *  counted as part of the main session totals. */
+  displayUsage?: "merged" | "separate";
+}
+
+/** Compression tuning. All fields accept a ratio (0.75) or percent string
+ *  ("75%") where noted. */
+export interface CompressConfig {
+  /** Context usage percentage that triggers forced compression nudges
+   *  (bypasses growth-gate + cadence). Accepts a ratio (0.75) or percent
+   *  string ("75%"). Default: 0.75. Maps to kernel nudge.maxContextLimitPct. */
+  maxContextLimit?: number | string;
+  /** Context usage percentage that triggers emergency truncation of large
+   *  tool outputs. Accepts a ratio (0.95) or percent string ("95%").
+   *  Default: 0.95. Must be >= maxContextLimit. Maps to kernel
+   *  nudge.emergencyThresholdPct + truncate.threshold. */
+  emergencyThresholdPercent?: number | string;
+  /** Token growth threshold for soft compression nudges. Default: 50000.
+   *  Maps to kernel nudge.growthFloor + nudge.growthCap. */
+  nudgeGrowthTokens?: number;
+}
+
 /**
  * Adapter configuration. Maps onto acp-kernel's `Config` plus Pi-specific knobs
  * (live model context window, protected tools, state persistence).
@@ -19,16 +50,6 @@ export interface AdapterConfig {
    *  warnings) are written regardless; `debug` only adds verbose diagnostics.
    *  Default: false (or env ACP_DEBUG=1/true). */
   debug?: boolean;
-  /** Enable acp_delegate tools (delegate/wait/cancel) and their system-prompt
-   *  section. Default: true. Set `delegate: false` (adapter config or
-   *  ~/.pi/acp.json) to skip registering them. */
-  delegate?: boolean;
-  /** How to display delegate usage in session totals.
-   *  "merged" — delegate usage is added to main session totals (Pi default).
-   *  "separate" — delegate usage is tracked separately, displayed in
-   *               system notifications (excluded from main session totals).
-   *  Default: "separate" */
-  displayUsage?: "merged" | "separate";
   /** Default timeout in seconds injected into the bash tool when the model
    *  omits `timeout`. Pi has NO built-in default, so without this a command
    *  that the model forgets to time out can hang for thousands of seconds.
@@ -45,11 +66,36 @@ export interface AdapterConfig {
    *  head-truncated with a notice telling the model how to see the full output
    *  (bash: read BashToolDetails.fullOutputPath). */
   toolOutputMaxBytes?: number;
+  /** Delegate sub-agent config. Accepts a boolean shorthand (`true` →
+   *  `{ enabled: true }`, `false` → `{ enabled: false }`) or a DelegateConfig
+   *  object. Default: enabled. */
+  delegate?: boolean | DelegateConfig;
+  /** Compression tuning. */
+  compress?: CompressConfig;
+  /** Legacy flat alias for `delegate.displayUsage`. Kept for backward
+   *  compatibility with existing acp.json files. Prefer `delegate.displayUsage`. */
+  displayUsage?: "merged" | "separate";
   coreOverrides?: Partial<Config>;
 }
 
 export const DEFAULT_TOOL_BASH_TIMEOUT = 60;
 export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000;
+
+/** Resolve delegate config from the adapter, handling the boolean shorthand
+ *  and the legacy flat `displayUsage` alias. */
+export function resolveDelegate(adapter: AdapterConfig): { enabled: boolean; displayUsage: "merged" | "separate" } {
+  const d = adapter.delegate;
+  if (typeof d === "object" && d !== null) {
+    return {
+      enabled: d.enabled !== false,
+      displayUsage: d.displayUsage ?? adapter.displayUsage ?? "separate",
+    };
+  }
+  return {
+    enabled: d !== false,
+    displayUsage: adapter.displayUsage ?? "separate",
+  };
+}
 
 export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;
@@ -63,9 +109,28 @@ export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number):
         : liveContextLimit > 0
           ? liveContextLimit
           : FALLBACK_LIMIT;
-  return defaultConfig(limit, {
+  const config = defaultConfig(limit, {
     protectedTools: adapter.protectedTools ?? [],
     preserveRecentMessages: adapter.preserveRecentMessages ?? 5,
     ...adapter.coreOverrides,
   });
+  const c = adapter.compress;
+  if (c?.maxContextLimit !== undefined) config.nudge.maxContextLimitPct = parsePercent(c.maxContextLimit);
+  if (c?.emergencyThresholdPercent !== undefined) {
+    const pct = parsePercent(c.emergencyThresholdPercent);
+    config.nudge.emergencyThresholdPct = pct;
+    config.truncate.threshold = pct;
+  }
+  if (c?.nudgeGrowthTokens !== undefined) {
+    config.nudge.growthFloor = c.nudgeGrowthTokens;
+    config.nudge.growthCap = c.nudgeGrowthTokens;
+  }
+  return config;
+}
+
+export function parsePercent(v: number | string): number {
+  if (typeof v === "number") return v;
+  const s = v.trim();
+  if (s.endsWith("%")) return Number(s.slice(0, -1)) / 100;
+  return Number(s);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { CoreMessage, NudgeDecision, CompressionBlock } from "acp-kernel";
 import { renderNudgeText } from "acp-kernel";
-import type { AdapterConfig } from "./config.js";
+import { type AdapterConfig, resolveDelegate } from "./config.js";
 import { createRuntime, type AcpRuntime } from "./runtime.js";
 import { makeCompressTool } from "./compress-tool.js";
 import { makeDecompressTool } from "./decompress-tool.js";
@@ -70,12 +70,12 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     try {
       const user = await loadUserConfig(ctx.cwd);
       runtime.setAdapter(applyUserConfig(runtime.adapter, user));
-      setDelegateDisplayUsage(runtime.adapter.displayUsage ?? "separate");
+      setDelegateDisplayUsage(resolveDelegate(runtime.adapter).displayUsage);
       if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
     }
-    if (runtime.adapter.delegate !== false) {
+    if (resolveDelegate(runtime.adapter).enabled) {
       pi.registerTool(makeDelegateTool(pi));
       pi.registerTool(makeDelegateWaitTool(pi));
       pi.registerTool(makeDelegateCancelTool(pi));

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -5,6 +5,7 @@ import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel"
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 import { logThrow } from "./log.js";
 import { getDelegateUsage } from "./delegate-tool.js";
+import { resolveDelegate } from "./config.js";
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -100,7 +101,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
     const costStr = cost > 0 ? ` ($${cost.toFixed(4)})` : "";
     extra.push("── Session delegate usage (excluded from main totals) ──");
     extra.push(`Tokens: ${delegateUsage.input.toLocaleString()} in, ${delegateUsage.output.toLocaleString()} out (${delegateUsage.totalTokens.toLocaleString()} total)${costStr}`);
-  } else if (runtime.adapter.displayUsage === "merged") {
+  } else if (resolveDelegate(runtime.adapter).displayUsage === "merged") {
     extra.push("");
     extra.push("merged mode: delegate usage is included in main session totals.");
   } else {

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
-import type { AdapterConfig } from "./config.js";
+import type { AdapterConfig, CompressConfig, DelegateConfig } from "./config.js";
 import { debug, logWarn } from "./log.js";
 
 /** User-facing config keys (subset of AdapterConfig). Loaded from
@@ -12,10 +12,11 @@ export interface UserAcpConfig {
   debug?: boolean;
   autoUpdate?: boolean;
   modelContextLimit?: number;
-  delegate?: boolean;
-  displayUsage?: "merged" | "separate";
   toolBashDefaultTimeout?: number;
   toolOutputMaxBytes?: number;
+  delegate?: boolean | DelegateConfig;
+  compress?: CompressConfig;
+  displayUsage?: "merged" | "separate";
 }
 
 /** Read global + project acp.json, project overrides global. Returns {} on any
@@ -46,7 +47,11 @@ function join(... parts: string[]): string {
   return path.join(...parts);
 }
 
-const KNOWN = new Set(["debug", "autoUpdate", "modelContextLimit", "delegate", "displayUsage", "toolBashDefaultTimeout", "toolOutputMaxBytes"]);
+const KNOWN = new Set([
+  "debug", "autoUpdate", "modelContextLimit",
+  "toolBashDefaultTimeout", "toolOutputMaxBytes",
+  "delegate", "compress", "displayUsage",
+]);
 
 function pickKnown(parsed: Record<string, unknown>): UserAcpConfig {
   const out: UserAcpConfig = {};
@@ -62,8 +67,6 @@ export function applyUserConfig(adapter: AdapterConfig, user: UserAcpConfig): Ad
   return {
     ...adapter,
     ...user,
-    // coreOverrides / protectedTools / preserveRecentMessages are not overridable
-    // from acp.json (keep them from the factory config).
     coreOverrides: adapter.coreOverrides,
     protectedTools: adapter.protectedTools,
     preserveRecentMessages: adapter.preserveRecentMessages,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveConfig, type AdapterConfig } from "../src/config.js";
+import { resolveConfig, resolveDelegate, type AdapterConfig } from "../src/config.js";
 
 const EMPTY: AdapterConfig = {};
 
@@ -45,4 +45,95 @@ test("resolveConfig ignores a non-positive ACP_MODEL_CONTEXT_LIMIT and falls thr
     if (prev === undefined) delete process.env.ACP_MODEL_CONTEXT_LIMIT;
     else process.env.ACP_MODEL_CONTEXT_LIMIT = prev;
   }
+});
+
+test("resolveConfig defaults to kernel 0.0.20 thresholds when no compress overrides set", () => {
+  const cfg = resolveConfig(EMPTY, 1_000_000);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.75);
+  assert.equal(cfg.nudge.emergencyThresholdPct, 0.95);
+  assert.equal(cfg.truncate.threshold, 0.95);
+});
+
+test("resolveConfig maps compress.maxContextLimit (number) to nudge.maxContextLimitPct", () => {
+  const cfg = resolveConfig({ compress: { maxContextLimit: 0.8 } }, 1_000_000);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.8);
+});
+
+test("resolveConfig maps compress.maxContextLimit (percent string) to nudge.maxContextLimitPct", () => {
+  const cfg = resolveConfig({ compress: { maxContextLimit: "80%" } }, 1_000_000);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.8);
+});
+
+test("resolveConfig maps compress.emergencyThresholdPercent to both nudge.emergencyThresholdPct and truncate.threshold", () => {
+  const cfg = resolveConfig({ compress: { emergencyThresholdPercent: "90%" } }, 1_000_000);
+  assert.equal(cfg.nudge.emergencyThresholdPct, 0.9);
+  assert.equal(cfg.truncate.threshold, 0.9);
+});
+
+test("resolveConfig maps compress.nudgeGrowthTokens to both growthFloor and growthCap", () => {
+  const cfg = resolveConfig({ compress: { nudgeGrowthTokens: 30000 } }, 1_000_000);
+  assert.equal(cfg.nudge.growthFloor, 30000);
+  assert.equal(cfg.nudge.growthCap, 30000);
+});
+
+test("resolveConfig leaves growthFloor/growthCap at kernel defaults when compress.nudgeGrowthTokens omitted", () => {
+  const cfg = resolveConfig(EMPTY, 1_000_000);
+  assert.equal(cfg.nudge.growthFloor, 50000);
+  assert.equal(cfg.nudge.growthCap, 50000);
+});
+
+test("resolveConfig handles all three compress fields together", () => {
+  const cfg = resolveConfig({ compress: { maxContextLimit: "70%", emergencyThresholdPercent: 0.9, nudgeGrowthTokens: 40000 } }, 1_000_000);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.7);
+  assert.equal(cfg.nudge.emergencyThresholdPct, 0.9);
+  assert.equal(cfg.truncate.threshold, 0.9);
+  assert.equal(cfg.nudge.growthFloor, 40000);
+  assert.equal(cfg.nudge.growthCap, 40000);
+});
+
+test("resolveDelegate: undefined delegate defaults to enabled + separate", () => {
+  const r = resolveDelegate({});
+  assert.equal(r.enabled, true);
+  assert.equal(r.displayUsage, "separate");
+});
+
+test("resolveDelegate: boolean true shorthand", () => {
+  const r = resolveDelegate({ delegate: true });
+  assert.equal(r.enabled, true);
+  assert.equal(r.displayUsage, "separate");
+});
+
+test("resolveDelegate: boolean false shorthand", () => {
+  const r = resolveDelegate({ delegate: false });
+  assert.equal(r.enabled, false);
+  assert.equal(r.displayUsage, "separate");
+});
+
+test("resolveDelegate: object with enabled + displayUsage", () => {
+  const r = resolveDelegate({ delegate: { enabled: false, displayUsage: "merged" } });
+  assert.equal(r.enabled, false);
+  assert.equal(r.displayUsage, "merged");
+});
+
+test("resolveDelegate: object with only enabled (displayUsage defaults)", () => {
+  const r = resolveDelegate({ delegate: { enabled: true } });
+  assert.equal(r.enabled, true);
+  assert.equal(r.displayUsage, "separate");
+});
+
+test("resolveDelegate: legacy flat displayUsage still works with boolean delegate", () => {
+  const r = resolveDelegate({ delegate: true, displayUsage: "merged" });
+  assert.equal(r.enabled, true);
+  assert.equal(r.displayUsage, "merged");
+});
+
+test("resolveDelegate: legacy flat displayUsage still works with undefined delegate", () => {
+  const r = resolveDelegate({ displayUsage: "merged" });
+  assert.equal(r.enabled, true);
+  assert.equal(r.displayUsage, "merged");
+});
+
+test("resolveDelegate: object displayUsage takes priority over legacy flat", () => {
+  const r = resolveDelegate({ delegate: { displayUsage: "separate" }, displayUsage: "merged" });
+  assert.equal(r.displayUsage, "separate");
 });


### PR DESCRIPTION
## release v0.1.35 — acp-kernel 0.0.20 + user-facing compression config

### acp-kernel 0.0.19 → 0.0.20
Two-tier usage gating (kernel PR #63):
- `maxContextLimitPct` 0.55→**0.75** (activated dead field → force-nudge at 75%, lossless)
- `emergencyThresholdPct` 0.80→**0.95** (emergency nudge)
- `truncate.threshold` 1.0→**0.95** (hard-truncate large tool outputs, lossy)

Kernel param names **unchanged** — zero downstream migration. pi's existing `emergencyOverride` code keeps working.

### New user-facing config fields (AdapterConfig)
Users can now tune compression thresholds in `~/.pi/acp.json` without touching raw kernel config:

| Field | Accepts | Default | Maps to kernel |
|-------|---------|---------|----------------|
| `maxContextLimit` | `0.75` or `"75%"` | 0.75 | `nudge.maxContextLimitPct` |
| `emergencyThresholdPercent` | `0.95` or `"95%"` | 0.95 | `nudge.emergencyThresholdPct` + `truncate.threshold` |
| `nudgeGrowthTokens` | number | 50000 | `nudge.growthFloor` + `nudge.growthCap` |

All optional — omitting a field keeps the kernel default. `coreOverrides` still available for power users.

### Example
```json
{
  "maxContextLimit": "80%",
  "emergencyThresholdPercent": "98%",
  "nudgeGrowthTokens": 60000
}
```

### Pre-flight
typecheck clean / **201 tests pass** (195 + 6 new) / build success.
