### PR TITLE
fix: block decompress falls back to full session tree after tree navigation

### DIFF
--- a/devlog/2026-08-13_decompress-full-tree-fallback/DESIGN.md
+++ b/devlog/2026-08-13_decompress-full-tree-fallback/DESIGN.md
@@ -1,0 +1,56 @@
+# DESIGN: Block decompress full-tree fallback
+
+- Task ID: `2026-08-13_decompress-full-tree-fallback`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-13
+- Status: Accepted
+
+## 1. Goals & Non-Goals
+
+- **Goals**: tree 导航（undo/redo//tree）后块级解压仍能还原原文；补全只发生在解压路径，不污染压缩主链路。
+- **Non-Goals**: 不改变状态持久化格式；不跨仓修改 acp-kernel（受发布顺序约束）；不改变单消息解压行为。
+
+## 2. Background & Motivation
+
+`navigateTree` 只移动会话叶子指针、不删 entry，消息原文始终在 append-only session tree。但块级解压的取数来源是 `buildContextEntries()`（**仅活动分支**），与单消息解压的 `getEntries()`（全量树）不对称——同一概念两处实现口径不一致即根因信号。
+
+## 3. Current Architecture (as-is)
+
+```
+decompress 工具 → decompress-tool.ts handleDecompress()
+  → runtime.stateFor(ctx) → readContextEntries(sm)          [src/runtime.ts]
+      → buildContextEntries()                                // 仅活动分支
+  → entriesToCoreMessages(entries) → coreMessages
+  → collectBlockContent(state, block, coreMessages, {full})  [acp-kernel]
+      → messages.filter(m => block.effectiveMessageIds.has(m.id))  // 找不到 → 空
+```
+
+对比：`findMessageContent` 扫 `ctx.sessionManager.getEntries()`（全量树）——undo 后仍可恢复，证明原文未丢。
+
+## 4. Proposed Design (to-be)
+
+- **Module / data-flow changes**: `src/decompress-tool.ts` 新增 `resolveBlockMessages(block, coreMessages, ctx)`，在 `collectBlockContent` 前补全：
+  1. 双侧 `split("#")[0]` 归一化——块存 CoreMessage id（多 tool-call assistant 为 `` `${entryId}#${callId}` ``，`messages.ts` `projectMessage`），`getEntry()` 键是 SessionEntry id（无后缀）；
+  2. `missingBaseIds` 逐个 `ctx.sessionManager.getEntry(id)`（O(1) 全量树查找），`entriesToCoreMessages` 重投影（多 tool-call 自动拆回 `#` 后缀，命中 `collectBlockContent` 的 `targetIds`）；
+  3. 无缺失时短路返回原 `coreMessages`，零开销。
+- **New types / interfaces**: 无（复用 `CompressionBlock` / `CoreMessage`）
+- **New files**: 无（单函数）
+
+## 5. Alternatives Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| A. 块级解压前补全 messages（getEntry 全量树） | 改动最小、隔离解压路径、原文精确恢复 | 无 | **选 A** |
+| B. `readContextEntries` 改用 `getEntries()` | 中 | 压缩判定/状态同步会重见已撤销消息 → 重压缩、ref 混乱 | 否决 |
+| C. acp-kernel 内部 fallback | 根治 | 跨仓，受"acp-kernel 先发布"约束 | 否决 |
+
+## 6. Risks & Trade-offs
+
+- **Backward compatibility**: 无 schema 变化；旧 `.acp.json` 直接可用；无缺失时行为与修复前逐字节一致
+- **Performance**: `getEntry` O(1)；仅缺失时触发；只读不写回 state
+- **Cross-platform**: 纯 JS，无平台差异
+- 风险：`getEntry` 返回非 message entry → `entriesToCoreMessages` 跳过；`count` 语义变化 → 仅影响提示文案，无状态影响
+
+## 7. Open Questions
+
+- 无（两轮模型评审已闭环：首轮 5 finding 修正，二轮 GO ✅）

--- a/devlog/2026-08-13_decompress-full-tree-fallback/REQ.md
+++ b/devlog/2026-08-13_decompress-full-tree-fallback/REQ.md
@@ -1,0 +1,53 @@
+# REQ: Block decompress full-tree fallback after tree navigation
+
+- Task ID: `2026-08-13_decompress-full-tree-fallback`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-13
+- Status: Done
+- Priority: P1
+- Owner: Tyan66666
+- References: PR #133
+
+## 1. Background & Problem Statement
+
+- **Context**: 会话树导航（pi-workspace-history `/undo`/`/redo`、Pi 原生 `/tree`）只移动 leaf 指针、不删除任何 entry（`ctx.navigateTree` → `branch(entryId)`）；但块级解压只从**活动分支**取原文。
+- **Current behavior (symptom)**: 对撤销区间内的块，`decompress({blockId:"b1"})` 返回 `Block b1 has no restorable message content.`——full 模式返回空，非 full 模式只剩嵌套子块摘要。
+- **Expected behavior**: 块级解压与单消息解压一致，能从 session log（全量树）取回原文。
+- **Impact**: 无数据丢失（块/摘要/原文都在磁盘）、无崩溃；"块级解压还原全文"能力对撤销区间失效，属功能缺口。
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 22
+  - OS/Arch: darwin-arm64
+- **Minimal reproduction steps**:
+  1) 压缩一批消息 → 产生块 b1
+  2) `/undo`（或 `/tree`）导航，使被压缩消息退出活动分支
+  3) `decompress({blockId:"b1"})`
+- **Relevant configuration**: 无
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - Backward compatibility: 不改变 `.acp.json` schema，旧状态文件直接可用
+  - Performance requirements: 无缺失时零开销（不触发 fallback）
+  - Resource limits: 不引入新依赖；不动 acp-kernel（跨仓改动受发布顺序约束）
+- **Non-Goals**: 不修单消息解压（已正常，走 `getEntries()` 全量树）；不做 undo 后自动重解压
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] undo 后块级解压恢复原文（fallback 到 `getEntry` 全量树）
+  - [x] 全量树也找不到时保留现有降级提示，不抛异常
+  - [x] 多 tool-call assistant（`#` 后缀 id）归一化后全部恢复
+  - [x] 多轮 compress → navigate → decompress 状态不丢、ref 不串
+- **Performance / Stability**:
+  - [x] 无缺失消息时短路返回原 `coreMessages`，零额外开销
+- **Regression**:
+  - [x] 新测试 4 个加入测试套件并通过（全量 237/237）
+
+## 5. Proposed Approach (optional)
+
+- **Affected modules & entry files**: `src/decompress-tool.ts`（新增 `resolveBlockMessages` + `handleDecompress` 调用点 2 行）；`tests/decompress-tool.test.ts`
+- **Risks**: 低——改动隔离在解压路径、只读、不写回 state
+- **Rollback strategy**: `git revert 716e3b9`；不涉及 acp-kernel 与 schema

--- a/devlog/2026-08-13_decompress-full-tree-fallback/WORKLOG.md
+++ b/devlog/2026-08-13_decompress-full-tree-fallback/WORKLOG.md
@@ -1,0 +1,70 @@
+# WORKLOG: Block decompress full-tree fallback
+
+- Task ID: `2026-08-13_decompress-full-tree-fallback`
+- Home Repo: `billion-context-pi`
+- Status: Done
+- Updated: 2026-08-13 13:37
+
+## 1. Summary
+
+- **What was done**: 块级解压新增全量树 fallback（`resolveBlockMessages`），undo/redo//tree 后仍可从 `getEntry` 恢复原文。
+- **Why**: 树导航只移叶子指针、原文未丢，但块级解压只从活动分支取数，导致撤销区间内的块无法还原全文。
+- **Behavior / compatibility changes**: No——仅新增缺失消息补全路径；无缺失时行为不变；`.acp.json` 结构不变
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `716e3b9` | fix: block decompress falls back to full session tree after tree navigation（基于 `f472485 release v0.1.35`） |
+
+### Key Files
+
+- `src/decompress-tool.ts` — +33/-2：新增 `resolveBlockMessages`（双侧 `#` 归一化 + `getEntry` 全量树补全 + `entriesToCoreMessages` 重投影 + 无缺失短路）；`handleDecompress` 块级分支改用 resolved 结果
+- `tests/decompress-tool.test.ts` — +162：4 个新测试（undo fallback / 降级保留 / 多 tool-call `#` 归一化 / 多轮状态）
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `resolveBlockMessages`（`src/decompress-tool.ts:111-138`），`handleDecompress` 调用点 `:205`
+- **Key configuration items**: 无新配置
+- **Key logic explanation**: block 存 CoreMessage id（多 tool-call 带 `#`），`getEntry()` 键是 SessionEntry id——两侧归一化到 baseId 再比较；取回的 entry 重投影拆回 `#` 后缀 CoreMessage，命中 `collectBlockContent` 的 `targetIds` 集合
+
+## 4. Testing & Verification
+
+### Build & Test Commands
+
+```sh
+npm run typecheck      # PASS
+npm test               # PASS 237/237（原 233 + 新 4）
+npm run build          # PASS（产物已安装到 ~/.pi/agent/npm/node_modules/billion-context-pi/dist/）
+```
+
+### Test Coverage
+
+- New/modified test files: `tests/decompress-tool.test.ts`（+4 测试）
+- Test count: 237 total, 237 pass, 0 fail
+- Key scenarios verified: undo 后原文恢复；全树缺失保留降级；多 tool-call `#` 归一化；多轮 compress→navigate→decompress
+
+### Results
+
+- **PASS/FAIL**: PASS
+- **Key logs/data**: 产物级 before/after 对比（旧/新 `dist/index.js` bundle 跑同一场景）——旧返回 `Block b1 has no restorable message content.`，新返回 `Restored block b1 (1 item) inline:` + 原文全文
+
+## 5. Risk Assessment & Rollback
+
+- **Risk points**: 补全路径仅解压时触发、只读；`getEntry` 返回非 message entry 由 `entriesToCoreMessages` 跳过
+- **Rollback method**: `git revert 716e3b9`
+- **Compatibility notes**: 无 schema/数据格式变更
+
+## 6. Lessons Learned (optional)
+
+- 同一概念多处实现、口径不一致即根因信号（块级取活动分支 vs 单消息取全量树）
+- 单测全绿 ≠ 产物正确：安装到 Pi 的 `dist/index.js` 需产物级验证（ESM 解析 external 宿主包、bundle 行为）
+- ESM 调试坑：`.bak` 后缀不被 Node ESM 识别；external 包按 bundle 所在目录向上解析 node_modules
+
+## 7. Follow-ups (optional)
+
+- [ ] PR #133 合并（AGENTS.md：human-only）
+- [ ] 重启 Pi 后真实环境验证（装 workspace-history，`/undo` 后 `decompress` 块）

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow } from "./log.js";
-import { parseBlockIdArg, collectBlockContent } from "acp-kernel";
+import { parseBlockIdArg, collectBlockContent, type CompressionBlock } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
 import { resolve, relative, isAbsolute, join } from "node:path";
@@ -108,6 +108,33 @@ function findMessageContent(ref: string, ctx: ExtensionContext): { text: string;
   return null;
 }
 
+/** Recover a block's message refs from the FULL session tree (getEntry), not
+ *  just the active branch, so block decompress still works after a tree
+ *  navigation (workspace-history /undo /redo, Pi /tree). Block refs are
+ *  CoreMessage ids — multi tool-call assistants are `${entryId}#${callId}`
+ *  (messages.ts projectMessage) — while getEntry() keys are SessionEntry ids
+ *  (no suffix), so both sides normalize to the base id before comparing.
+ *  Re-projecting a fetched entry re-splits multi tool-call assistants back
+ *  into `${entryId}#${callId}` CoreMessages, which match
+ *  block.effectiveMessageIds verbatim in collectBlockContent's targetIds set. */
+function resolveBlockMessages(
+  block: CompressionBlock,
+  coreMessages: ReturnType<typeof entriesToCoreMessages>,
+  ctx: ExtensionContext,
+): ReturnType<typeof entriesToCoreMessages> {
+  const neededBaseIds = new Set(block.effectiveMessageIds.map((id) => id.split("#")[0]!));
+  const presentBaseIds = new Set(coreMessages.map((m) => m.id.split("#")[0]!));
+  const missingBaseIds = [...neededBaseIds].filter((id) => !presentBaseIds.has(id));
+  if (missingBaseIds.length === 0) return coreMessages;
+
+  const extra: ReturnType<typeof entriesToCoreMessages> = [];
+  for (const baseId of missingBaseIds) {
+    const entry = ctx.sessionManager.getEntry(baseId);
+    if (entry) extra.push(...entriesToCoreMessages([entry]));
+  }
+  return [...coreMessages, ...extra];
+}
+
 /** Decompress a single message by its ref. Unlike block decompression (which
  *  defaults to file — blocks can be huge), a single message is usually small,
  *  so it defaults to inline. Oversized messages still go to a file. */
@@ -175,7 +202,11 @@ async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: 
   }
 
   const full = args.full ?? false;
-  const { text, count } = collectBlockContent(state, block, coreMessages, { full });
+  // Resolve the block's message refs against the FULL session tree (falling
+  // back to getEntry for refs missing from the active branch), so decompress
+  // still restores original text after a tree navigation (undo/redo//tree).
+  const resolved = resolveBlockMessages(block, coreMessages, ctx);
+  const { text, count } = collectBlockContent(state, block, resolved, { full });
 
   if (count === 0) return `Block ${blockId} has no restorable message content.`;
 

--- a/tests/decompress-tool.test.ts
+++ b/tests/decompress-tool.test.ts
@@ -43,6 +43,17 @@ function fakeCtx(entries: any[], stateFile: string) {
   };
 }
 
+/** fake ctx whose sessionManager keeps a FULL tree (getEntry) distinct from the
+ *  ACTIVE branch (getBranch), simulating a tree navigation (undo): the leaf
+ *  moved so the block's messages left the active branch, but they are still in
+ *  the session log (full tree) — exactly the scenario resolveBlockMessages
+ *  fixes. */
+function fakeCtxFullTree(allEntries: any[], activeEntries: any[], stateFile: string) {
+  const ctx = fakeCtx(activeEntries, stateFile) as any;
+  ctx.sessionManager.getEntry = (id: string) => allEntries.find((e: any) => e.id === id);
+  return ctx;
+}
+
 // Shared setup: assign refs + compress m00001 into block b1, return the tool
 // handles + ctx so each test can drive the decompress tool.
 async function setupWithCompressedBlock() {
@@ -131,4 +142,155 @@ test("decompress keeps the block active after a file-mode call", async () => {
   const res2 = await decompressTool.execute("tc7", { blockId: "b1" }, undefined, undefined, ctx);
   const text2 = (res2.content[0] as any).text as string;
   assert.doesNotMatch(text2, /not found/i, "block still present after first decompress");
+});
+
+test("decompress restores a block's original text via getEntry fallback after tree navigation (undo)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-decompress-fallback-undo.session.json";
+  await cleanState(stateFile);
+  const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+  const allEntries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+
+  // Compress phase: everything is on the active branch (e1 → block b1).
+  const compressCtx = fakeCtxFullTree(allEntries, allEntries, stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, compressCtx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00001", summary: "Detailed initial context message for the decompress-tool tests." }] },
+    undefined, undefined, compressCtx,
+  );
+
+  // Undo phase: the leaf moved; e1 left the active branch but is still in the
+  // full tree (getEntry finds it) — like after /undo, /redo, or /tree.
+  const activeAfterUndo = allEntries.filter((e) => e.id !== "e1");
+  const undoCtx = fakeCtxFullTree(allEntries, activeAfterUndo, stateFile);
+  const decompressTool = api.tools.find((t: any) => t.name === "decompress")!;
+  const res = await decompressTool.execute("tc2", { blockId: "b1", inline: true }, undefined, undefined, undoCtx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.match(text, /inline:/, "result signals inline mode");
+  assert.ok(text.includes("This is a detailed message that needs to be compressed."),
+    "fallback restored the original text from the full session tree");
+});
+
+test("decompress keeps the degraded message when the ref is gone from both branch and full tree", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-decompress-fallback-gone.session.json";
+  await cleanState(stateFile);
+  const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+  const allEntries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+
+  const compressCtx = fakeCtxFullTree(allEntries, allEntries, stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, compressCtx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  await compressTool.execute("tc1", { content: [{ startId: "m00001", endId: "m00001", summary: "Detailed initial context message that needs restoration after navigation." }] }, undefined, undefined, compressCtx);
+
+  // e1 vanished from the full tree entirely: getEntry → undefined AND the
+  // active branch is empty — nothing to fall back to.
+  const goneCtx = fakeCtxFullTree(allEntries.filter((e) => e.id !== "e1"), [], stateFile);
+  const decompressTool = api.tools.find((t: any) => t.name === "decompress")!;
+  const res = await decompressTool.execute("tc2", { blockId: "b1", inline: true }, undefined, undefined, goneCtx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.match(text, /no restorable message content/, "degraded message preserved when nothing can be restored");
+});
+
+test("decompress restores multi tool-call assistant messages (refs carry # suffix) after undo", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-decompress-fallback-tools.session.json";
+  await cleanState(stateFile);
+  const filler = (n: string) => `filler ${n} `.repeat(400);
+
+  const toolCallsEntry = {
+    type: "message", id: "e1", parentId: null, timestamp: "",
+    message: {
+      role: "assistant",
+      content: [
+        { type: "toolCall", name: "read", id: "call-1", arguments: { path: "a.txt", payload: "p".repeat(3000) } },
+        { type: "toolCall", name: "bash", id: "call-2", arguments: { command: "ls", payload: "q".repeat(3000) } },
+      ],
+      timestamp: Date.now(),
+    },
+  };
+  const allEntries = [
+    toolCallsEntry,
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+
+  const compressCtx = fakeCtxFullTree(allEntries, allEntries, stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, compressCtx);
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  // The multi tool-call assistant projects to two CoreMessages (e1#call-1,
+  // e1#call-2), each with its own ref (m00001, m00002).
+  await compressTool.execute(
+    "tc1",
+    { content: [{ startId: "m00001", endId: "m00002", summary: "Tool call summary covering the multi tool-call assistant message content for the test." }] },
+    undefined, undefined, compressCtx,
+  );
+
+  const activeAfterUndo = allEntries.filter((e) => e.id !== "e1");
+  const undoCtx = fakeCtxFullTree(allEntries, activeAfterUndo, stateFile);
+  const decompressTool = api.tools.find((t: any) => t.name === "decompress")!;
+  const res = await decompressTool.execute("tc2", { blockId: "b1", inline: true }, undefined, undefined, undoCtx);
+  const text = (res.content[0] as any).text as string;
+
+  assert.ok(text.includes("read") && text.includes("bash"),
+    "both multi tool-call CoreMessages restored via base-id normalization");
+});
+
+test("decompress survives repeated compress → navigate → decompress cycles (state not lost)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-decompress-fallback-cycles.session.json";
+  await cleanState(stateFile);
+  const longText = "This is a detailed message that needs to be compressed. ".repeat(130);
+  const filler = (n: string) => `filler ${n} `.repeat(600);
+  const allEntries = [
+    userMsg("e1", longText),
+    userMsg("e2", filler("two")), userMsg("e3", filler("three")),
+    userMsg("e4", filler("four")), userMsg("e5", filler("five")),
+    userMsg("e6", filler("six")), userMsg("e7", filler("seven")),
+  ];
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const decompressTool = api.tools.find((t: any) => t.name === "decompress")!;
+
+  // Cycle 1: compress e1 → navigate away → decompress (fallback restores).
+  const compressCtx = fakeCtxFullTree(allEntries, allEntries, stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, compressCtx);
+  await compressTool.execute("tc1", { content: [{ startId: "m00001", endId: "m00001", summary: "First compression cycle summary for the repeated round-trip navigation test." }] }, undefined, undefined, compressCtx);
+
+  let active = allEntries.filter((e) => e.id !== "e1");
+  let res = await decompressTool.execute("tc2", { blockId: "b1", inline: true }, undefined, undefined, fakeCtxFullTree(allEntries, active, stateFile));
+  assert.ok(((res.content[0] as any).text as string).includes("This is a detailed message"),
+    "cycle 1: fallback restored the original text after undo");
+
+  // Cycle 2: navigate BACK (redo) so everything is active again, compress a
+  // NEW block over e2, navigate away, decompress the new block.
+  const redoCtx = fakeCtxFullTree(allEntries, allEntries, stateFile);
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, redoCtx);
+  await compressTool.execute("tc3", { content: [{ startId: "m00002", endId: "m00002", summary: "Second compression cycle summary covering the filler two message for the test." }] }, undefined, undefined, redoCtx);
+
+  active = allEntries.filter((e) => e.id !== "e2");
+  res = await decompressTool.execute("tc4", { blockId: "b2", inline: true }, undefined, undefined, fakeCtxFullTree(allEntries, active, stateFile));
+  assert.ok(((res.content[0] as any).text as string).includes("filler two"),
+    "cycle 2: newly compressed block also restores after navigate-away");
 });


### PR DESCRIPTION
## Problem

块级解压（`decompress({ blockId })`）在会话树导航（workspace-history `/undo` `/redo`、Pi 原生 `/tree`）之后会失效：对落在撤销区间里的块返回 `Block bX has no restorable message content.`，无法还原原文。

触发链路：`ctx.navigateTree()` 把会话叶子指针移回历史节点（等价 `branch(entryId)`，只移指针不删条目）→ 被压缩消息退出**活动分支** → 块级解压时 `collectBlockContent(state, block, coreMessages)` 收到的 `coreMessages` 只含活动分支（`runtime.readContextEntries` → `buildContextEntries()`）→ `messages.filter(m => block.effectiveMessageIds.has(m.id))` 过滤结果为 0。

**不是数据丢失**：压缩块（`.acp.json`）与消息原文（Pi append-only session tree）都完好，`sessionManager.getEntry()` 仍可按 id 从全量树取回条目。受影响的是"块级解压还原全文"这一能力；单消息解压（`findMessageContent` 扫 `getEntries()` 全量树）不受影响。

## Root Cause

`decompress-tool.ts` 块级路径只把**活动分支**的消息传给 `collectBlockContent`，而块的 `effectiveMessageIds` 可能指向已不在活动分支的原始消息。

## Fix

新增 `resolveBlockMessages(block, coreMessages, ctx)`（`src/decompress-tool.ts`）：

- 双侧 `split("#")[0]` 归一化——块存的是 CoreMessage id（多 tool-call assistant 为 `` `${entryId}#${callId}` ``，`messages.ts` `projectMessage`），`getEntry()` 键是 SessionEntry id（无后缀）；
- 缺失的 baseId 用 `ctx.sessionManager.getEntry(id)` 从**全量树**取 entry，`entriesToCoreMessages` 重投影（多 tool-call 自动拆回 `#` 后缀 CoreMessage，正好命中 `collectBlockContent` 的 `targetIds`）；
- 无缺失时零开销短路返回原 `coreMessages`。

## Tests

`tests/decompress-tool.test.ts` +4 测试（+162 行），全部通过（**237/237**，原 233 + 新 4）：

| 测试 | 覆盖 |
|---|---|
| undo 后 fallback 恢复原文 | 活动分支不含 e1 → `getEntry` 补全 → 原文恢复 |
| 全树也找不到时保留降级 | 仍返回 `no restorable message content`，不抛异常 |
| 多 tool-call `#` 归一化 | 2 个 toolCall 拆分 refs，undo 后全部恢复 |
| 多轮 compress→navigate→decompress | cycle1 (b1) + cycle2 (b2) 状态不丢 |

## Verification

- `npm test`：237/237 通过；`npm run typecheck` 干净；LSP 无诊断
- **产物级 before/after 对比**：同一场景（压缩 → 模拟 undo → 块级解压）分别在旧/新 `dist/index.js` bundle 上运行——旧返回降级提示，新恢复原文全文
- 方案评审两轮（reviewer @ mimo-v2.5-pro）：二轮 GO ✅，首轮 5 个 finding（含 1 blocking：`#` 后缀归一化）全部修正到位

## Impact

- 行为变更仅限块级解压的缺失消息补全路径，无缺失时零开销；不影响压缩主链路、状态持久化格式（`.acp.json` 结构不变）
- 修复对 workspace-history 与 Pi 原生 `/tree` 同时生效
