### PR TITLE
fix(decompress): harden toFile against symlink path-escape

### DIFF
--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -5,7 +5,8 @@ import { debug, logError, logInfo, logThrow } from "./log.js";
 import { parseBlockIdArg, collectBlockContent, type CompressionBlock } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
-import { resolve, relative, isAbsolute, join } from "node:path";
+import { existsSync, realpathSync } from "node:fs";
+import { resolve, relative, isAbsolute, join, basename, dirname } from "node:path";
 import { tmpdir, homedir } from "node:os";
 
 /** Directory for auto-generated decompress output files. */
@@ -69,14 +70,33 @@ function resolveToFilePath(targetPath: string): string | { error: string } {
     ? join(homedir(), targetPath.slice(2))
     : targetPath;
   const resolved = resolve(expanded);
-  const isAllowed = ALLOWED_DIRS.some((dir) => {
-    const rel = relative(dir, resolved);
+  // Resolve symlinks in the longest existing ancestor before the containment
+  // check — a symlinked dir inside an allowed root must not escape it.
+  let probe = resolved;
+  const suffix: string[] = [];
+  while (!existsSync(probe) && probe !== dirname(probe)) {
+    suffix.unshift(basename(probe));
+    probe = dirname(probe);
+  }
+  const real = existsSync(probe) ? realpathSync(probe) : probe;
+  const checked = join(real, ...suffix);
+  // Compare against realpath'd roots too: tmpdir() often sits behind a
+  // symlink (/var -> /private/var on macOS) and the string forms diverge.
+  const allowed = ALLOWED_DIRS.map((d) => {
+    try {
+      return realpathSync(d);
+    } catch {
+      return d; // root does not exist yet — keep the literal form
+    }
+  });
+  const isAllowed = allowed.some((dir) => {
+    const rel = relative(dir, checked);
     return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
   });
   if (!isAllowed) {
     return { error: `Error: toFile path must be under ${tmpdir()}, ~/.cache/opencode, or ~/.cache/pi. Got: ${targetPath}` };
   }
-  return resolved;
+  return checked;
 }
 
 /** Generate a unique auto file path for a block. Uses a timestamp so repeated
@@ -181,7 +201,7 @@ async function handleMessageRef(
 
 async function handleDecompress(args: DecompressArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
   const { state, coreMessages } = await runtime.stateFor(ctx);
-  const arg = args.blockId.trim();
+  const arg = (args.blockId ?? "").trim();
 
   // Resolve what `arg` refers to. Check message-ref FIRST (data-driven: a ref
   // exists in some block's effectiveMessageIds). This must precede block-id

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -5,7 +5,7 @@ import { debug, logError, logInfo, logThrow } from "./log.js";
 import { parseBlockIdArg, collectBlockContent, type CompressionBlock } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, readlinkSync, realpathSync } from "node:fs";
 import { resolve, relative, isAbsolute, join, basename, dirname } from "node:path";
 import { tmpdir, homedir } from "node:os";
 
@@ -79,7 +79,22 @@ function resolveToFilePath(targetPath: string): string | { error: string } {
     probe = dirname(probe);
   }
   const real = existsSync(probe) ? realpathSync(probe) : probe;
-  const checked = join(real, ...suffix);
+  // Re-resolve any dangling symlinks among the suffix components. existsSync
+  // follows links, so a symlink whose target does not (yet) exist is treated
+  // as non-existent and skipped by the walk above — but writing through it
+  // would land at the (possibly outside) target. Resolve via lstat/readlink.
+  let checked = real;
+  for (const part of suffix) {
+    checked = join(checked, part);
+    try {
+      if (lstatSync(checked).isSymbolicLink()) {
+        const target = readlinkSync(checked);
+        checked = isAbsolute(target) ? resolve(target) : resolve(dirname(checked), target);
+      }
+    } catch {
+      // not statable or not a symlink — keep the literal component
+    }
+  }
   // Compare against realpath'd roots too: tmpdir() often sits behind a
   // symlink (/var -> /private/var on macOS) and the string forms diverge.
   const allowed = ALLOWED_DIRS.map((d) => {

--- a/tests/decompress-tool.test.ts
+++ b/tests/decompress-tool.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { rm, readFile, mkdtemp, symlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
 import { createAcpExtension } from "../src/index.js";
 
@@ -145,6 +145,18 @@ test("decompress toFile rejects paths that escape an allowed root via a symlink"
   const res = await decompressTool.execute("tc-sym", { blockId: "b1", toFile: target }, undefined, undefined, ctx);
   const text = (res.content[0] as any).text as string;
   assert.match(text, /must be under/i, "rejects path escaping an allowed root through a symlink");
+});
+
+test("decompress toFile rejects a dangling symlink whose target escapes the allowed roots", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const jail = await mkdtemp(join(tmpdir(), "pai-acp-jail-dangling-"));
+  const link = join(jail, "dangling-link");
+  const escapedTarget = join(homedir(), `acp-dangling-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await symlink(escapedTarget, link);
+  const target = join(link, "out.txt");
+  const res = await decompressTool.execute("tc-sym2", { blockId: "b1", toFile: target }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+  assert.match(text, /must be under/i, "rejects a dangling symlink that would write outside allowed roots");
 });
 
 test("decompress keeps the block active after a file-mode call", async () => {

--- a/tests/decompress-tool.test.ts
+++ b/tests/decompress-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { rm, readFile, mkdtemp } from "node:fs/promises";
+import { rm, readFile, mkdtemp, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createAcpExtension } from "../src/index.js";
@@ -130,6 +130,21 @@ test("decompress toFile rejects paths outside allowed roots", async () => {
   const res = await decompressTool.execute("tc5", { blockId: "b1", toFile: "/etc/passwd" }, undefined, undefined, ctx);
   const text = (res.content[0] as any).text as string;
   assert.match(text, /must be under/i, "rejects arbitrary filesystem path");
+});
+
+test("decompress toFile rejects paths that escape an allowed root via a symlink", async () => {
+  const { decompressTool, ctx } = await setupWithCompressedBlock();
+  const jail = await mkdtemp(join(tmpdir(), "pai-acp-jail-"));
+  // A symlink inside the (allowed) jail that points OUTSIDE all allowed roots.
+  // /etc exists on both Linux and macOS, so realpath can follow the link.
+  // The literal path looks contained (jail/evil-link/x.txt under tmpdir), but
+  // resolving the symlink reveals it lands in /etc — must be rejected.
+  const link = join(jail, "evil-link");
+  await symlink("/etc", link);
+  const target = join(link, "passwd.txt");
+  const res = await decompressTool.execute("tc-sym", { blockId: "b1", toFile: target }, undefined, undefined, ctx);
+  const text = (res.content[0] as any).text as string;
+  assert.match(text, /must be under/i, "rejects path escaping an allowed root through a symlink");
 });
 
 test("decompress keeps the block active after a file-mode call", async () => {


### PR DESCRIPTION
## What

`resolveToFilePath` checked path containment against the **literal** resolved path. A symlink inside an allowed root (e.g. `/tmp`) that points **outside** the allowed roots could pass the check and let `decompress --toFile` write to an arbitrary filesystem location.

## Fix

- Resolve symlinks in the **longest existing ancestor** of the target before the containment check, so a symlinked component that escapes is resolved to its real target.
- Compare against **realpath'd roots** too — `tmpdir()` itself often sits behind a symlink (`/var -> /private/var` on macOS), so the string forms would otherwise diverge and reject legitimate writes.
- Null-guard `args.blockId` before `trim()` for robustness.

## Test

New regression test `decompress toFile rejects paths that escape an allowed root via a symlink`: creates a symlink inside an allowed jail pointing at `/etc`, asserts the write is rejected. Fails on the old code (literal-path check), passes with the fix.

```
✔ decompress toFile rejects paths that escape an allowed root via a symlink
```

## Validation

- typecheck ✓
- full suite: **276 pass / 0 fail** ✓
- build ✓

## Scope

Minimal, isolated, no cross-repo dependency. Extracted from #119 (thanks @21307369 for the original implementation). This is the high-priority security item from the #119 review split — the rest of #119 (the `/compact` pipeline, clean-output, i18n) is being split into separate PRs.