### PR TITLE
release v0.1.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.34",
+	"version": "0.1.35",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.34",
+			"version": "0.1.35",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.34",
+	"version": "0.1.35",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## release v0.1.35

Small release of everything merged to `master` since v0.1.34. **Version bump only** — `acp-kernel` stays pinned at `0.0.19` (no cross-repo dependency change).

Pre-flight: `typecheck` ✅ · `npm test` 233 pass / 0 fail ✅ · `npm run build` ✅

### Shipped since v0.1.34

**omp (one-message-prompt) compatibility fixes**
- #121 `fix(omp): rebuild refs before compression` — prune orphan refs pointing to removed messages; rebuild refs via `processTurn` before `applyCompression`.
- #123 `fix(omp): match truncated tool results` — recognize OMP `"[truncated for context space] — original ~NNN tokens]"` envelope so a truncated tool result still matches its persisted ref (no false re-compression).
- #124 `fix(omp): stabilize live message references` — persist + migrate `live-N` refs across session reload; identity-based matching that strips leading/trailing ACP tags.

**state**
- #125 `fix(state): clone session inherits parent compression state` — `/clone` and `/fork` child sessions now walk the `parentSession` chain and inherit the parent's compression state (was empty → context overflow on the first turn of a cloned session).

**delegate**
- #106 `feat: delegate sub-agent LLM usage tracking` — parse the delegate child's `message_end` usage, accumulate across calls, surface in footer + `/acp-status` + wait/cancel results; new `displayUsage` config; `agent_settled` → ~10s force-kill (was ~5min idle-watchdog floor). Also establishes the `devlog/` system and moves #105's design doc there.

### Merge order note
PR #126 (`release v0.1.35: acp-kernel 0.0.20 + config`) **also targets 0.1.35** on its own branch. Once this small release ships as 0.1.35, #126 should be re-bumped to **0.1.36** (acp-kernel 0.0.20 + the 3 user-facing nudge configs) and rebased onto the new master.
