### PR TITLE
chore(deps): bump acp-kernel to 0.0.22 (compress error-handling fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.21",
+		"acp-kernel": "0.0.22",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
## 升级 acp-kernel 依赖至 0.0.22（compress 错误处理修复）

关联 issue: ranxianglei/billion-context-pi#135
关联 PR: ranxianglei/acp-kernel#65（修复实现，本 PR 的前置）

### 改动

`package.json`：`"acp-kernel": "0.0.21" → "0.0.22"`（唯一变更，1 行）。

插件代码**零逻辑改动**——`compress-tool.ts` 为透传，不参与错误归因/重试引导逻辑。

### 为什么只升依赖

问题根因全部位于 acp-kernel（缺陷 A：批处理错误无 range 归因；缺陷 B：已消费 range 重试误报 too-small，见 issue #135 完整说明）。billion-context-pi 无需代码改动，仅需消费修复后的 kernel。

### 验证

- `npm run typecheck`：0 错
- `npm test`：255/255 通过
- `npm run build`：成功（dist/index.js 439KB，内联新 kernel，含 `already compressed` / `Skipped range` 修复标记）
- 兼容性：下游消费面（`compress-tool.ts` 解构 `{ blocksCreated, tokensCompressed, errors, warnings }`）语义不变，仅错误/警告文案变化（修复目的）。详见 issue #135 兼容性表。

### ⚠️ 合并顺序（严格依赖）

按 AGENTS.md 跨仓库依赖规则，**acp-kernel 必须先行**：

1. 合并 ranxianglei/acp-kernel#65 → CI 走 `2026-08-13_release-v0.0.22` release 分支自动 publish **v0.0.22**
2. 验证 `npm view acp-kernel version` 输出 `0.0.22`
3. 然后本 PR 的 CI（`npm ci` 按 pin 安装 0.0.22）才能通过

> 注：`package-lock.json` 中 acp-kernel 条目（resolved/integrity）待 0.0.22 发布后 `npm install` 刷新，本 PR 暂只提交 `package.json` 一行。
