### PR TITLE
fix(omp): preserve compression across transformed contexts

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10,6 +10,7 @@ import { resolveConfig, type AdapterConfig } from "./config.js";
 import { entriesToCoreMessages, extractText, matchesStoredText, messageIdentity, messageRef } from "./messages.js";
 import { SessionStateStore, type LiveRefOrigin } from "./state.js";
 import { logInfo, logWarn } from "./log.js";
+import { findUniqueLongestRun, type MatchRange } from "./sequence-match.js";
 
 type SessionEntrySource = {
   buildContextEntries?: () => SessionEntry[];
@@ -47,15 +48,17 @@ export interface AcpRuntime {
 
 function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: CompressionState, origins: LiveRefOrigin[]): SessionEntry[] {
   const persisted = entries.filter((e): e is SessionMessageEntry => e.type === "message");
-  const matched = matchUniqueLongestRun(persisted, live, (entry, message) => sameMessage(entry.message, message));
-  const prior = matchUniqueLongestRun(origins, live, (origin, message) => origin.identity === messageIdentity(message));
+  const liveIdentities = live.map(messageIdentity);
+  const persistedIdentities = persisted.map((entry) => messageIdentity(entry.message));
+  const persistedRange = findUniqueLongestRun<MatchKey>(persistedIdentities, normalizePersistedMatchKeys(persisted, persistedIdentities, live, liveIdentities));
+  const originRange = findUniqueLongestRun(origins.map((origin) => origin.identity), liveIdentities);
   const out: SessionEntry[] = [];
   const nextOrigins: LiveRefOrigin[] = [];
   const usedIds = new Set<string>();
   for (let i = 0; i < live.length; i++) {
     const msg = live[i]!;
-    const entry = matched[i];
-    const origin = prior[i];
+    const entry = valueInRange(persisted, persistedRange, i);
+    const origin = valueInRange(origins, originRange, i);
     if (entry) {
       if (origin) migrateLiveRefs(state, origin.rawId, entry.id);
       else migrateTaggedRef(state, msg, entry.id);
@@ -65,10 +68,10 @@ function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: 
     const id = origin?.rawId ?? nextLiveId(state, usedIds, i);
     usedIds.add(id);
     out.push({ type: "message", id, parentId: null, timestamp: String(msg.timestamp ?? Date.now()), message: msg });
-    nextOrigins.push({ rawId: id, identity: messageIdentity(msg) });
+    nextOrigins.push({ rawId: id, identity: liveIdentities[i]! });
   }
   origins.splice(0, origins.length, ...nextOrigins);
-  const unmatched = matched.reduce((count, entry) => count + (entry === undefined ? 1 : 0), 0);
+  const unmatched = live.length - (persistedRange?.length ?? 0);
   if (unmatched > 0) logInfo("runtime", { event: "merge-live-entries", live: live.length, unmatched });
   return out;
 }
@@ -103,57 +106,54 @@ function migrateLiveRefs(state: CompressionState, liveId: string, stableId: stri
   }
 }
 
-function matchUniqueLongestRun<T>(candidates: T[], live: AgentMessage[], matches: (candidate: T, message: AgentMessage) => boolean): Array<T | undefined> {
-  const result: Array<T | undefined> = Array<T | undefined>(live.length).fill(undefined);
-  let next: Uint32Array = new Uint32Array(live.length + 1);
-  let current: Uint32Array = new Uint32Array(live.length + 1);
-  let matchedCandidateStart = -1;
-  let matchedLiveStart = -1;
-  let matchedLength = 0;
-  let ambiguous = false;
-  for (let candidateIndex = candidates.length - 1; candidateIndex >= 0; candidateIndex--) {
-    current.fill(0);
-    for (let liveIndex = live.length - 1; liveIndex >= 0; liveIndex--) {
-      if (!matches(candidates[candidateIndex]!, live[liveIndex]!)) continue;
-      const runLength = 1 + next[liveIndex + 1]!;
-      current[liveIndex] = runLength;
-      if (runLength > matchedLength) {
-        matchedCandidateStart = candidateIndex;
-        matchedLiveStart = liveIndex;
-        matchedLength = runLength;
-        ambiguous = false;
-      } else if (runLength === matchedLength) {
-        ambiguous = true;
-      }
-    }
-    const previous = next;
-    next = current;
-    current = previous;
+type MatchKey = string | symbol;
+
+const NO_PERSISTED_MATCH = Symbol("no-persisted-match");
+
+function normalizePersistedMatchKeys(
+  persisted: readonly SessionMessageEntry[],
+  persistedIdentities: readonly string[],
+  live: readonly AgentMessage[],
+  liveIdentities: readonly string[],
+): MatchKey[] {
+  const persistedByStructure = new Map<string, number>();
+  for (let index = 0; index < persisted.length; index++) {
+    const key = toolResultStructureKey(persisted[index]!.message);
+    if (key === undefined) continue;
+    persistedByStructure.set(key, persistedByStructure.has(key) ? -1 : index);
   }
-  if (matchedCandidateStart < 0 || ambiguous) return result;
-  for (let index = 0; index < matchedLength; index++) {
-    result[matchedLiveStart + index] = candidates[matchedCandidateStart + index];
-  }
-  return result;
+  return live.map((message, liveIndex) => {
+    const key = toolResultStructureKey(message);
+    const candidateIndex = key === undefined ? undefined : persistedByStructure.get(key);
+    if (candidateIndex === undefined) return liveIdentities[liveIndex]!;
+    if (candidateIndex < 0) return NO_PERSISTED_MATCH;
+    return sameToolResult(persisted[candidateIndex]!.message, message)
+      ? persistedIdentities[candidateIndex]!
+      : liveIdentities[liveIndex]!;
+  });
 }
 
-function sameMessage(a: AgentMessage, b: AgentMessage): boolean {
-  try {
-    if (messageIdentity(a) === messageIdentity(b)) return true;
-    const ra = (a as { role?: string }).role;
-    const rb = (b as { role?: string }).role;
-    if (ra !== rb || ra !== "toolResult") return false;
-    const ca = (a as { content?: unknown }).content;
-    const cb = (b as { content?: unknown }).content;
-    return sameNonTextBlocks(ca, cb) && matchesStoredText(extractText(ca), extractText(cb));
-  } catch (e) {
-    logWarn("runtime", { event: "message-compare-failed", error: e instanceof Error ? e.message : String(e) });
-    return a === b;
-  }
+function toolResultStructureKey(message: AgentMessage): string | undefined {
+  if (message.role !== "toolResult") return undefined;
+  return `${message.toolName}\0${message.toolCallId}`;
+}
+
+function valueInRange<T>(values: readonly T[], range: MatchRange | undefined, liveIndex: number): T | undefined {
+  if (!range || liveIndex < range.liveStart || liveIndex >= range.liveStart + range.length) return undefined;
+  return values[range.candidateStart + liveIndex - range.liveStart];
+}
+
+function sameToolResult(stored: AgentMessage, visible: AgentMessage): boolean {
+  if (stored.role !== "toolResult" || visible.role !== "toolResult") return false;
+  return sameNonTextBlocks(stored.content, visible.content)
+    && matchesStoredText(extractText(stored.content), extractText(visible.content));
 }
 
 function sameNonTextBlocks(a: unknown, b: unknown): boolean {
-  const nonText = (blocks: unknown[]): unknown[] => blocks.filter((block) => (block as { type?: string }).type !== "text");
+  const nonText = (blocks: unknown[]): unknown[] => blocks.filter((block) => {
+    if (!block || typeof block !== "object" || !("type" in block)) return true;
+    return block.type !== "text";
+  });
   try {
     const na = Array.isArray(a) ? nonText(a) : [];
     const nb = Array.isArray(b) ? nonText(b) : [];

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -47,8 +47,8 @@ export interface AcpRuntime {
 
 function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: CompressionState, origins: LiveRefOrigin[]): SessionEntry[] {
   const persisted = entries.filter((e): e is SessionMessageEntry => e.type === "message");
-  const matched = matchPersistedSuffix(persisted, live);
-  const prior = matchOrigins(origins, live);
+  const matched = matchSuffixRun(persisted, live, (entry, message) => sameMessage(entry.message, message));
+  const prior = matchSuffixRun(origins, live, (origin, message) => origin.identity === messageIdentity(message));
   const out: SessionEntry[] = [];
   const nextOrigins: LiveRefOrigin[] = [];
   const usedIds = new Set<string>();
@@ -68,21 +68,11 @@ function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: 
     nextOrigins.push({ rawId: id, identity: messageIdentity(msg) });
   }
   origins.splice(0, origins.length, ...nextOrigins);
-  const unmatched = live.length - matched.length;
+  const unmatched = matched.reduce((count, entry) => count + (entry === undefined ? 1 : 0), 0);
   if (unmatched > 0) logInfo("runtime", { event: "merge-live-entries", live: live.length, unmatched });
   return out;
 }
 
-function matchOrigins(origins: LiveRefOrigin[], live: AgentMessage[]): Array<LiveRefOrigin | undefined> {
-  for (let start = 0; start < origins.length; start++) {
-    const count = origins.length - start;
-    if (count > live.length) continue;
-    if (origins.slice(start).every((origin, index) => origin.identity === messageIdentity(live[index]!))) {
-      return [...origins.slice(start), ...Array<undefined>(live.length - count)];
-    }
-  }
-  return Array<undefined>(live.length);
-}
 
 function nextLiveId(state: CompressionState, used: Set<string>, index: number): string {
   let id = `live-${index}`;
@@ -113,14 +103,33 @@ function migrateLiveRefs(state: CompressionState, liveId: string, stableId: stri
   }
 }
 
-function matchPersistedSuffix(persisted: SessionMessageEntry[], live: AgentMessage[]): SessionMessageEntry[] {
-  for (let start = 0; start < persisted.length; start++) {
-    const count = persisted.length - start;
-    if (count > live.length) continue;
-    const suffix = persisted.slice(start);
-    if (suffix.every((entry, index) => sameMessage(entry.message, live[index]!))) return suffix;
+function matchSuffixRun<T>(candidates: T[], live: AgentMessage[], matches: (candidate: T, message: AgentMessage) => boolean): Array<T | undefined> {
+  const result: Array<T | undefined> = Array<T | undefined>(live.length).fill(undefined);
+  let next: Uint32Array = new Uint32Array(live.length + 1);
+  let current: Uint32Array = new Uint32Array(live.length + 1);
+  let matchedCandidateStart = -1;
+  let matchedLiveStart = -1;
+  for (let candidateIndex = candidates.length - 1; candidateIndex >= 0; candidateIndex--) {
+    current.fill(0);
+    const suffixLength = candidates.length - candidateIndex;
+    for (let liveIndex = live.length - 1; liveIndex >= 0; liveIndex--) {
+      if (!matches(candidates[candidateIndex]!, live[liveIndex]!)) continue;
+      const runLength = 1 + next[liveIndex + 1]!;
+      current[liveIndex] = runLength;
+      if (runLength >= suffixLength) {
+        matchedCandidateStart = candidateIndex;
+        matchedLiveStart = liveIndex;
+      }
+    }
+    const previous = next;
+    next = current;
+    current = previous;
   }
-  return [];
+  if (matchedCandidateStart < 0) return result;
+  for (let index = 0; index < candidates.length - matchedCandidateStart; index++) {
+    result[matchedLiveStart + index] = candidates[matchedCandidateStart + index];
+  }
+  return result;
 }
 
 function sameMessage(a: AgentMessage, b: AgentMessage): boolean {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -47,8 +47,8 @@ export interface AcpRuntime {
 
 function mergeLiveEntries(entries: SessionEntry[], live: AgentMessage[], state: CompressionState, origins: LiveRefOrigin[]): SessionEntry[] {
   const persisted = entries.filter((e): e is SessionMessageEntry => e.type === "message");
-  const matched = matchSuffixRun(persisted, live, (entry, message) => sameMessage(entry.message, message));
-  const prior = matchSuffixRun(origins, live, (origin, message) => origin.identity === messageIdentity(message));
+  const matched = matchUniqueLongestRun(persisted, live, (entry, message) => sameMessage(entry.message, message));
+  const prior = matchUniqueLongestRun(origins, live, (origin, message) => origin.identity === messageIdentity(message));
   const out: SessionEntry[] = [];
   const nextOrigins: LiveRefOrigin[] = [];
   const usedIds = new Set<string>();
@@ -103,30 +103,35 @@ function migrateLiveRefs(state: CompressionState, liveId: string, stableId: stri
   }
 }
 
-function matchSuffixRun<T>(candidates: T[], live: AgentMessage[], matches: (candidate: T, message: AgentMessage) => boolean): Array<T | undefined> {
+function matchUniqueLongestRun<T>(candidates: T[], live: AgentMessage[], matches: (candidate: T, message: AgentMessage) => boolean): Array<T | undefined> {
   const result: Array<T | undefined> = Array<T | undefined>(live.length).fill(undefined);
   let next: Uint32Array = new Uint32Array(live.length + 1);
   let current: Uint32Array = new Uint32Array(live.length + 1);
   let matchedCandidateStart = -1;
   let matchedLiveStart = -1;
+  let matchedLength = 0;
+  let ambiguous = false;
   for (let candidateIndex = candidates.length - 1; candidateIndex >= 0; candidateIndex--) {
     current.fill(0);
-    const suffixLength = candidates.length - candidateIndex;
     for (let liveIndex = live.length - 1; liveIndex >= 0; liveIndex--) {
       if (!matches(candidates[candidateIndex]!, live[liveIndex]!)) continue;
       const runLength = 1 + next[liveIndex + 1]!;
       current[liveIndex] = runLength;
-      if (runLength >= suffixLength) {
+      if (runLength > matchedLength) {
         matchedCandidateStart = candidateIndex;
         matchedLiveStart = liveIndex;
+        matchedLength = runLength;
+        ambiguous = false;
+      } else if (runLength === matchedLength) {
+        ambiguous = true;
       }
     }
     const previous = next;
     next = current;
     current = previous;
   }
-  if (matchedCandidateStart < 0) return result;
-  for (let index = 0; index < candidates.length - matchedCandidateStart; index++) {
+  if (matchedCandidateStart < 0 || ambiguous) return result;
+  for (let index = 0; index < matchedLength; index++) {
     result[matchedLiveStart + index] = candidates[matchedCandidateStart + index];
   }
   return result;

--- a/src/sequence-match.ts
+++ b/src/sequence-match.ts
@@ -1,0 +1,105 @@
+export interface MatchRange {
+  candidateStart: number;
+  liveStart: number;
+  length: number;
+}
+
+export function findUniqueLongestRun<Key>(candidates: readonly Key[], live: readonly Key[]): MatchRange | undefined {
+  if (candidates.length === 0 || live.length === 0) return undefined;
+
+  const ids = new Map<Key, number>();
+  const intern = (key: Key): number => {
+    const existing = ids.get(key);
+    if (existing !== undefined) return existing;
+    const id = ids.size + 1;
+    ids.set(key, id);
+    return id;
+  };
+  const candidateIds = candidates.map(intern);
+  const liveIds = live.map(intern);
+  const separator = ids.size + 1;
+  const sequence = [...candidateIds, separator, ...liveIds];
+  const suffixArray = buildSuffixArray(sequence);
+  const lcp = buildLcp(sequence, suffixArray);
+  const candidateLength = candidates.length;
+  const liveOffset = candidateLength + 1;
+  const sourceOf = (suffix: number): 0 | 1 | undefined => {
+    if (suffix < candidateLength) return 0;
+    if (suffix >= liveOffset) return 1;
+    return undefined;
+  };
+
+  let bestLength = 0;
+  for (let index = 1; index < suffixArray.length; index++) {
+    const leftSource = sourceOf(suffixArray[index - 1]!);
+    const rightSource = sourceOf(suffixArray[index]!);
+    if (leftSource === undefined || rightSource === undefined || leftSource === rightSource) continue;
+    bestLength = Math.max(bestLength, lcp[index]!);
+  }
+  if (bestLength === 0) return undefined;
+
+  let pairCount = 0;
+  let uniqueCandidateStart = -1;
+  let uniqueLiveStart = -1;
+  for (let start = 0; start < suffixArray.length;) {
+    let end = start;
+    while (end + 1 < suffixArray.length && lcp[end + 1]! >= bestLength) end++;
+    if (end > start) {
+      const candidateStarts: number[] = [];
+      const liveStarts: number[] = [];
+      for (let index = start; index <= end; index++) {
+        const suffix = suffixArray[index]!;
+        const source = sourceOf(suffix);
+        if (source === 0) candidateStarts.push(suffix);
+        else if (source === 1) liveStarts.push(suffix - liveOffset);
+      }
+      const groupPairs = candidateStarts.length * liveStarts.length;
+      pairCount += groupPairs;
+      if (groupPairs === 1) {
+        uniqueCandidateStart = candidateStarts[0]!;
+        uniqueLiveStart = liveStarts[0]!;
+      }
+      if (pairCount > 1) return undefined;
+    }
+    start = end + 1;
+  }
+
+  return pairCount === 1
+    ? { candidateStart: uniqueCandidateStart, liveStart: uniqueLiveStart, length: bestLength }
+    : undefined;
+}
+
+function buildSuffixArray(sequence: readonly number[]): number[] {
+  const suffixArray = sequence.map((_, index) => index);
+  let ranks = [...sequence];
+  for (let width = 1; width < sequence.length; width *= 2) {
+    suffixArray.sort((left, right) => ranks[left]! - ranks[right]! || (ranks[left + width] ?? -1) - (ranks[right + width] ?? -1));
+    const nextRanks = Array<number>(sequence.length);
+    nextRanks[suffixArray[0]!] = 0;
+    for (let index = 1; index < suffixArray.length; index++) {
+      const previous = suffixArray[index - 1]!;
+      const current = suffixArray[index]!;
+      const differs = ranks[previous] !== ranks[current] || (ranks[previous + width] ?? -1) !== (ranks[current + width] ?? -1);
+      nextRanks[current] = nextRanks[previous]! + (differs ? 1 : 0);
+    }
+    ranks = nextRanks;
+    if (ranks[suffixArray.at(-1)!] === sequence.length - 1) break;
+  }
+  return suffixArray;
+}
+
+function buildLcp(sequence: readonly number[], suffixArray: readonly number[]): number[] {
+  const positions = Array<number>(sequence.length);
+  for (let index = 0; index < suffixArray.length; index++) positions[suffixArray[index]!] = index;
+  const lcp = Array<number>(sequence.length).fill(0);
+  let length = 0;
+  for (let start = 0; start < sequence.length; start++) {
+    const position = positions[start]!;
+    if (position === 0) continue;
+    const previous = suffixArray[position - 1]!;
+    while (start + length < sequence.length && previous + length < sequence.length && sequence[start + length] === sequence[previous + length]) length++;
+    lcp[position] = length;
+    if (length > 0) length--;
+  }
+  return lcp;
+}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -238,6 +238,24 @@ test("omp rejects a non-contiguous persisted subsequence", async () => {
   assert.equal(saved.messageRefs.byRaw["live-0"], firstRef);
 });
 
+test("omp rejects ambiguous equal-length persisted runs", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/nonexistent-pai-acp-ambiguous-run.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const persisted = [userMsg("e1", "same"), userMsg("gap", "different"), userMsg("e2", "same")];
+  const ctx = fakeCtx(persisted, stateFile);
+  const result = await handlers.get("context")![0]!({
+    type: "context",
+    messages: [{ role: "user", content: "same", timestamp: 1 }],
+  }, ctx);
+  const liveRef = result.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.messageRefs.byRaw.e1, undefined);
+  assert.equal(saved.messageRefs.byRaw.e2, undefined);
+  assert.equal(saved.messageRefs.byRaw["live-0"], liveRef);
+});
+
 test("omp migrates a live ref after the provider context evicts its prefix", async () => {
   const { api, handlers } = captureApi();
   createAcpExtension({ modelContextLimit: 200_000 })(api);
@@ -632,6 +650,59 @@ test("omp keeps compression blocks active when provider context has an extra pre
   const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
   assert.equal(saved.blocks[0].active, true, "the compressed block must remain active after the prefix");
   assert.ok(next.messages.length < texts.length + 1, "covered messages must be replaced in provider context");
+});
+
+test("omp keeps compression active when persisted and provider tails diverge", async (t) => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as unknown as ExtensionAPI);
+  const dir = await mkdtemp(join(tmpdir(), "pai-acp-omp-branch-divergence-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const stateFile = join(dir, "session.json");
+  const commonTexts = [
+    "This first common message is large enough to compress. ".repeat(130),
+    "This second common message is also part of the compressed range. ".repeat(130),
+    ...["three", "four", "five", "six", "seven"].map((n) => `common filler ${n} `.repeat(400)),
+  ];
+  let persisted = commonTexts.map((text, index) => userMsg(`e${index + 1}`, text));
+  const ctx = {
+    ...fakeCtx(persisted, stateFile),
+    sessionManager: {
+      getBranch: () => persisted,
+      getSessionId: () => "test-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+  const liveCommon = commonTexts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() }));
+  const initial = await handlers.get("context")![0]!({ type: "context", messages: liveCommon }, ctx);
+  const first = initial.messages[0] as { content: Array<{ type?: string; text?: string }> };
+  const targetRef = first.content.find((block) => block.type === "text")!.text!.match(/m\d{5}/)![0];
+  const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
+  const compressed = await compressTool.execute(
+    "tc-omp-branch-divergence",
+    { content: [{ startId: targetRef, endId: "m00002", summary: "The first two common messages were compressed into a durable ACP summary." }] },
+    undefined,
+    undefined,
+    ctx,
+  );
+  assert.match(compressed.content[0].text, /1 block/);
+
+  const activeUserText = "current user on the active branch";
+  persisted = [...persisted, userMsg("e-active-user", activeUserText)];
+  const divergent = await handlers.get("context")![0]!(
+    {
+      type: "context",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "projected provider-only prefix" }], timestamp: Date.now() },
+        ...liveCommon,
+        { role: "assistant", content: [{ type: "text", text: "abandoned branch assistant tail" }], timestamp: Date.now() },
+        { role: "user", content: [{ type: "text", text: activeUserText }], timestamp: Date.now() },
+      ],
+    },
+    ctx,
+  );
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.blocks[0].active, true, "the compressed block must remain active across divergent branch tails");
+  assert.ok(divergent.messages.length < commonTexts.length + 3, "covered common messages must stay pruned");
 });
 
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -583,6 +583,57 @@ test("empty live context preserves refs created for an unpersisted message", asy
   const state = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
   assert.equal(state.messageRefs.byRaw["live-0"], "m00001");
 });
+test("omp keeps compression blocks active when provider context has an extra prefix", async (t) => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as unknown as ExtensionAPI);
+  const dir = await mkdtemp(join(tmpdir(), "pai-acp-omp-provider-prefix-"));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const stateFile = join(dir, "session.json");
+  const texts = [
+    "This first message is large enough to compress. ".repeat(130),
+    "This second message is also part of the compressed range. ".repeat(130),
+    ...["three", "four", "five", "six", "seven"].map((n) => `filler ${n} `.repeat(400)),
+  ];
+  const persisted = texts.map((text, index) => userMsg(`e${index + 1}`, text));
+  const ctx = {
+    ...fakeCtx(persisted, stateFile),
+    sessionManager: {
+      getBranch: () => persisted,
+      getSessionId: () => "test-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+  const initial = await handlers.get("context")![0]!(
+    { type: "context", messages: texts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() })) },
+    ctx,
+  );
+  const first = initial.messages[0] as { content: Array<{ type?: string; text?: string }> };
+  const targetRef = first.content.find((block) => block.type === "text")!.text!.match(/m\d{5}/)![0];
+  const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
+  const compressed = await compressTool.execute(
+    "tc-omp-provider-prefix",
+    { content: [{ startId: targetRef, endId: "m00002", summary: "The first two messages were compressed into a durable ACP summary." }] },
+    undefined,
+    undefined,
+    ctx,
+  );
+  assert.match(compressed.content[0].text, /1 block/);
+
+  const next = await handlers.get("context")![0]!(
+    {
+      type: "context",
+      messages: [
+        { role: "user", content: [{ type: "text", text: "provider-only context prefix" }], timestamp: Date.now() },
+        ...texts.map((text) => ({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() })),
+      ],
+    },
+    ctx,
+  );
+  const saved = JSON.parse(await readFile(`${stateFile}.acp.json`, "utf8"));
+  assert.equal(saved.blocks[0].active, true, "the compressed block must remain active after the prefix");
+  assert.ok(next.messages.length < texts.length + 1, "covered messages must be replaced in provider context");
+});
+
 
 test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the system prompt", () => {
   const { api, handlers } = captureApi();

--- a/tests/sequence-match.test.ts
+++ b/tests/sequence-match.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findUniqueLongestRun } from "../src/sequence-match.js";
+
+test("finds an exact unique full run", () => {
+  assert.deepEqual(findUniqueLongestRun(["A", "B", "C"], ["A", "B", "C"]), {
+    candidateStart: 0,
+    liveStart: 0,
+    length: 3,
+  });
+});
+
+test("finds a unique run between unrelated prefix and tail", () => {
+  assert.deepEqual(findUniqueLongestRun(["A", "B", "C", "D"], ["X", "A", "B", "C", "Y"]), {
+    candidateStart: 0,
+    liveStart: 1,
+    length: 3,
+  });
+});
+
+test("rejects non-contiguous and tied maximal runs", () => {
+  assert.equal(findUniqueLongestRun(["A", "X", "B"], ["A", "B"]), undefined);
+  assert.equal(findUniqueLongestRun(["A", "B", "X", "C", "D"], ["A", "B", "Y", "C", "D"]), undefined);
+});
+
+test("distinguishes repeated tokens from repeated maximal alignments", () => {
+  assert.deepEqual(findUniqueLongestRun(["A", "A", "A"], ["A", "A", "A"]), {
+    candidateStart: 0,
+    liveStart: 0,
+    length: 3,
+  });
+  assert.equal(findUniqueLongestRun(["A", "A", "A"], ["A", "A"]), undefined);
+  assert.deepEqual(findUniqueLongestRun(["A", "B", "C", "A", "C", "B"], ["A", "B", "C"]), {
+    candidateStart: 0,
+    liveStart: 0,
+    length: 3,
+  });
+});
+
+test("handles periodic unique and ambiguous runs", () => {
+  assert.deepEqual(findUniqueLongestRun(["A", "B", "C", "A", "B", "C"], ["B", "C", "A", "B", "C"]), {
+    candidateStart: 1,
+    liveStart: 0,
+    length: 5,
+  });
+  assert.equal(findUniqueLongestRun(["A", "B", "C", "A", "B", "C"], ["A", "B", "C"]), undefined);
+});
+
+test("matches the brute-force contract for small sequences", () => {
+  const alphabet = ["A", "B", "C"];
+  for (let candidateLength = 0; candidateLength <= 4; candidateLength++) {
+    for (const candidates of sequences(alphabet, candidateLength)) {
+      for (let liveLength = 0; liveLength <= 4; liveLength++) {
+        for (const live of sequences(alphabet, liveLength)) {
+          assert.deepEqual(findUniqueLongestRun(candidates, live), bruteForceMatch(candidates, live), `${candidates.join("")} / ${live.join("")}`);
+        }
+      }
+    }
+  }
+});
+
+function sequences<T>(alphabet: readonly T[], length: number): T[][] {
+  if (length === 0) return [[]];
+  return sequences(alphabet, length - 1).flatMap((prefix) => alphabet.map((value) => [...prefix, value]));
+}
+
+function bruteForceMatch<T>(candidates: readonly T[], live: readonly T[]) {
+  let bestLength = 0;
+  let candidateStart = -1;
+  let liveStart = -1;
+  let count = 0;
+  for (let candidateIndex = 0; candidateIndex < candidates.length; candidateIndex++) {
+    for (let liveIndex = 0; liveIndex < live.length; liveIndex++) {
+      let length = 0;
+      while (candidateIndex + length < candidates.length && liveIndex + length < live.length && candidates[candidateIndex + length] === live[liveIndex + length]) length++;
+      if (length > bestLength) {
+        bestLength = length;
+        candidateStart = candidateIndex;
+        liveStart = liveIndex;
+        count = 1;
+      } else if (length === bestLength && length > 0) {
+        count++;
+      }
+    }
+  }
+  return bestLength > 0 && count === 1 ? { candidateStart, liveStart, length: bestLength } : undefined;
+}


### PR DESCRIPTION
## Why

OMP's persisted session branch and the provider's live context are not always identical.

The live context may contain a provider-only prefix, an unpersisted current message, or a stale branch tail after `/tree`, checkpoint, or rewind navigation. The previous suffix-only matching logic failed in these cases and reassigned stable message IDs to `live-*` IDs. Existing compression blocks then became inactive, causing compressed messages to re-enter the model context.

This fixes the OMP compression failure reported in #129.

## What

- Match persisted and live messages through their unique longest contiguous run.
- Preserve stable message references across provider-only prefixes and divergent branch tails.
- Reject non-contiguous and ambiguous equal-length matches instead of guessing.
- Preserve emergency-truncated tool-result matching while rejecting ambiguous tool identities.
- Replace the quadratic dynamic-programming matcher with a suffix-array/LCP implementation.
- Precompute message identities once per context hook.

## Performance

Measured through the OMP context hook:

| Messages | Before | After |
| ---: | ---: | ---: |
| 250 | 64 ms | 15 ms |
| 500 | 195 ms | 12 ms |
| 1000 | 786 ms | 17 ms |
| 1500 | 1687 ms | 23 ms |

The 1500-message case improves from 1687 ms to 23 ms.

A repeated tool-result identity case also improves from 719 ms to 11 ms at 500 messages.

## Validation

- [x] TypeScript typecheck
- [x] Sequence matcher tests: 6/6
- [x] OMP integration tests: 29/29
- [x] Full test suite: 264/264
- [x] Exhaustive matcher oracle: 14,641 cases, 0 mismatches
- [x] Random matcher oracle: 100,000 cases, 0 mismatches
- [x] Real stale-branch session replay: 4/4 compression blocks active
- [x] Production build and installed-bundle import smoke test
- [x] Independent Standards and Spec review; no open blockers

## Scope

This only changes the OMP `getBranch()` plus live-context merge path. Native Pi's `buildContextEntries()` path, ACP state format, `LiveRefOrigin`, and `acp-kernel` are unchanged.

Fixes #129