### PR TITLE
feat(prompts): customizable prompts via acp.json (Layer 2)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -56,6 +56,17 @@ A minimal config enabling only debug logging:
 }
 ```
 
+An advanced config overriding one of the kernel's compression prompt rules (requires the risk acknowledgement):
+
+```json
+{
+  "prompts": {
+    "compressPhilosophy": "My custom compression philosophy text..."
+  },
+  "acknowledgePromptsRisk": true
+}
+```
+
 ---
 
 ## Parameter Reference
@@ -94,6 +105,13 @@ All keys below are currently **ACTIVE**.
 | `compress.maxContextLimit` | number \| string | `"75%"` | 🟢 ACTIVE | Context threshold that triggers forced compression nudges. |
 | `compress.emergencyThresholdPercent` | number \| string | `"95%"` | 🟢 ACTIVE | Context threshold that triggers emergency truncation. |
 | `compress.nudgeGrowthTokens` | number | `50000` | 🟢 ACTIVE | Token growth step for soft compression nudges. |
+
+**Prompts keys**
+
+| Key | Type | Default | Status | Description |
+|-----|------|---------|--------|-------------|
+| `prompts` | object | *(kernel defaults)* | 🟢 ACTIVE | Override acp-kernel's 4 load-bearing compression prompt rules. Each set field replaces the default verbatim. |
+| `acknowledgePromptsRisk` | boolean | `false` | 🟢 ACTIVE | Must be `true` for `prompts` overrides to take effect; otherwise overrides are dropped and defaults are used. |
 
 **Environment variables**
 
@@ -201,6 +219,44 @@ The flow is:
 - **Default:** `50000`
 - **Status:** 🟢 ACTIVE
 - **Description:** The token-growth threshold that controls the cadence of **soft** compression nudges. A soft nudge fires roughly every time this many tokens of new compressible content accumulate. A lower value means the model is nudged to compress more often; a higher value means less frequent nudges. This only governs *growth-driven* nudges — once usage crosses `compress.maxContextLimit`, forced nudges take over regardless of this setting. Maps to the kernel settings `nudge.growthFloor` and `nudge.growthCap`.
+
+---
+
+## Prompts Customization
+
+The `prompts` object overrides acp-kernel's **load-bearing** compression prompt rules — the verbatim instructions the model receives about *how* to write summaries (keep full file paths, function signatures, decisions and rationale; drop verbose logs, etc.). These four fields are embedded into the system prompt and the compression nudge text:
+
+| Field | What it governs |
+|-------|-----------------|
+| `compressPhilosophy` | The two failure modes to avoid (over-/under-compression) and the single test for when to compress. |
+| `howToCompressRules` | Tier-1 rules: what to KEEP verbatim vs DROP, and the summary priority order. |
+| `tier2DistillRules` | Tier-2 distillation rules (decisions/outcomes only). |
+| `tier3CondenseRules` | Tier-3 ultra-condensation rules (bare facts). |
+
+> ⚠️ **Quality risk.** These rules are tuned for retrieval quality. Replacing them with looser text can silently degrade summaries — lost paths, signatures, and decisions lead to worse reconstruction later. The `acknowledgePromptsRisk` gate exists to make this an explicit, deliberate choice.
+
+### `prompts`
+
+- **Type:** `object` (partial — omit fields to keep their defaults)
+- **Default:** *(kernel defaults)* — the verbatim rules shipped with acp-kernel
+- **Status:** 🟢 ACTIVE
+- **Description:** Override one or more of the four compression prompt fields. Each field you set replaces the kernel default **verbatim**; fields you omit are inherited unchanged. Non-string values are silently dropped (only deliberate string overrides apply). Requires `acknowledgePromptsRisk: true` — without it, every override is dropped and the defaults are used, with a warning logged. Example:
+
+  ```json
+  {
+    "prompts": {
+      "tier3CondenseRules": "Condense to a single line per block. Preserve only the outcome."
+    },
+    "acknowledgePromptsRisk": true
+  }
+  ```
+
+### `acknowledgePromptsRisk`
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Status:** 🟢 ACTIVE
+- **Description:** The safety gate for `prompts` overrides. Set to `true` to acknowledge that replacing the kernel's tuned compression rules may reduce summary quality, and to make your `prompts` overrides take effect. When `false` (or omitted), all `prompts` overrides are ignored and the kernel defaults are used. If `resolvePrompts` rejects your override (for example a malformed value that still passes the type check), the extension falls back to the defaults and logs a `prompts-resolve-failed` warning rather than failing to start.
 
 ---
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -56,12 +56,15 @@ A minimal config enabling only debug logging:
 }
 ```
 
-An advanced config overriding one of the kernel's compression prompt rules (requires the risk acknowledgement):
+An advanced config overriding the kernel's compression prompt rules (requires the risk acknowledgement). Set only the fields you want to change; the rest inherit the kernel defaults:
 
 ```json
 {
   "prompts": {
-    "compressPhilosophy": "My custom compression philosophy text..."
+    "compressPhilosophy": "My compression philosophy...",
+    "howToCompressRules": "My tier-1 rules...",
+    "tier2DistillRules": "My tier-2 distillation rules...",
+    "tier3CondenseRules": "My tier-3 condensation rules..."
   },
   "acknowledgePromptsRisk": true
 }
@@ -245,7 +248,10 @@ The `prompts` object overrides acp-kernel's **load-bearing** compression prompt 
   ```json
   {
     "prompts": {
-      "tier3CondenseRules": "Condense to a single line per block. Preserve only the outcome."
+      "compressPhilosophy": "Compress aggressively; prefer signal over completeness.",
+      "howToCompressRules": "Keep file paths + signatures verbatim. Drop verbose logs.",
+      "tier2DistillRules": "Decisions and outcomes only; drop process and paths.",
+      "tier3CondenseRules": "One line per block: bare facts only."
     },
     "acknowledgePromptsRisk": true
   }

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -56,12 +56,15 @@
 }
 ```
 
-覆盖内核某条压缩提示词规则的高级配置（需要风险确认）：
+覆盖内核压缩提示词规则的高级配置（需要风险确认）。只设置你想改的字段，其余继承内核默认值：
 
 ```json
 {
   "prompts": {
-    "compressPhilosophy": "我的自定义压缩理念文本……"
+    "compressPhilosophy": "我的压缩理念……",
+    "howToCompressRules": "我的 tier-1 规则……",
+    "tier2DistillRules": "我的 tier-2 蒸馏规则……",
+    "tier3CondenseRules": "我的 tier-3 浓缩规则……"
   },
   "acknowledgePromptsRisk": true
 }
@@ -245,7 +248,10 @@
   ```json
   {
     "prompts": {
-      "tier3CondenseRules": "每个块浓缩为一行。只保留结果。"
+      "compressPhilosophy": "激进压缩；优先保留信号而非完整性。",
+      "howToCompressRules": "逐字保留文件路径+签名。丢弃冗长日志。",
+      "tier2DistillRules": "仅决策与结果；丢弃过程和路径。",
+      "tier3CondenseRules": "每个块一行：仅核心事实。"
     },
     "acknowledgePromptsRisk": true
   }

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -56,6 +56,17 @@
 }
 ```
 
+覆盖内核某条压缩提示词规则的高级配置（需要风险确认）：
+
+```json
+{
+  "prompts": {
+    "compressPhilosophy": "我的自定义压缩理念文本……"
+  },
+  "acknowledgePromptsRisk": true
+}
+```
+
 ---
 
 ## 参数总览
@@ -94,6 +105,13 @@
 | `compress.maxContextLimit` | number \| string | `"75%"` | 🟢 ACTIVE | 触发强制压缩 nudge 的上下文阈值。 |
 | `compress.emergencyThresholdPercent` | number \| string | `"95%"` | 🟢 ACTIVE | 触发紧急截断的上下文阈值。 |
 | `compress.nudgeGrowthTokens` | number | `50000` | 🟢 ACTIVE | 软压缩 nudge 的 token 增长步长。 |
+
+**prompts 键**
+
+| 键 | 类型 | 默认值 | 状态 | 说明 |
+|----|------|--------|------|------|
+| `prompts` | object | *(内核默认)* | 🟢 ACTIVE | 覆盖 acp-kernel 的 4 条承重压缩提示词规则。每个设置的字段逐字替换默认值。 |
+| `acknowledgePromptsRisk` | boolean | `false` | 🟢 ACTIVE | 必须为 `true`，`prompts` 覆盖才会生效；否则覆盖被丢弃、使用默认值。 |
 
 **环境变量**
 
@@ -201,6 +219,44 @@
 - **默认值：** `50000`
 - **状态：** 🟢 ACTIVE
 - **说明：** 控制**软**压缩 nudge 频率的 token 增长阈值。每当积累约这么多新可压缩内容时，触发一次软 nudge。值越低模型被 nudge 压缩的频率越高；值越低频率越低。此设置只控制*基于增长的* nudge——用量越过 `compress.maxContextLimit` 后，强制 nudge 接管，不受此设置影响。映射到内核设置 `nudge.growthFloor` 和 `nudge.growthCap`。
+
+---
+
+## 提示词自定义
+
+`prompts` 对象覆盖 acp-kernel 的**承重**压缩提示词规则——即模型收到的关于*如何*写摘要的逐字指令（保留完整文件路径、函数签名、决策与理由；丢弃冗长日志等）。这四个字段被嵌入系统提示词和压缩 nudge 文本：
+
+| 字段 | 控制内容 |
+|------|----------|
+| `compressPhilosophy` | 要避免的两种失败模式（过度/不足压缩），以及何时压缩的唯一判据。 |
+| `howToCompressRules` | Tier-1 规则：哪些内容需逐字保留、哪些需丢弃，以及摘要优先级顺序。 |
+| `tier2DistillRules` | Tier-2 蒸馏规则（仅决策/结果）。 |
+| `tier3CondenseRules` | Tier-3 超级浓缩规则（仅核心事实）。 |
+
+> ⚠️ **质量风险。** 这些规则是为检索质量调优的。用更宽松的文本替换它们会悄无声息地降低摘要质量——丢失路径、签名和决策会导致后续重建变差。`acknowledgePromptsRisk` 门禁的存在，是为了让这成为一个明确、深思熟虑的选择。
+
+### `prompts`
+
+- **类型：** `object`（部分覆盖——省略字段则保持其默认值）
+- **默认值：** *(内核默认)* —— acp-kernel 内置的逐字规则
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖四个压缩提示词字段中的一个或多个。你设置的每个字段**逐字**替换内核默认值；省略的字段原样继承。非字符串值会被静默丢弃（只有明确的字符串覆盖才生效）。需要 `acknowledgePromptsRisk: true`——否则所有覆盖被丢弃并使用默认值，同时记录一条警告。示例：
+
+  ```json
+  {
+    "prompts": {
+      "tier3CondenseRules": "每个块浓缩为一行。只保留结果。"
+    },
+    "acknowledgePromptsRisk": true
+  }
+  ```
+
+### `acknowledgePromptsRisk`
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **状态：** 🟢 ACTIVE
+- **说明：** `prompts` 覆盖的安全门禁。设为 `true` 以确认替换内核调优的压缩规则可能降低摘要质量，并使你的 `prompts` 覆盖生效。为 `false`（或省略）时，所有 `prompts` 覆盖被忽略，使用内核默认值。如果 `resolvePrompts` 拒绝了你的覆盖（例如某个仍通过类型检查的畸形值），扩展会回退到默认值并记录 `prompts-resolve-failed` 警告，而不是启动失败。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
   "nudgeGrowthTokens": 50000,
 
   "prompts": {
-    "compressPhilosophy": "Override the kernel's compression philosophy..."
+    "compressPhilosophy": "Override the compression philosophy...",
+    "howToCompressRules": "Override tier-1 rules...",
+    "tier2DistillRules": "Override tier-2 distillation rules...",
+    "tier3CondenseRules": "Override tier-3 condensation rules..."
   },
   "acknowledgePromptsRisk": true
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,12 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
   "toolOutputMaxBytes": 200000,
   "maxContextLimit": "75%",
   "emergencyThresholdPercent": "95%",
-  "nudgeGrowthTokens": 50000
+  "nudgeGrowthTokens": 50000,
+
+  "prompts": {
+    "compressPhilosophy": "Override the kernel's compression philosophy..."
+  },
+  "acknowledgePromptsRisk": true
 }
 ```
 
@@ -166,8 +171,10 @@ Create `~/.pi/acp.json` (global) and/or `<project>/.pi/acp.json` (project-local,
 | `maxContextLimit` | `"75%"` | Context usage threshold that triggers **forced compression** nudges (bypasses growth-gate + cadence). Accepts a ratio (`0.75`) or percent string (`"75%"`). Lower = compress earlier / more aggressively. Maps to kernel `nudge.maxContextLimitPct`. |
 | `emergencyThresholdPercent` | `"95%"` | Context usage threshold that triggers **emergency truncation** of large tool outputs to keep the session alive. Accepts a ratio (`0.95`) or percent string (`"95%"`). Must be ≥ `maxContextLimit`. Maps to kernel `nudge.emergencyThresholdPct` + `truncate.threshold`. |
 | `nudgeGrowthTokens` | `50000` | Token growth step for soft compression nudges. A nudge fires roughly every time this many tokens become compressible. Lower = compress more often; higher = compress less often. Maps to kernel `nudge.growthFloor` + `nudge.growthCap`. |
+| `prompts` | *(kernel defaults)* | Override acp-kernel's 4 load-bearing compression prompt rules (`compressPhilosophy`, `howToCompressRules`, `tier2DistillRules`, `tier3CondenseRules`). Each set field replaces the default verbatim; omitted fields are inherited. Non-string values are dropped. Requires `acknowledgePromptsRisk: true` — otherwise overrides are ignored and defaults are used. |
+| `acknowledgePromptsRisk` | `false` | Safety gate for `prompts` overrides. Set `true` to acknowledge that replacing the tuned compression rules may reduce summary quality (lost paths/signatures/decisions → worse retrieval) and to make overrides take effect. |
 
-> **Only these nine keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three nudge thresholds (`maxContextLimit`, `emergencyThresholdPercent`, `nudgeGrowthTokens`) form a three-tier escalation: growth-driven soft nudges → forced nudges at `maxContextLimit` → emergency truncation at `emergencyThresholdPercent`.
+> **Only these eleven keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three nudge thresholds (`maxContextLimit`, `emergencyThresholdPercent`, `nudgeGrowthTokens`) form a three-tier escalation: growth-driven soft nudges → forced nudges at `maxContextLimit` → emergency truncation at `emergencyThresholdPercent`.
 
 ### Environment variables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -150,7 +150,12 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
   "toolOutputMaxBytes": 200000,
   "maxContextLimit": "75%",
   "emergencyThresholdPercent": "95%",
-  "nudgeGrowthTokens": 50000
+  "nudgeGrowthTokens": 50000,
+
+  "prompts": {
+    "compressPhilosophy": "覆盖内核的压缩理念……"
+  },
+  "acknowledgePromptsRisk": true
 }
 ```
 
@@ -165,8 +170,10 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
 | `maxContextLimit` | `"75%"` | 上下文使用率达到此值时触发**强制压缩** nudge(绕过增长门控 + 频率限制)。支持比例(`0.75`)或百分比字符串(`"75%"`)。调小 → 更早/更激进压缩。映射到内核 `nudge.maxContextLimitPct`。 |
 | `emergencyThresholdPercent` | `"95%"` | 上下文使用率达到此值时触发**紧急截断**,硬截断大块工具输出以保住会话。支持比例(`0.95`)或百分比字符串(`"95%"`)。必须 ≥ `maxContextLimit`。映射到内核 `nudge.emergencyThresholdPct` + `truncate.threshold`。 |
 | `nudgeGrowthTokens` | `50000` | 软压缩 nudge 的增长步长(token)。大约每积累这么多可压缩 token 就触发一次 nudge。调小 → 压得更频繁;调大 → 压得更少。映射到内核 `nudge.growthFloor` + `nudge.growthCap`。 |
+| `prompts` | *(内核默认)* | 覆盖 acp-kernel 的 4 条承重压缩提示词规则(`compressPhilosophy`、`howToCompressRules`、`tier2DistillRules`、`tier3CondenseRules`)。每个设置的字段逐字替换默认值;省略的字段继承默认。非字符串值被丢弃。需要 `acknowledgePromptsRisk: true`——否则覆盖被忽略,使用默认值。 |
+| `acknowledgePromptsRisk` | `false` | `prompts` 覆盖的安全门禁。设为 `true` 以确认替换调优过的压缩规则可能降低摘要质量(丢失路径/签名/决策 → 检索变差),并使覆盖生效。 |
 
-> **只有这九个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`)是代码级的,不向用户开放。三个 nudge 阈值(`maxContextLimit`、`emergencyThresholdPercent`、`nudgeGrowthTokens`)构成三级触发:增长驱动的软 nudge → `maxContextLimit` 强制 nudge → `emergencyThresholdPercent` 紧急截断。
+> **只有这十一个 key 会被 `acp.json` 读取。** 其他调优参数(`preserveRecentMessages`、`protectedTools`)是代码级的,不向用户开放。三个 nudge 阈值(`maxContextLimit`、`emergencyThresholdPercent`、`nudgeGrowthTokens`)构成三级触发:增长驱动的软 nudge → `maxContextLimit` 强制 nudge → `emergencyThresholdPercent` 紧急截断。
 
 ### 环境变量
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,7 +153,10 @@ billion-context-pi 开箱即用,无需任何配置。可以在 JSON 配置文件
   "nudgeGrowthTokens": 50000,
 
   "prompts": {
-    "compressPhilosophy": "覆盖内核的压缩理念……"
+    "compressPhilosophy": "覆盖压缩理念……",
+    "howToCompressRules": "覆盖 tier-1 规则……",
+    "tier2DistillRules": "覆盖 tier-2 蒸馏规则……",
+    "tier3CondenseRules": "覆盖 tier-3 浓缩规则……"
   },
   "acknowledgePromptsRisk": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.21",
+				"acp-kernel": "0.0.22",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.21",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.21.tgz",
-			"integrity": "sha512-BSBQzBle5LdiRseXXcDIah6QmdrE4JgrKvz1Y33yOaxIGFkLgaztoOC4QqPYSBxg4yTJLSvEcHWzvVhuc6AseQ==",
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.22.tgz",
+			"integrity": "sha512-c/FYZ31VbJ14eAHuhN1nQpKR+AuFQgNATyfPrU5I0Cn3LUgRLWRsFR1zh7VDgXullscJvaSb5oGc7hL+79F7TA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.21",
+		"acp-kernel": "0.0.22",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { defaultConfig, type Config } from "acp-kernel";
+import { defaultConfig, type Config, type Prompts } from "acp-kernel";
 
 /** Delegate sub-agent configuration. */
 export interface DelegateConfig {
@@ -75,6 +75,15 @@ export interface AdapterConfig {
   /** Legacy flat alias for `delegate.displayUsage`. Kept for backward
    *  compatibility with existing acp.json files. Prefer `delegate.displayUsage`. */
   displayUsage?: "merged" | "separate";
+  /** Override acp-kernel's load-bearing compression prompt rules (the 4
+   *  Prompts fields). Each set field replaces the kernel default verbatim.
+   *  Requires acknowledgePromptsRisk: true — without it, overrides are dropped
+   *  (defaults used) and a warning is logged. Set via ~/.pi/acp.json. */
+  prompts?: Partial<Prompts>;
+  /** Must be true for `prompts` overrides to take effect. Acknowledges that
+   *  replacing the kernel's tuned compression rules may reduce summary quality
+   *  (lost paths/signatures/decisions → worse retrieval). */
+  acknowledgePromptsRisk?: boolean;
   coreOverrides?: Partial<Config>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import type {
   ExtensionFactory,
   SessionMessageEntry,
 } from "@earendil-works/pi-coding-agent";
-import type { CoreMessage, NudgeDecision, CompressionBlock } from "acp-kernel";
-import { renderNudgeText } from "acp-kernel";
+import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-kernel";
+import { renderNudgeText, resolvePrompts, defaultPrompts } from "acp-kernel";
 import { type AdapterConfig, resolveDelegate } from "./config.js";
 import { createRuntime, type AcpRuntime } from "./runtime.js";
 import { makeCompressTool } from "./compress-tool.js";
@@ -15,7 +15,7 @@ import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages } from "./messages.js";
-import { ACP_SYSTEM_PROMPT, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
+import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, setDebugEnabled, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
@@ -74,6 +74,12 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
       if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
+    }
+    try {
+      runtime.setPrompts(resolvePrompts(runtime.adapter.prompts, { acknowledgeRisk: runtime.adapter.acknowledgePromptsRisk === true }));
+    } catch (e) {
+      logWarn("config", { event: "prompts-resolve-failed", error: e instanceof Error ? e.message : String(e) });
+      runtime.setPrompts(defaultPrompts);
     }
     if (resolveDelegate(runtime.adapter).enabled) {
       pi.registerTool(makeDelegateTool(pi));
@@ -155,7 +161,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         prunedMsgs: coreMessages.length - turn.messages.length + turn.messages.filter((m) => m.id.startsWith("acp_summary")).length,
         nudgeShouldInject: turn.nudge?.shouldInject ?? false,
         nudgeReason: turn.nudge?.reason ?? null,
-        nudgeVoice: turn.nudge ? renderNudgeText(turn.nudge).voice : null,
+        nudgeVoice: turn.nudge ? renderNudgeText(turn.nudge, runtime.prompts).voice : null,
       nudgePct: turn.nudge ? Math.round(turn.nudge.contextUsage * 100) : null,
       nudgeTier: turn.nudge?.tier ?? null,
       nudgeCompressibleCount: turn.nudge?.compressibleRanges.length ?? 0,
@@ -187,8 +193,8 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const turnKey = lastUserMessageId(entries) ?? sid;
       const alreadyShown = !emergency && runtime.nudgeShownFor(turnKey);
       if (!alreadyShown) {
-        rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active)));
-        const rendered = renderNudgeText(turn.nudge);
+        rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active), runtime.prompts));
+        const rendered = renderNudgeText(turn.nudge, runtime.prompts);
         const top = [...turn.nudge.compressibleRanges].sort((a, b) => b.tokens - a.tokens)[0];
         const example = top ? `\n\nExample: compress({ content: [{ startId: "${top.startRef}", endId: "${top.endRef}", summary: "..." }] })` : "";
         if (emergency) {
@@ -227,7 +233,8 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("before_agent_start", (event) => {
     const delegate = runtime.adapter.delegate !== false;
-    const prompt = delegate ? `${ACP_SYSTEM_PROMPT}\n${ACP_DELEGATE_PROMPT}` : ACP_SYSTEM_PROMPT;
+    const acp = buildAcpSystemPrompt(runtime.prompts);
+    const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;
     return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, prompt) };
   });
 }
@@ -250,8 +257,8 @@ function collectOriginals(entries: Array<{ type: string; id: string; message?: A
   return map;
 }
 
-function nudgeMessage(nudge: NudgeDecision, blocks: CompressionBlock[]): AgentMessage {
-  const rendered = renderNudgeText(nudge);
+function nudgeMessage(nudge: NudgeDecision, blocks: CompressionBlock[], prompts: Prompts): AgentMessage {
+  const rendered = renderNudgeText(nudge, prompts);
   const lines = [rendered.text];
 
   if (blocks.length > 0) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,9 +2,11 @@ import type { ExtensionContext, SessionEntry, SessionMessageEntry } from "@earen
 import {
   createCore,
   defaultCountTokens,
+  defaultPrompts,
   type CompressionCore,
   type CompressionState,
   type Config,
+  type Prompts,
 } from "acp-kernel";
 import { resolveConfig, type AdapterConfig } from "./config.js";
 import { entriesToCoreMessages, extractText, matchesStoredText, messageIdentity, messageRef } from "./messages.js";
@@ -35,6 +37,8 @@ export interface AcpRuntime {
   store: SessionStateStore;
   adapter: AdapterConfig;
   setAdapter(adapter: AdapterConfig): void;
+  prompts: Prompts;
+  setPrompts(prompts: Prompts): void;
   markNudgeShown(turnKey: string): void;
   nudgeShownFor(turnKey: string): boolean;
   clearNudgeTracking(): void;
@@ -169,6 +173,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const store = new SessionStateStore();
   const locks = new Map<string, Promise<void>>();
   let adapterRef = adapter;
+  let promptsRef: Prompts = defaultPrompts;
   const nudgeShownTurns = new Set<string>();
 
   async function acquireLock(sid: string): Promise<() => void> {
@@ -222,5 +227,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };
+  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };
 }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -62,7 +62,7 @@ decompress restores previously compressed content and writes it to a file by def
 CONTEXT BREAKDOWN
 
 When context usage passes a threshold, the system appends a breakdown showing where tokens are spent. Compress the largest ranges first when the current step no longer needs them.
-  `;
+`;
 }
 
 export const ACP_DELEGATE_PROMPT = `

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,11 +1,7 @@
-import {
-  COMPRESS_PHILOSOPHY,
-  HOW_TO_COMPRESS_RULES,
-  TIER2_DISTILL_RULES,
-  TIER3_CONDENSE_RULES,
-} from "acp-kernel";
+import type { Prompts } from "acp-kernel";
 
-export const ACP_SYSTEM_PROMPT = `
+export function buildAcpSystemPrompt(prompts: Prompts): string {
+  return `
 ACP context management
 
 ACP TAGS
@@ -29,7 +25,7 @@ You have four context-management tools:
 - search_context — Search compressed block summaries (and optionally visible messages) by keyword. Use BEFORE decompressing to find the right block. Example: search_context({ query: "auth token refresh" }).
 - acp_status — Context status with compressible ranges. No args = overview + totals. scope:"uncompressed" for range view; add view:"messages" for per-message listing. scope:"compressed" for block details.
 
-${COMPRESS_PHILOSOPHY}
+${prompts.compressPhilosophy}
 
 WHEN TO COMPRESS
 
@@ -47,7 +43,7 @@ WHEN NOT TO COMPRESS
 - Important user messages — preserve their exact intent, constraints, and acceptance criteria. If a message in the range must stay verbatim, exclude it from the compress range instead of compressing it.
 - Protected tool outputs — hard-excluded from compression ranges, survive intact in visible context.
 
-${HOW_TO_COMPRESS_RULES}
+${prompts.howToCompressRules}
 
 MULTI-TIER COMPRESSION
 
@@ -55,9 +51,9 @@ Summaries accumulate as the session grows. When tier-1 summaries pile up, the sy
 
 To compress blocks: use block IDs as boundaries: compress({ content: [{ startId: "b3", endId: "b15", summary: "..." }] }). This deactivates the consumed blocks and creates a new higher-tier block.
 
-${TIER2_DISTILL_RULES}
+${prompts.tier2DistillRules}
 
-${TIER3_CONDENSE_RULES}
+${prompts.tier3CondenseRules}
 
 THE PHILOSOPHY OF DECOMPRESS
 
@@ -66,7 +62,8 @@ decompress restores previously compressed content and writes it to a file by def
 CONTEXT BREAKDOWN
 
 When context usage passes a threshold, the system appends a breakdown showing where tokens are spent. Compress the largest ranges first when the current step no longer needs them.
-`;
+  `;
+}
 
 export const ACP_DELEGATE_PROMPT = `
 ACP_DELEGATE NOTIFICATIONS

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import { homedir } from "node:os";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import type { Prompts } from "acp-kernel";
 import type { AdapterConfig, CompressConfig, DelegateConfig } from "./config.js";
 import { debug, logWarn } from "./log.js";
 
@@ -17,6 +18,8 @@ export interface UserAcpConfig {
   delegate?: boolean | DelegateConfig;
   compress?: CompressConfig;
   displayUsage?: "merged" | "separate";
+  prompts?: Partial<Prompts>;
+  acknowledgePromptsRisk?: boolean;
 }
 
 /** Read global + project acp.json, project overrides global. Returns {} on any
@@ -51,6 +54,7 @@ const KNOWN = new Set([
   "debug", "autoUpdate", "modelContextLimit",
   "toolBashDefaultTimeout", "toolOutputMaxBytes",
   "delegate", "compress", "displayUsage",
+  "prompts", "acknowledgePromptsRisk",
 ]);
 
 function pickKnown(parsed: Record<string, unknown>): UserAcpConfig {

--- a/tests/prompts-config.test.ts
+++ b/tests/prompts-config.test.ts
@@ -69,3 +69,20 @@ test("applyUserConfig flows prompts through to the adapter", () => {
   assert.equal(result.acknowledgePromptsRisk, true, "ack flag merged");
   assert.equal(result.modelContextLimit, 200_000, "other fields preserved");
 });
+
+test("buildAcpSystemPrompt default output is byte-stable (no trailing whitespace, full rules embedded)", () => {
+  const prompt = buildAcpSystemPrompt(defaultPrompts);
+  assert.ok(
+    prompt.endsWith("the current step no longer needs them.\n"),
+    "ends exactly like the master const — const->function refactor must not add trailing whitespace",
+  );
+  assert.equal(
+    /\s$/.test(prompt.replace(/\n$/, "")),
+    false,
+    "no trailing whitespace before the final newline",
+  );
+  assert.ok(prompt.includes(defaultPrompts.compressPhilosophy), "full compressPhilosophy embedded verbatim");
+  assert.ok(prompt.includes(defaultPrompts.howToCompressRules), "full howToCompressRules embedded verbatim");
+  assert.ok(prompt.includes(defaultPrompts.tier2DistillRules), "full tier2DistillRules embedded verbatim");
+  assert.ok(prompt.includes(defaultPrompts.tier3CondenseRules), "full tier3CondenseRules embedded verbatim");
+});

--- a/tests/prompts-config.test.ts
+++ b/tests/prompts-config.test.ts
@@ -1,0 +1,71 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { resolvePrompts, defaultPrompts } from "acp-kernel";
+import { buildAcpSystemPrompt } from "../src/system-prompt.js";
+import { loadUserConfig, applyUserConfig } from "../src/user-config.js";
+import type { AdapterConfig } from "../src/config.js";
+
+const CONFIG_DIR_NAME = ".pi";
+
+test("buildAcpSystemPrompt with defaults contains the philosophy and tier rules", () => {
+  const prompt = buildAcpSystemPrompt(defaultPrompts);
+  assert.ok(prompt.includes("ACP context management"), "has header");
+  assert.ok(prompt.includes(defaultPrompts.compressPhilosophy.slice(0, 40)), "embeds compressPhilosophy");
+  assert.ok(prompt.includes(defaultPrompts.howToCompressRules.slice(0, 40)), "embeds howToCompressRules");
+  assert.ok(prompt.includes(defaultPrompts.tier2DistillRules.slice(0, 40)), "embeds tier2DistillRules");
+  assert.ok(prompt.includes(defaultPrompts.tier3CondenseRules.slice(0, 40)), "embeds tier3CondenseRules");
+});
+
+test("buildAcpSystemPrompt reflects acknowledged custom prompts", () => {
+  const custom = resolvePrompts(
+    { compressPhilosophy: "CUSTOM-PHILOSOPHY-MARKER" },
+    { acknowledgeRisk: true },
+  );
+  const prompt = buildAcpSystemPrompt(custom);
+  assert.ok(prompt.includes("CUSTOM-PHILOSOPHY-MARKER"), "custom philosophy present");
+  assert.ok(!prompt.includes(defaultPrompts.compressPhilosophy.slice(0, 40)), "default philosophy replaced");
+  assert.ok(prompt.includes(defaultPrompts.howToCompressRules.slice(0, 40)), "unoverridden fields keep defaults");
+});
+
+test("resolvePrompts throws on override without acknowledgeRisk", () => {
+  assert.throws(
+    () => resolvePrompts({ compressPhilosophy: "x" }),
+    /acknowledgeRisk/,
+    "ungated override must throw",
+  );
+});
+
+test("resolvePrompts with empty overrides is a no-op (no gate needed)", () => {
+  const resolved = resolvePrompts({});
+  assert.equal(resolved.compressPhilosophy, defaultPrompts.compressPhilosophy);
+});
+
+test("loadUserConfig picks up prompts and acknowledgePromptsRisk keys", async () => {
+  const tmpDir = path.join(os.tmpdir(), `acp-prompts-${Date.now()}`);
+  const cfgDir = path.join(tmpDir, CONFIG_DIR_NAME);
+  await fs.mkdir(cfgDir, { recursive: true });
+  await fs.writeFile(
+    path.join(cfgDir, "acp.json"),
+    JSON.stringify({ prompts: { compressPhilosophy: "X" }, acknowledgePromptsRisk: true }),
+    "utf8",
+  );
+  try {
+    const config = await loadUserConfig(tmpDir);
+    assert.equal(config.acknowledgePromptsRisk, true, "acknowledgePromptsRisk loaded");
+    assert.deepEqual(config.prompts, { compressPhilosophy: "X" }, "prompts loaded");
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("applyUserConfig flows prompts through to the adapter", () => {
+  const adapter: AdapterConfig = { modelContextLimit: 200_000 };
+  const user = { prompts: { tier3CondenseRules: "Y" }, acknowledgePromptsRisk: true };
+  const result = applyUserConfig(adapter, user);
+  assert.deepEqual(result.prompts, { tier3CondenseRules: "Y" }, "prompts merged");
+  assert.equal(result.acknowledgePromptsRisk, true, "ack flag merged");
+  assert.equal(result.modelContextLimit, 200_000, "other fields preserved");
+});


### PR DESCRIPTION
## What

Plumbs acp-kernel's Layer 0 `Prompts` override ([acp-kernel#62](https://github.com/ranxianglei/acp-kernel/pull/62)) into billion-context-pi. Users can now override the 4 load-bearing compression prompt rules via `~/.pi/agent/acp.json`, gated by `acknowledgePromptsRisk`.

Tracks [dog/billion-context-pi#27](https://github.com/ranxianglei/billion-context-pi/issues/27).

## Usage

```json
{
  "prompts": {
    "compressPhilosophy": "My custom compression philosophy..."
  },
  "acknowledgePromptsRisk": true
}
```

Without `acknowledgePromptsRisk: true`, overrides are **dropped** (defaults used) and a warning is logged — the session never crashes. This mirrors the kernel's `resolvePrompts` gate and the `compress` tool's `dangerous`/`acknowledgeRisk` pattern.

## Changes (10 files, +263/−27)

| File | Change |
|------|--------|
| `src/config.ts` | Add `prompts?: Partial<Prompts>` + `acknowledgePromptsRisk?: boolean` to `AdapterConfig` (with JSDoc) |
| `src/user-config.ts` | Whitelist `prompts`/`acknowledgePromptsRisk` in `UserAcpConfig` + `KNOWN` set |
| `src/runtime.ts` | Store resolved `Prompts` on `AcpRuntime` + `setPrompts()` (`defaultPrompts` until session_start resolves) |
| `src/system-prompt.ts` | `ACP_SYSTEM_PROMPT` const → `buildAcpSystemPrompt(prompts: Prompts)` function |
| `src/index.ts` | Resolve prompts at `session_start` (try/catch → fall back to `defaultPrompts` + warn); pass `runtime.prompts` to all 3 `renderNudgeText` calls + the system-prompt builder |
| `tests/prompts-config.test.ts` | 7 tests (defaults, custom override, gate throw, config load, merge, byte-identity) |
| `CONFIGURATION.md` | New "Prompts Customization" section + Quick-start example + summary table (per existing annotation convention) |
| `CONFIGURATION.zh-CN.md` | Same in Chinese (提示词自定义) |
| `README.md` | JSON example rows + config-table rows + key-count note 9 → 11 |
| `README.zh-CN.md` | Same in Chinese |

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ — **262 pass / 0 fail** (256 baseline after rebase + 6 new; +1 byte-identity from review)
- `npm run build` ✅ — `dist/index.js` 437KB (acp-kernel bundled inline)

## Dual-agent review

Two oracle agents reviewed for regressions (per issue #27). Verdict: **ship-with-fixes**. One real regression found and fixed: the `buildAcpSystemPrompt` closing backtick was 2-space indented, adding trailing-whitespace bytes to the default system prompt vs the old const. Dedented to column 0 — byte-identity restored (regression test added). Non-blocking observations (resume path, README key count) noted.

## Rebase onto master

Rebased onto `7ca667f` (v0.1.36 merge). Three conflicts resolved by keeping **both sides'** additions (non-overlapping fields):
- `src/config.ts` — master's `delegate`/`compress`/`displayUsage` + this PR's `prompts`/`acknowledgePromptsRisk`
- `src/index.ts` — imports merged; `session_start` keeps master's `resolveDelegate(...).enabled` gate + this PR's prompts resolution try/catch
- `src/user-config.ts` — `UserAcpConfig` + `KNOWN` set carry all keys

Now `mergeable: true` (no conflicts).

## ⚠️ Cross-repo dependency — blocked on acp-kernel publish

This imports `resolvePrompts` / `defaultPrompts` / `Prompts` from `acp-kernel`, added by [acp-kernel#62](https://github.com/ranxianglei/acp-kernel/pull/62). **0.0.21 shipped without Layer 0** (it was a different nudge fix, #64). Per AGENTS.md §5 cross-repo release order:

1. Merge acp-kernel#62 → publishes as **0.0.22**
2. `npm view acp-kernel version` returns 0.0.22
3. **Then** this PR: bump `acp-kernel` pin `0.0.20` → `0.0.22` in a release commit, refresh lockfile, re-run CI

CI on this branch fails at typecheck until step 1 ships (0.0.20/0.0.21 do not export these symbols). Locally validated via the AGENTS.md "Local pre-validation" overlay (Layer 0 dist overlaid onto `node_modules/acp-kernel`).

## Design notes

- **Default behavior is byte-identical**: with no `prompts` in acp.json, `resolvePrompts(undefined)` returns `defaultPrompts`, so the system prompt and nudges are unchanged (asserted by a byte-stability test).
- The resolved `Prompts` lives on `AcpRuntime` (not re-resolved per turn) — consistent with how `adapter` config is stored.
- Only the 4 load-bearing rules are exposed; surface text (headers, tool descriptions) stays fixed (see acp-kernel `DESIGN-prompts.md §Non-goals`).

🤖 Merge is human-only — I will not merge this PR.
