### PR TITLE
ci: add Windows to test matrix for cross-platform regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [22, 24]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
+          cache: npm
       - run: npm ci
       - run: npm run typecheck
       - run: npm test


### PR DESCRIPTION
## What

Add `windows-latest` to the `test` job matrix in `.github/workflows/ci.yml`, so every PR and every push to `master` is automatically regression-tested on **both** Ubuntu and Windows (Node 22 & 24 = 4 jobs).

```diff
   test:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         node-version: [22, 24]
+    runs-on: ${{ matrix.os }}
```

Also adds `cache: npm` to `setup-node` (speeds up `npm ci`, especially on the slower Windows runners).

## Why

The project ships in `billion-context-pi`, a Pi coding-agent extension that is widely used on **Windows**. Until now CI only ran on `ubuntu-latest`, so Windows-specific regressions slipped through and had to be caught by hand on a VM. Recent examples that ubuntu-only CI could not have caught:

- #101 `findNpmRoot` infinite loop on Windows (POSIX-only `dir !== "/"` guard) + flaky timing/path-separator tests
- #130 delegate entry resolution for embedded hosts (Windows `%APPDATA%\npm` global install path, `[\\/]` cross-platform regex)

A Windows test matrix prevents this whole class of regression going forward.

## Scope

- `test` job only — now runs `npm ci` / `typecheck` / `test` / `build` on Ubuntu + Windows × Node 22/24.
- `e2e` job is untouched (it runs bash scripts + Docker, stays Ubuntu-only).
- `pr-validation` stays Ubuntu-only (branch-name check, platform-agnostic).
- `fail-fast: false` so a platform-specific failure doesn't cancel the other matrix jobs (makes diagnosing OS-specific breakage much easier).

## Verification

The full suite was run on a Windows 10 / Node v22.23.2 VM via the same commands the CI job uses:

```
npm ci && npm run typecheck && npm test && npm run build
# → 255 pass / 0 fail / 0 skip  (typecheck ✅ build ✅)
```

This includes the timing-sensitive watchdog tests (margins widened in #101) and the new cross-platform delegate-entry tests from #130. GHA `windows-latest` (Server 2022) should behave equivalently or faster.

## Notes

- Windows runners consume ~2× the build minutes of Linux. If minutes become a concern, the matrix can be trimmed to `os: [ubuntu-latest]` + node [22,24] for Linux and a single `windows-latest`/node-22 job, but the full 4-cell matrix is recommended for thorough regression.
- Merge is left to a human (per AGENTS.md §4).
