### PR TITLE
release v0.1.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.1.36
+
+- Bump acp-kernel to 0.0.21 (two-tier gating: maxContextLimitPct 75% force-nudge + emergencyThresholdPct 95% truncate, spam fix when no compressible content, over-limit emergency voice)
+- New compress config sub-object: `maxContextLimit`, `emergencyThresholdPercent`, `nudgeGrowthTokens` (maps to kernel `nudge.maxContextLimitPct`, `nudge.emergencyThresholdPct` + `truncate.threshold`, `nudge.growthFloor` + `nudge.growthCap`)
+- New delegate config sub-object: `delegate: { enabled, displayUsage }` (boolean shorthand + legacy flat `displayUsage` backward compat)
+- Standalone CONFIGURATION.md + CONFIGURATION.zh-CN.md reference docs


### PR DESCRIPTION
CI did not auto-publish 0.1.36 because PR #126's branch was named *_kernel-0.0.20 (not *_release-v*). This release PR triggers the publish step. Version is already 0.1.36 on master; this PR adds a CHANGELOG.md.