### PR TITLE
fix: delegate 子代理在嵌入宿主（如 pi-web）下解析正确的 pi CLI 入口

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -3,10 +3,10 @@ import {
   type ChildProcess,
   type SpawnOptions,
 } from "node:child_process";
-import { createWriteStream, type WriteStream } from "node:fs";
+import { createWriteStream, existsSync, type WriteStream } from "node:fs";
 import { mkdir, mkdtemp, writeFile, rm, appendFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve as resolvePath } from "node:path";
 import { Type, type Static } from "typebox";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import type {
@@ -37,6 +37,56 @@ export function delegateSpawnOptions(cwd: string, env: NodeJS.ProcessEnv): Spawn
     stdio: ["pipe", "pipe", "pipe"],
     shell: false,
   };
+}
+
+const PI_CLI_ENTRY_RE = /[\\/]pi-coding-agent[\\/]dist[\\/]cli\.js$/;
+const PI_PACKAGE_REL = join("@earendil-works", "pi-coding-agent", "dist", "cli.js");
+
+function probeUpFromArgv(argv1: string): string | null {
+  let dir = resolvePath(dirname(argv1) || process.cwd());
+  for (;;) {
+    const candidate = join(dir, "node_modules", PI_PACKAGE_REL);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+function piCliGlobalCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+  if (process.platform === "win32") {
+    if (env.APPDATA) candidates.push(join(env.APPDATA, "npm", "node_modules", PI_PACKAGE_REL));
+  } else {
+    const home = env.HOME ?? env.USERPROFILE;
+    if (home) candidates.push(join(home, ".local", "lib", "node_modules", PI_PACKAGE_REL));
+    candidates.push(join("/usr/local", "lib", "node_modules", PI_PACKAGE_REL));
+    candidates.push(join("/usr", "lib", "node_modules", PI_PACKAGE_REL));
+  }
+  return candidates;
+}
+
+/** Resolve the pi CLI entry for delegate child processes.
+ *  argv[1] is only the pi CLI under a CLI host; embedded hosts (e.g. pi-web)
+ *  run the SDK inside another node process, so probe instead. Non-pi hosts
+ *  (omp) keep argv[1] untouched. */
+export function resolvePiCliEntry(
+  argv1: string,
+  env: NodeJS.ProcessEnv = process.env,
+  piHost = true,
+): string {
+  const explicit = env.PI_CLI_PATH;
+  if (explicit) return explicit;
+  if (argv1 && PI_CLI_ENTRY_RE.test(argv1)) return argv1;
+  if (piHost) {
+    const probed = probeUpFromArgv(argv1);
+    if (probed) return probed;
+    for (const candidate of piCliGlobalCandidates(env)) {
+      if (existsSync(candidate)) return candidate;
+    }
+    logWarn("delegate", { event: "cli-entry-unresolved", argv1, fallback: "argv[1]" });
+  }
+  return argv1;
 }
 
 /** ACP context-management tools that every restricted delegate must retain
@@ -627,7 +677,7 @@ async function runDelegate(
 
   const child = spawn(
     process.execPath,
-    [process.argv[1]!, ...cliArgs],
+    [resolvePiCliEntry(process.argv[1] ?? "", process.env, isPiHost(ctx.sessionManager)), ...cliArgs],
     delegateSpawnOptions(cwd, childEnv),
   ) as ChildProcess;
   child.stdin?.once("error", (e: Error) => {

--- a/tests/delegate-entry.test.ts
+++ b/tests/delegate-entry.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolvePiCliEntry } from "../src/delegate-tool.js";
+
+const REL = join("@earendil-works", "pi-coding-agent", "dist", "cli.js");
+
+/** A machine with pi installed under /usr/* would defeat the fallback test. */
+function globalPiInstalled(): boolean {
+  if (process.platform === "win32") return false;
+  return ["/usr/local/lib", "/usr/lib"].some((p) => existsSync(join(p, "node_modules", REL)));
+}
+
+function makeTree(rel: string): string {
+  const base = mkdtempSync(join(tmpdir(), "acp-entry-"));
+  const cli = join(base, rel);
+  mkdirSync(join(cli, ".."), { recursive: true });
+  writeFileSync(cli, "");
+  return base;
+}
+
+test("PI_CLI_PATH env overrides everything, even when argv[1] is the pi CLI", () => {
+  const argv1 = join("node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+  const explicit = join("custom", "pi", "cli.js");
+  assert.equal(
+    resolvePiCliEntry(argv1, { PI_CLI_PATH: explicit }, true),
+    explicit,
+  );
+});
+
+test("argv[1] matching the pi CLI path is used as-is (CLI host, no fs probing)", () => {
+  const posixPath = "/usr/local/lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js";
+  assert.equal(resolvePiCliEntry(posixPath, {}, true), posixPath);
+
+  const winPath = "C:\\Users\\dev\\node_modules\\@earendil-works\\pi-coding-agent\\dist\\cli.js";
+  assert.equal(resolvePiCliEntry(winPath, {}, true), winPath);
+});
+
+test("embedded host probes upward from argv[1] (pi-web: next bin finds pi-coding-agent)", () => {
+  const base = makeTree(join("app", "node_modules", REL));
+  const nextBin = join(base, "app", "node_modules", "next", "dist", "bin", "next");
+  try {
+    const expected = join(base, "app", "node_modules", REL);
+    assert.equal(resolvePiCliEntry(nextBin, {}, true), expected);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("global install candidates are probed when upward probe fails", () => {
+  const base = mkdtempSync(join(tmpdir(), "acp-entry-global-"));
+  try {
+    let env: NodeJS.ProcessEnv;
+    let expected: string;
+    if (process.platform === "win32") {
+      expected = join(base, "npm", "node_modules", REL);
+      mkdirSync(join(expected, ".."), { recursive: true });
+      writeFileSync(expected, "");
+      env = { APPDATA: base };
+    } else {
+      expected = join(base, ".local", "lib", "node_modules", REL);
+      mkdirSync(join(expected, ".."), { recursive: true });
+      writeFileSync(expected, "");
+      env = { HOME: base };
+    }
+    const argv1 = join(base, "host", "bin", "server.js");
+    assert.equal(resolvePiCliEntry(argv1, env, true), expected);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test("unresolvable pi host falls back to argv[1] (never worse than status quo)", { skip: globalPiInstalled() }, () => {
+  const argv1 = join(tmpdir(), "acp-entry-nohit", "bin", "server.js");
+  assert.equal(resolvePiCliEntry(argv1, {}, true), argv1);
+});
+
+test("non-pi host (omp) keeps argv[1] untouched - probing is pi-host only", () => {
+  const argv1 = join("omp", "dist", "cli.js");
+  assert.equal(resolvePiCliEntry(argv1, {}, false), argv1);
+});
+
+test("PI_CLI_PATH still overrides on non-pi hosts (explicit user choice)", () => {
+  const explicit = join("custom", "pi", "cli.js");
+  assert.equal(
+    resolvePiCliEntry(join("omp", "dist", "cli.js"), { PI_CLI_PATH: explicit }, false),
+    explicit,
+  );
+});


### PR DESCRIPTION
## 这个 PR 解决了什么

先说结论：这是一个通用 bug，不是某个环境特有的问题——只要把 pi SDK 嵌进别的 node 进程里跑，delegate 就必踩坑，pi-web 只是其中最典型的一个。delegate 工具本身是支持 print/json 这类非 CLI 宿主场景的，偏偏 spawn 子代理时入口这一处写死了"宿主进程的 argv[1]"，等于默认宿主一定是 pi CLI。

这个假设在 pi CLI（TUI）下刚好成立，所以一直没被发现。但在官方网页版 pi-web 里，pi SDK 嵌在 next 服务器进程内（会话宿主是 `node next start`），`argv[1]` 指向的是 next 的 bin。于是子代理实际被派生成 `node next --mode json ...` / `node next -p --no-session ...`，next 不认识 pi 的 CLI 参数，所有 delegate 在 0.1 秒内必败：

- async 模式：`error: unknown option '--mode'`
- sync 模式：`error: option '-p, --port <port>' argument '--no-session' is invalid...`（`-p` 被 next 当成了 `--port`）

## 修改思路

新增 `resolvePiCliEntry()`，按优先级解析 pi CLI 入口：

1. `PI_CLI_PATH` 环境变量（显式覆盖，特殊安装路径可以自己指）
2. `argv[1]` 命中 pi CLI 路径正则（`…/pi-coding-agent/dist/cli.js`）→ 直接用它，CLI 宿主走原路径，一点没变
3. 从 `argv[1]` 所在目录逐级往上找 `node_modules/@earendil-works/pi-coding-agent/dist/cli.js`——覆盖 pi-web 的情况（next bin 和 pi 在同一个 node_modules 里）
4. 常见的全局安装位置（Windows `%APPDATA%\npm`；Linux `~/.local/lib`、`/usr/local/lib`、`/usr/lib`，逐个做存在性校验）
5. 实在找不到就兜底返回原来的 `argv[1]`，并记一条 logWarn——至少不比现状差，将来遇到新宿主也好排查

第 3、4 步只在 `isPiHost` 为真时执行，omp 宿主完全不经过探测链，还是原样用自己的 `argv[1]`。

## 影响与兼容性

- pi CLI 宿主：行为完全不变（正则命中即返回原路径）
- omp 宿主：行为完全不变（探测链被宿主判断门控跳过）
- pi-web 这类嵌入宿主：从 100% 秒失败变为正常可用
- 纯增量改动，新环境变量是可选的，现有配置都不受影响

## 验证

- 新增 `tests/delegate-entry.test.ts` 7 个用例：PI_CLI_PATH 优先、argv 正则命中（含 Windows 路径）、pi-web 向上探测、全局候选、兜底回退、omp 不探测、omp 下 env 仍生效
- 全套测试 240 项通过；`npm run typecheck`、`npm run build` 无错误
- 实测：把同逻辑的补丁打到安装包后在 pi-web 里验证过，delegate 从 100% 秒失败恢复正常（sync 最小用例 exit 0，多个 async researcher 任务正常完成）。复现：pi-web 开会话 → 调 `acp_delegate` → 0.1s 内报 `unknown option '--mode'`

## 说明

第一次给这个项目提 PR，代码风格、测试组织或描述格式如果有不合惯例的地方，请直接指出，我会尽快调整。
