### PR TITLE
release v0.1.37

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.36",
+	"version": "0.1.37",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.36",
+			"version": "0.1.37",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.22",
+				"acp-kernel": "0.0.23",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.22",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.22.tgz",
-			"integrity": "sha512-c/FYZ31VbJ14eAHuhN1nQpKR+AuFQgNATyfPrU5I0Cn3LUgRLWRsFR1zh7VDgXullscJvaSb5oGc7hL+79F7TA==",
+			"version": "0.0.23",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
+			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.36",
+	"version": "0.1.37",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.22",
+		"acp-kernel": "0.0.23",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Release v0.1.37.

## Changes since v0.1.36

Includes all PRs merged since v0.1.36 (PR #131):

| PR | Description |
|----|-------------|
| #128 | **feat(prompts): customizable prompts via acp.json (Layer 2)** — overridable `Prompts` interface, `prompts` + `acknowledgePromptsRisk` config keys, byte-identical defaults |
| #133 | fix: block decompress falls back to full session tree after tree navigation |
| #138 | fix(omp): preserve compression refs across branch switches + provider prefixes; perf: reduce context matching complexity |
| #132 | ci(windows): cross-platform test matrix + Windows in e2e |
| #134 | ci(windows): spawn npm.cmd via shell on Windows |
| #130 | fix: delegate entry in embedded hosts |

## Dependency bump

- **acp-kernel 0.0.22 → 0.0.23** (PR acp-kernel#68: keep reasoning paired with its assistant message across compression)

## Verification

- typecheck ✅
- 275 tests pass ✅
- build ✅ (dist/index.js, acp-kernel 0.0.23 bundled inline)

---

Two fields bumped in `package.json`:
- `billion-context-pi` 0.1.36 → 0.1.37
- `acp-kernel` 0.0.22 → 0.0.23