### PR TITLE
feat(guardrails): clean noisy bash output (dedupe + denoise)

### DIFF
--- a/src/clean-output.ts
+++ b/src/clean-output.ts
@@ -1,0 +1,124 @@
+import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
+
+/**
+ * Tool-output cleaning — dedupe + noise reduction for bash results.
+ *
+ * Pure functions, zero deps (kept separate from the guardrail wiring so the
+ * logic can be tested in isolation and, if ever needed, lifted into its own
+ * extension without dragging the ACP runtime along).
+ *
+ * Safety rules (validated against real outputs, see session notes):
+ *  - Only lines that are NOT indented and NOT code-anchored are deduped.
+ *    Indented lines are code/structure — never touched. This makes the
+ *    dedupe immune to source-code reads (real-world error rate ~0).
+ *  - A line is code-anchored when it starts with `{});` or ends with `{};`.
+ *    npm-style warnings (`... (preinstall: ...)`) end with `)` and survive.
+ *  - Repetition is counted globally (≥2), not only consecutive — npm's
+ *    allow-scripts block repeats in alternating order, which a uniq-style
+ *    consecutive check would miss entirely.
+ *  - \r residues (progress-bar frames) are cut back to the last frame.
+ *  - Runs of ≥2 blank lines collapse to one.
+ */
+
+type ContentPart = ToolResultEvent["content"][number];
+
+/** Split on \n, preserve trailing newline flag separately. */
+function splitLines(text: string): { lines: string[]; trailingNewline: boolean } {
+  if (text === "") return { lines: [], trailingNewline: false };
+  const trailingNewline = text.endsWith("\n");
+  const lines = text.split("\n");
+  if (trailingNewline && lines[lines.length - 1] === "") lines.pop();
+  return { lines, trailingNewline };
+}
+
+/** True when the line is code-shaped: indented, or a syntax anchor. */
+function isCodeLine(line: string): boolean {
+  if (line.length === 0) return true;
+  if (/^[ \t]/.test(line)) return true;
+  if (/^[{});]/.test(line)) return true;
+  if (/[{};]$/.test(line)) return true;
+  return false;
+}
+
+/** Cut \r frames back to the final visible state of the line. */
+function stripCarriageReturns(line: string): string {
+  const idx = line.lastIndexOf("\r");
+  return idx >= 0 ? line.slice(idx + 1) : line;
+}
+
+/**
+ * Dedupe repeated non-code lines across the whole output.
+ * First occurrence survives (tagged `(×N)`), later occurrences are dropped.
+ * Order of remaining lines is preserved.
+ */
+function dedupeLines(lines: string[]): string[] {
+  const seen = new Map<string, number>();
+  const outIdx = new Map<string, number>();
+  const out: string[] = [];
+
+  for (const raw of lines) {
+    const line = stripCarriageReturns(raw);
+    if (line.trim() === "" || isCodeLine(line)) {
+      out.push(line);
+      continue;
+    }
+
+    const n = (seen.get(line) ?? 0) + 1;
+    seen.set(line, n);
+
+    if (n === 1) {
+      out.push(line);
+      outIdx.set(line, out.length - 1);
+    } else {
+      const idx = outIdx.get(line)!;
+      out[idx] = `${line} (×${n})`;
+    }
+  }
+
+  return out;
+}
+
+/** Collapse runs of ≥2 blank lines into a single blank line. */
+function collapseBlankRuns(lines: string[]): string[] {
+  const out: string[] = [];
+  let prevBlank = false;
+  for (const line of lines) {
+    const blank = line.trim() === "";
+    if (blank && prevBlank) continue;
+    out.push(line);
+    prevBlank = blank;
+  }
+  return out;
+}
+
+export function cleanToolText(text: string): string {
+  if (!text) return text;
+  const { lines, trailingNewline } = splitLines(text);
+  if (lines.length === 0) return text;
+
+  const deduped = dedupeLines(lines);
+  const collapsed = collapseBlankRuns(deduped);
+  const joined = collapsed.join("\n");
+
+  return trailingNewline ? joined + "\n" : joined;
+}
+
+export function cleanToolContent(content: ContentPart[]): ContentPart[] | undefined {
+  let changed = false;
+  const out: ContentPart[] = [];
+  for (const c of content) {
+    if (c.type !== "text") {
+      out.push(c);
+      continue;
+    }
+    const raw = (c as { text: string }).text;
+    const cleaned = cleanToolText(raw);
+    if (cleaned !== raw) {
+      changed = true;
+      out.push({ ...c, text: cleaned } as ContentPart);
+    } else {
+      out.push(c);
+    }
+  }
+  return changed ? out : undefined;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,10 @@ export interface AdapterConfig {
    *  head-truncated with a notice telling the model how to see the full output
    *  (bash: read BashToolDetails.fullOutputPath). */
   toolOutputMaxBytes?: number;
+  /** 工具输出清洗（去重 + 去噪），仅作用于 bash 工具结果。默认 true。
+   *  规则保守：只折叠无缩进、非代码锚的重复行（日志/警告模板），
+   *  代码类输出（缩进行、`{};` 锚行）完全豁免。设为 false 关闭。 */
+  toolOutputClean?: boolean;
   /** Delegate sub-agent config. Accepts a boolean shorthand (`true` →
    *  `{ enabled: true }`, `false` → `{ enabled: false }`) or a DelegateConfig
    *  object. Default: enabled. */
@@ -89,6 +93,7 @@ export interface AdapterConfig {
 
 export const DEFAULT_TOOL_BASH_TIMEOUT = 60;
 export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000;
+export const DEFAULT_TOOL_OUTPUT_CLEAN = true;
 
 /** Resolve delegate config from the adapter, handling the boolean shorthand
  *  and the legacy flat `displayUsage` alias. */

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -3,7 +3,8 @@ import {
   type ExtensionAPI,
   type ToolResultEvent,
 } from "@earendil-works/pi-coding-agent";
-import { DEFAULT_TOOL_BASH_TIMEOUT, DEFAULT_TOOL_OUTPUT_MAX_BYTES } from "./config.js";
+import { DEFAULT_TOOL_BASH_TIMEOUT, DEFAULT_TOOL_OUTPUT_MAX_BYTES, DEFAULT_TOOL_OUTPUT_CLEAN } from "./config.js";
+import { cleanToolContent } from "./clean-output.js";
 import { debug, logInfo, logWarn } from "./log.js";
 import type { AcpRuntime } from "./runtime.js";
 
@@ -133,6 +134,15 @@ export function wireToolGuardrails(pi: ExtensionAPI, runtime: AcpRuntime): void 
         modified = next;
         debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
         logWarn("guardrail", { event: "output-cap", max, hadPath: !!fullPath });
+      }
+    }
+
+    const clean = runtime.adapter.toolOutputClean ?? DEFAULT_TOOL_OUTPUT_CLEAN;
+    if (clean && isBash && !event.isError) {
+      const cleaned = cleanToolContent(modified ?? event.content);
+      if (cleaned) {
+        modified = cleaned;
+        debug.event("guardrail-output-clean", {});
       }
     }
 

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -15,6 +15,7 @@ export interface UserAcpConfig {
   modelContextLimit?: number;
   toolBashDefaultTimeout?: number;
   toolOutputMaxBytes?: number;
+  toolOutputClean?: boolean;
   delegate?: boolean | DelegateConfig;
   compress?: CompressConfig;
   displayUsage?: "merged" | "separate";
@@ -52,7 +53,7 @@ function join(... parts: string[]): string {
 
 const KNOWN = new Set([
   "debug", "autoUpdate", "modelContextLimit",
-  "toolBashDefaultTimeout", "toolOutputMaxBytes",
+  "toolBashDefaultTimeout", "toolOutputMaxBytes", "toolOutputClean",
   "delegate", "compress", "displayUsage",
   "prompts", "acknowledgePromptsRisk",
 ]);

--- a/tests/clean-output.test.ts
+++ b/tests/clean-output.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { cleanToolText, cleanToolContent } from "../src/clean-output.js";
+
+test("dedupes globally repeated non-code lines (npm allow-scripts alternating block)", () => {
+  const input = [
+    "npm warn allow-scripts   @google/genai@1.52.0 (preinstall: echo 'preinstall: no-op')",
+    "npm warn allow-scripts   protobufjs@7.6.5 (postinstall: node scripts/postinstall)",
+    "npm warn allow-scripts   @google/genai@1.52.0 (preinstall: echo 'preinstall: no-op')",
+    "npm warn allow-scripts   protobufjs@7.6.5 (postinstall: node scripts/postinstall)",
+  ].join("\n");
+  const out = cleanToolText(input);
+  assert.equal(
+    out,
+    [
+      "npm warn allow-scripts   @google/genai@1.52.0 (preinstall: echo 'preinstall: no-op') (×2)",
+      "npm warn allow-scripts   protobufjs@7.6.5 (postinstall: node scripts/postinstall) (×2)",
+    ].join("\n"),
+  );
+});
+
+test("dedupes three+ consecutive identical lines into one tagged line", () => {
+  const out = cleanToolText("=== checkpoint ===\n=== checkpoint ===\n=== checkpoint ===\n=== checkpoint ===\n");
+  assert.equal(out, "=== checkpoint === (×4)\n");
+});
+
+test("never touches indented lines (source code reads are immune)", () => {
+  const input = [
+    "function a() {",
+    "  return 1;",
+    "  return 1;",
+    "  return 1;",
+    "}",
+    "function b() {",
+    "  return 1;",
+    "}",
+  ].join("\n");
+  const out = cleanToolText(input);
+  assert.equal(out, input, "indented code lines must pass through untouched");
+});
+
+test("never touches code-anchor lines (closing braces, statements)", () => {
+  const input = "}\n}\n}\nimport x from \"y\";\n";
+  assert.equal(cleanToolText(input), "}\n}\n}\nimport x from \"y\";\n");
+});
+
+test("dedupes top-level non-code lines even when separated by code-shaped lines", () => {
+  const input = [
+    "Processing file A",
+    "  const x = 1;",
+    "Processing file A",
+    "Processing file A",
+  ].join("\n");
+  const out = cleanToolText(input);
+  assert.equal(out, "Processing file A (×3)\n  const x = 1;");
+});
+
+test("collapses \r progress-bar frames to the final frame", () => {
+  const input = "Downloading 10%\rDownloading 50%\rDownloading 100%\nDone";
+  const out = cleanToolText(input);
+  assert.equal(out, "Downloading 100%\nDone");
+});
+
+test("collapses runs of ≥2 blank lines into one", () => {
+  const input = "a\n\n\n\nb";
+  assert.equal(cleanToolText(input), "a\n\nb");
+});
+
+test("handles empty and single-line input unchanged", () => {
+  assert.equal(cleanToolText(""), "");
+  assert.equal(cleanToolText("just one line"), "just one line");
+});
+
+test("keeps order of remaining lines", () => {
+  const input = "first\nsecond\nfirst\nthird\nsecond\n";
+  const out = cleanToolText(input);
+  assert.equal(out, "first (×2)\nsecond (×2)\nthird\n");
+});
+
+test("cleanToolContent returns undefined when nothing changed", () => {
+  const content = [{ type: "text", text: "unique line\nindented  x\n}" }];
+  assert.equal(cleanToolContent(content), undefined);
+});
+
+test("cleanToolContent rewrites text parts and preserves non-text parts", () => {
+  const content = [
+    { type: "image", source: { media_type: "image/png", data: "AAAA" } },
+    { type: "text", text: "same\nsame\nother" },
+  ];
+  const out = cleanToolContent(content);
+  assert.ok(out, "should return cleaned content");
+  assert.equal(out![0].type, "image", "image part survives");
+  assert.equal((out![1] as { text: string }).text, "same (×2)\nother");
+});


### PR DESCRIPTION
## What

bash tool results frequently carry repeated template lines (npm `allow-scripts` warnings repeat in *alternating order*, which a consecutive `uniq` would miss) and `\r` progress-bar frames. This adds a conservative output cleaner.

## Behavior

Runs on the `tool_result` guardrail, **bash + success only**, gated by `toolOutputClean` (default `true`, settable via `acp.json`):

- **Global dedupe** of repeated non-code lines (≥2): first occurrence survives tagged `(×N)`, later dropped. Global — not consecutive — so npm's alternating repeats collapse correctly.
- **Never touches code**: indented lines and code-anchor lines (start `{});` or end `{};`) are exempt. Source-code reads pass through untouched (real-world error rate ~0).
- Cut `\r` progress frames back to the final frame.
- Collapse runs of ≥2 blank lines to one.

## Files

- `src/clean-output.ts` — pure functions, zero deps (unit-tested in isolation)
- `src/tool-guardrails.ts` — wired after cap, before timeout notice
- `src/config.ts` — `toolOutputClean?: boolean` + `DEFAULT_TOOL_OUTPUT_CLEAN = true`
- `src/user-config.ts` — whitelisted for `acp.json` (gap in original #119: field existed but wasn't settable)
- `tests/clean-output.test.ts` — 11 tests

## Validation

typecheck ✓ / **286 tests pass** (11 new) ✓ / build ✓

## Scope

Minimal, isolated, no cross-repo dependency. `capToolOutput` is **not** touched (its reorder refactor from #119 is a separate concern, kept out of this PR). Extracted from #119 (thanks @21307369).