### PR TITLE
feat(compact): route /compact through the ACP compression pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.36",
 			"license": "MIT",
 			"devDependencies": {
+				"@earendil-works/pi-ai": "^0.83.0",
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
 				"acp-kernel": "0.0.22",
@@ -23,6 +24,529 @@
 				"@earendil-works/pi-coding-agent": "*",
 				"typebox": "*"
 			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.977.7",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+			"integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@aws-sdk/xml-builder": "^3.972.38",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.31.1",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+			"integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.70",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+			"integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+			"integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+			"integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-login": "^3.972.75",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.75",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+			"integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.79",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+			"integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.68",
+				"@aws-sdk/credential-provider-http": "^3.972.70",
+				"@aws-sdk/credential-provider-ini": "^3.973.13",
+				"@aws-sdk/credential-provider-process": "^3.972.68",
+				"@aws-sdk/credential-provider-sso": "^3.973.12",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.74",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.68",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+			"integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+			"integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/token-providers": "3.1108.0",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1108.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+			"integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.74",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+			"integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/nested-clients": "^3.997.42",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.32",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
+			"integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
+			"integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.50",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
+			"integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+			"integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.7",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.44",
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+			"integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+			"integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.3",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.3",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+			"integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
+			"integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.38",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+			"integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai": {
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+			"integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.6",
+				"@opentelemetry/api": "1.9.0",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.7"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+			"integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
 			"version": "0.83.0",
@@ -2425,6 +2949,31 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2463,6 +3012,113 @@
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+			"integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.62.3",
@@ -2814,6 +3470,134 @@
 				"win32"
 			]
 		},
+		"node_modules/@smithy/core": {
+			"version": "3.32.0",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+			"integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+			"integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+			"integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+			"integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.32.0",
+				"@smithy/types": "^4.17.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+			"integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2830,6 +3614,13 @@
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@typescript/typescript-aix-ppc64": {
 			"version": "7.0.2",
@@ -3194,12 +3985,67 @@
 				"node": ">=20"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/bundle-require": {
 			"version": "5.1.0",
@@ -3270,6 +4116,16 @@
 				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3286,6 +4142,16 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/esbuild": {
@@ -3330,6 +4196,13 @@
 				"@esbuild/win32-x64": "0.27.7"
 			}
 		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3348,6 +4221,30 @@
 				}
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
 		"node_modules/fix-dts-default-cjs-exports": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -3358,6 +4255,19 @@
 				"magic-string": "^0.30.17",
 				"mlly": "^1.7.4",
 				"rollup": "^4.34.8"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fsevents": {
@@ -3375,6 +4285,92 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/gaxios": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+			"integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/joycon": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3383,6 +4379,53 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -3414,6 +4457,13 @@
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
+		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -3457,6 +4507,46 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3466,6 +4556,49 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -3559,6 +4692,30 @@
 				}
 			}
 		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3581,6 +4738,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/rollup": {
@@ -3627,6 +4794,27 @@
 				"@rollup/rollup-win32-x64-msvc": "4.62.3",
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/source-map": {
 			"version": "0.7.6",
@@ -3718,12 +4906,26 @@
 				"tree-kill": "cli.js"
 			}
 		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
 			"integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
 			"dev": true,
 			"license": "Apache-2.0"
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/tsup": {
 			"version": "8.5.1",
@@ -4336,6 +5538,58 @@
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
+		"@earendil-works/pi-ai": "^0.83.0",
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
 		"acp-kernel": "0.0.22",

--- a/src/auto-compress.ts
+++ b/src/auto-compress.ts
@@ -1,0 +1,202 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { complete } from "@earendil-works/pi-ai/compat";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import type { CoreMessage, CompressionState, CompressibleRange, Prompts } from "acp-kernel";
+import { debug, logInfo, logWarn } from "./log.js";
+
+const TIMEOUT_MS = 60_000;
+const MAX_OUTPUT_TOKENS = 3000;
+const MAX_SLICE_CHARS = 150_000;
+const MAX_MSG_CHARS = 4000;
+
+/** Reads `compressModel` from `~/.<CONFIG_DIR_NAME>/acp.json as `provider:modelId`. */
+export function readCompressModel(): string | null {
+  try {
+    const cfg = JSON.parse(readFileSync(join(homedir(), CONFIG_DIR_NAME, "acp.json"), "utf8")) as Record<string, unknown>;
+    return typeof cfg.compressModel === "string" && cfg.compressModel.length > 0 ? cfg.compressModel : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCompressModel<T extends { provider: string; id: string }>(
+  registry: { find(provider: string, modelId: string): T | undefined },
+  currentModel: T | undefined,
+  configured: string | null,
+): { model: T; label: string } | null {
+  if (configured) {
+    const sep = configured.indexOf(":");
+    const provider = sep > 0 ? configured.slice(0, sep) : "openai";
+    const modelId = sep > 0 ? configured.slice(sep + 1) : configured;
+    const model = registry.find(provider, modelId);
+    return model ? { model, label: configured } : null;
+  }
+  return currentModel ? { model: currentModel, label: `${currentModel.provider}:${currentModel.id}` } : null;
+}
+
+function refNum(ref: string): number {
+  const m = /^m(\d+)$/.exec(ref);
+  return m ? parseInt(m[1]!, 10) : -1;
+}
+
+export function sliceRange(messages: CoreMessage[], state: CompressionState, startRef: string, endRef: string): CoreMessage[] {
+  const lo = refNum(startRef);
+  const hi = refNum(endRef);
+  return messages.filter((m) => {
+    const ref = state.messageRefs.byRaw[m.id];
+    if (!ref) return false;
+    const n = refNum(ref);
+    return n >= lo && n <= hi;
+  });
+}
+
+/** Pick the compressible span to compress. The kernel's recommended ranges are
+ *  small groups (split at user boundaries and protected gaps) that routinely
+ *  fall below `minCompressRange`, which the kernel would reject. Seed on the
+ *  largest range and expand to adjacent ranges (smallest gap first) until the
+ *  span covers enough text — counting every message in the span, matching the
+ *  kernel's own validation. Returns null when even the whole compressible set
+ *  is below the threshold. */
+export function selectRangeSpan(
+  ranges: CompressibleRange[],
+  messages: CoreMessage[],
+  state: CompressionState,
+  minChars: number,
+): { startRef: string; endRef: string; tokens: number } | null {
+  const sorted = [...ranges].sort((a, b) => refNum(a.startRef) - refNum(b.startRef));
+  if (sorted.length === 0) return null;
+  let seed = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i]!.tokens > sorted[seed]!.tokens) seed = i;
+  }
+  const charsOf = (startRef: string, endRef: string): number =>
+    sliceRange(messages, state, startRef, endRef).reduce((n, m) => n + (m.text?.length ?? 0), 0);
+  let lo = seed;
+  let hi = seed;
+  let startRef = sorted[lo]!.startRef;
+  let endRef = sorted[hi]!.endRef;
+  let chars = charsOf(startRef, endRef);
+  while (chars < minChars && (lo > 0 || hi < sorted.length - 1)) {
+    const leftGap = lo > 0 ? refNum(sorted[lo]!.startRef) - refNum(sorted[lo - 1]!.endRef) : Number.POSITIVE_INFINITY;
+    const rightGap = hi < sorted.length - 1 ? refNum(sorted[hi + 1]!.startRef) - refNum(sorted[hi]!.endRef) : Number.POSITIVE_INFINITY;
+    if (leftGap <= rightGap) lo--;
+    else hi++;
+    startRef = sorted[lo]!.startRef;
+    endRef = sorted[hi]!.endRef;
+    chars = charsOf(startRef, endRef);
+  }
+  if (chars < minChars) return null;
+  return { startRef, endRef, tokens: Math.ceil(chars / 4) };
+}
+
+export function formatSlice(slice: CoreMessage[], state: CompressionState): string {
+  let out = "";
+  let skipped = 0;
+  for (let i = 0; i < slice.length; i++) {
+    const m = slice[i]!;
+    const ref = state.messageRefs.byRaw[m.id] ?? m.id;
+    const role = m.role === "tool" ? "tool result" : m.role;
+    const raw = m.text ?? "";
+    const text = raw.slice(0, MAX_MSG_CHARS);
+    const cut = text.length < raw.length;
+    const line = `[${ref}] ${role}${m.toolName ? ` (${m.toolName})` : ""}: ${text}${cut ? " …[truncated]" : ""}\n`;
+    if (out.length + line.length > MAX_SLICE_CHARS) {
+      skipped = slice.length - i;
+      break;
+    }
+    out += line;
+  }
+  if (skipped > 0) {
+    out += `…[truncated: ${skipped} more message(s) in range not shown — cover them in the summary or split the range]\n`;
+  }
+  return out;
+}
+
+export function parseSummary(text: string): string | null {
+  const cleaned = text.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+  try {
+    const obj = JSON.parse(cleaned) as { summary?: unknown };
+    if (typeof obj.summary === "string" && obj.summary.length > 0) return obj.summary;
+  } catch {
+    // never guess — fall back so the caller lets Pi do its native compaction
+  }
+  return null;
+}
+
+/** Build the summary-generation system prompt FROM the kernel's load-bearing
+ *  compression rules (the same `Prompts` the compress tool and tier-1
+ *  compression use), so /compact honors `acp.json` prompt overrides and stays
+ *  consistent with the rest of the ACP pipeline. `/compact` compresses an old
+ *  contiguous range, so the tier-1 `howToCompressRules` are the right rule
+ *  set (not tier-2/tier-3 distillation rules). */
+export function buildSummaryPrompt(prompts: Prompts): string {
+  return (
+    prompts.compressPhilosophy.trim() +
+    "\n\n" +
+    prompts.howToCompressRules.trim() +
+    "\n\nCompress the message range provided below into ONE dense, self-contained technical summary " +
+    "following the rules above. Output ONLY a JSON object: " +
+    '{"summary": "..."} ' +
+    "where the value is the full summary as a single string."
+  );
+}
+
+/** Generate a summary for a message range using the compression model. Shared
+ *  entry point for the `/compact` handler. Returns null when no model is
+ *  usable, the slice is empty, the model is unauthenticated, or the response
+ *  is unparseable — the caller then returns `undefined` so Pi falls back to
+ *  its native compaction. */
+export async function summarizeRange(
+  ctx: ExtensionContext,
+  messages: CoreMessage[],
+  state: CompressionState,
+  startRef: string,
+  endRef: string,
+  prompts: Prompts,
+): Promise<{ summary: string; model: string } | null> {
+  const configured = readCompressModel();
+  const resolved = resolveCompressModel(ctx.modelRegistry, ctx.model, configured);
+  if (!resolved) return null;
+  const { model, label } = resolved;
+  const slice = sliceRange(messages, state, startRef, endRef);
+  if (slice.length === 0) return null;
+  const tokens = Math.ceil(slice.reduce((n, m) => n + (m.text?.length ?? 0), 0) / 4);
+
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok || !auth.apiKey) {
+    logWarn("summarize-range", { event: "auth-missing", model: label, error: auth.ok ? null : auth.error });
+    return null;
+  }
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
+  try {
+    const userText =
+      `${buildSummaryPrompt(prompts)}\n\n` +
+      `Message range [${startRef}..${endRef}] (${tokens} tokens, ${slice.length} messages). Compress it:\n\n` +
+      formatSlice(slice, state);
+    const response = await complete(
+      model,
+      { messages: [{ role: "user", content: [{ type: "text", text: userText }], timestamp: Date.now() }] },
+      { apiKey: auth.apiKey, headers: auth.headers, env: auth.env, maxTokens: MAX_OUTPUT_TOKENS, signal: ac.signal },
+    );
+    const summary = parseSummary(
+      response.content.filter((c): c is { type: "text"; text: string } => c.type === "text").map((c) => c.text).join("\n"),
+    );
+    if (!summary) {
+      logWarn("summarize-range", { event: "unparseable-summary", model: label, span: `${startRef}..${endRef}` });
+      return null;
+    }
+    logInfo("summarize-range", { event: "summary", span: `${startRef}..${endRef}`, model: label, tokens, summaryLen: summary.length });
+    return { summary, model: label };
+  } catch (e) {
+    logWarn("summarize-range", { event: "failed", model: label, error: String(e) });
+    return null;
+  } finally {
+    clearTimeout(timer);
+    debug.event("summarize-range-done", { span: `${startRef}..${endRef}`, model: label });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages } from "./messages.js";
+import { summarizeRange, selectRangeSpan } from "./auto-compress.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
@@ -32,7 +33,7 @@ declare const CURRENT_VERSION: string;
 export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactory {
   return (pi: ExtensionAPI) => {
     const runtime = createRuntime(adapter);
-    wireCompactionDisable(pi);
+    wireCompactionDisable(pi, runtime);
     wireSessionLifecycle(pi, runtime);
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
@@ -49,10 +50,80 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
 
 export default createAcpExtension();
 
-// ACP owns compression; cancel Pi's built-in auto-compaction entirely (mirrors
-// opencode-acp requiring opencode's compaction.auto = false).
-function wireCompactionDisable(pi: ExtensionAPI): void {
-  pi.on("session_before_compact", () => ({ cancel: true }));
+// ACP owns compression. On `/compact` we intercept Pi's native compaction and
+// instead run the message range through the kernel's compression pipeline:
+// pick a compressible span, summarize it with a model (explicit `compressModel`
+// or the session model), and applyCompression. We then hand the summary back
+// to Pi as the compaction result so Pi stores it. On any failure we return
+// undefined so Pi falls back to its own compaction rather than losing context.
+function wireCompactionDisable(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  pi.on("session_before_compact", async (event, ctx) => {
+    let release: (() => void) | undefined;
+    try {
+      const sid = ctx.sessionManager?.getSessionId?.() ?? "";
+      release = await runtime.acquireLock(sid);
+      const { state, coreMessages } = await runtime.stateFor(ctx);
+      const config = runtime.configFor(ctx);
+      const coveredIds = collectCoveredMessageIds(state);
+      const tokenCount = estimateTokens(coreMessages, coveredIds);
+
+      const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount });
+      await runtime.save(turn.state, ctx);
+
+      const ranges = (turn.nudge?.compressibleRanges ?? []).filter((r) => !r.dangerous);
+      if (ranges.length === 0) return undefined;
+
+      const span = selectRangeSpan(ranges, turn.messages, turn.state, config.compress.minCompressRange ?? 5000);
+      if (!span) return undefined;
+
+      ctx.ui?.notify?.(`ACP: compressing ~${span.tokens} tokens…`, "info");
+      const result = await summarizeRange(ctx, turn.messages, turn.state, span.startRef, span.endRef, runtime.prompts);
+      if (!result) {
+        ctx.ui?.notify?.("ACP: compression fell back to Pi native compaction", "warning");
+        return undefined;
+      }
+      const { summary, model } = result;
+
+      const applied = runtime.core.applyCompression({
+        ranges: [{ startRef: span.startRef, endRef: span.endRef, summary }],
+        messages: turn.messages,
+        state: turn.state,
+        config,
+      });
+      const errors = applied.result.errors ?? [];
+      if (errors.length > 0) {
+        logWarn("compact", { sid, event: "rejected", span: `${span.startRef}..${span.endRef}`, model, errors });
+        return undefined;
+      }
+      await runtime.save(applied.state, ctx);
+
+      logInfo("compact", {
+        sid,
+        event: "acp-compaction",
+        span: `${span.startRef}..${span.endRef}`,
+        tokens: span.tokens,
+        model,
+        blocksCreated: applied.result.blocksCreated,
+        reason: event.reason,
+      });
+      debug.event("compact-acp", { sid, span: `${span.startRef}..${span.endRef}`, tokens: span.tokens, model, reason: event.reason });
+
+      ctx.ui?.notify?.(`ACP: compressed ~${span.tokens} tokens via ${model}`, "info");
+
+      return {
+        compaction: {
+          summary,
+          firstKeptEntryId: event.preparation.firstKeptEntryId,
+          tokensBefore: event.preparation.tokensBefore,
+        },
+      };
+    } catch (e) {
+      logThrow("compact", e, { sid: ctx.sessionManager?.getSessionId?.() ?? "" });
+      return undefined;
+    } finally {
+      release?.();
+    }
+  });
 }
 
 // (acp_delegate injection is best-effort: sendUserMessage is fire-and-forget

--- a/tests/auto-compress.test.ts
+++ b/tests/auto-compress.test.ts
@@ -30,6 +30,19 @@ function makeRange(startRef: string, endRef: string, tokens: number) {
   return { startRef, endRef, tokens, dangerous: false };
 }
 
+function withHome<T>(dir: string, fn: () => T): T {
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+  try {
+    return fn();
+  } finally {
+    process.env.HOME = prevHome;
+    process.env.USERPROFILE = prevProfile;
+  }
+}
+
 test("parseSummary extracts summary from plain JSON object", () => {
   assert.equal(parseSummary('{"summary":"hello world"}'), "hello world");
 });
@@ -82,40 +95,31 @@ test("resolveCompressModel: nothing usable → null", () => {
 
 test("readCompressModel returns null when acp.json absent (graceful)", () => {
   const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
-  const prev = process.env.HOME;
-  process.env.HOME = dir;
   try {
-    assert.equal(readCompressModel(), null);
+    withHome(dir, () => assert.equal(readCompressModel(), null));
   } finally {
-    process.env.HOME = prev;
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
 test("readCompressModel reads provider:modelId from acp.json", () => {
   const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
-  const prev = process.env.HOME;
-  process.env.HOME = dir;
   try {
     mkdirSync(join(dir, CONFIG_DIR_NAME), { recursive: true });
     writeFileSync(join(dir, CONFIG_DIR_NAME, "acp.json"), JSON.stringify({ compressModel: "openai:gpt-4o" }));
-    assert.equal(readCompressModel(), "openai:gpt-4o");
+    withHome(dir, () => assert.equal(readCompressModel(), "openai:gpt-4o"));
   } finally {
-    process.env.HOME = prev;
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
 test("readCompressModel ignores empty / non-string compressModel", () => {
   const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
-  const prev = process.env.HOME;
-  process.env.HOME = dir;
   try {
     mkdirSync(join(dir, CONFIG_DIR_NAME), { recursive: true });
     writeFileSync(join(dir, CONFIG_DIR_NAME, "acp.json"), JSON.stringify({ compressModel: "" }));
-    assert.equal(readCompressModel(), null);
+    withHome(dir, () => assert.equal(readCompressModel(), null));
   } finally {
-    process.env.HOME = prev;
     rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/tests/auto-compress.test.ts
+++ b/tests/auto-compress.test.ts
@@ -1,0 +1,197 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import {
+  readCompressModel,
+  resolveCompressModel,
+  sliceRange,
+  selectRangeSpan,
+  formatSlice,
+  parseSummary,
+  buildSummaryPrompt,
+} from "../src/auto-compress.ts";
+import { defaultPrompts } from "acp-kernel";
+
+type CoreMessageLite = { id: string; role: string; text?: string; toolName?: string };
+type StateLite = { messageRefs: { byRaw: Record<string, string> } };
+
+function makeState(ids: string[]): StateLite {
+  const byRaw: Record<string, string> = {};
+  ids.forEach((id, i) => {
+    byRaw[id] = `m${String(i).padStart(5, "0")}`;
+  });
+  return { messageRefs: { byRaw } };
+}
+
+function makeRange(startRef: string, endRef: string, tokens: number) {
+  return { startRef, endRef, tokens, dangerous: false };
+}
+
+test("parseSummary extracts summary from plain JSON object", () => {
+  assert.equal(parseSummary('{"summary":"hello world"}'), "hello world");
+});
+
+test("parseSummary strips ```json fences", () => {
+  assert.equal(parseSummary('```json\n{"summary":"fenced"}\n```'), "fenced");
+});
+
+test("parseSummary returns null on non-JSON, empty, or missing summary", () => {
+  assert.equal(parseSummary("not json at all"), null);
+  assert.equal(parseSummary('{"summary":""}'), null);
+  assert.equal(parseSummary('{"other":"x"}'), null);
+  assert.equal(parseSummary('{"summary":123}'), null);
+});
+
+test("resolveCompressModel: explicit configured model wins", () => {
+  const registry = { find: (p: string, id: string) => (p === "openai" && id === "gpt-4o" ? { provider: p, id } : undefined) };
+  const current = { provider: "anthropic", id: "claude" };
+  const r = resolveCompressModel(registry as never, current as never, "openai:gpt-4o");
+  assert.equal(r?.model.provider, "openai");
+  assert.equal(r?.model.id, "gpt-4o");
+  assert.equal(r?.label, "openai:gpt-4o");
+});
+
+test("resolveCompressModel: configured missing → null (not fallback) so caller surfaces config error", () => {
+  const registry = { find: () => undefined };
+  const current = { provider: "anthropic", id: "claude" };
+  assert.equal(resolveCompressModel(registry as never, current as never, "openai:nonexistent"), null);
+});
+
+test("resolveCompressModel: no config → current session model", () => {
+  const registry = { find: () => undefined };
+  const current = { provider: "anthropic", id: "claude" };
+  const r = resolveCompressModel(registry as never, current as never, null);
+  assert.equal(r?.model.provider, "anthropic");
+  assert.equal(r?.label, "anthropic:claude");
+});
+
+test("resolveCompressModel: bare model id without provider defaults to openai", () => {
+  const registry = { find: (p: string, id: string) => (p === "openai" ? { provider: p, id } : undefined) };
+  const r = resolveCompressModel(registry as never, undefined, "gpt-4o-mini");
+  assert.equal(r?.model.provider, "openai");
+  assert.equal(r?.model.id, "gpt-4o-mini");
+});
+
+test("resolveCompressModel: nothing usable → null", () => {
+  const registry = { find: () => undefined };
+  assert.equal(resolveCompressModel(registry as never, undefined, null), null);
+});
+
+test("readCompressModel returns null when acp.json absent (graceful)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
+  const prev = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    assert.equal(readCompressModel(), null);
+  } finally {
+    process.env.HOME = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readCompressModel reads provider:modelId from acp.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
+  const prev = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    mkdirSync(join(dir, CONFIG_DIR_NAME), { recursive: true });
+    writeFileSync(join(dir, CONFIG_DIR_NAME, "acp.json"), JSON.stringify({ compressModel: "openai:gpt-4o" }));
+    assert.equal(readCompressModel(), "openai:gpt-4o");
+  } finally {
+    process.env.HOME = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readCompressModel ignores empty / non-string compressModel", () => {
+  const dir = mkdtempSync(join(tmpdir(), "acp-compact-"));
+  const prev = process.env.HOME;
+  process.env.HOME = dir;
+  try {
+    mkdirSync(join(dir, CONFIG_DIR_NAME), { recursive: true });
+    writeFileSync(join(dir, CONFIG_DIR_NAME, "acp.json"), JSON.stringify({ compressModel: "" }));
+    assert.equal(readCompressModel(), null);
+  } finally {
+    process.env.HOME = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("sliceRange filters messages within the ref span (inclusive)", () => {
+  const ids = ["a", "b", "c", "d", "e"];
+  const msgs: CoreMessageLite[] = ids.map((id) => ({ id, role: "user", text: id }));
+  const state = makeState(ids);
+  const slice = sliceRange(msgs as never, state as never, "m00001", "m00003");
+  assert.deepEqual(slice.map((m) => m.id), ["b", "c", "d"]);
+});
+
+test("sliceRange ignores messages without a ref", () => {
+  const msgs: CoreMessageLite[] = [{ id: "a", role: "user", text: "a" }, { id: "nope", role: "user", text: "x" }];
+  const state = makeState(["a"]);
+  const slice = sliceRange(msgs as never, state as never, "m00000", "m00005");
+  assert.deepEqual(slice.map((m) => m.id), ["a"]);
+});
+
+test("selectRangeSpan returns null when the whole set is below minChars", () => {
+  const ids = ["a", "b"];
+  const msgs: CoreMessageLite[] = ids.map((id) => ({ id, role: "user", text: "tiny" }));
+  const state = makeState(ids);
+  const ranges = [makeRange("m00000", "m00001", 5)];
+  assert.equal(selectRangeSpan(ranges, msgs as never, state as never, 5000), null);
+});
+
+test("selectRangeSpan seeds on largest range and expands until chars >= minChars", () => {
+  const ids = Array.from({ length: 8 }, (_, i) => `m${i}`);
+  const msgs: CoreMessageLite[] = ids.map((id, i) => ({ id: `id${i}`, role: "user", text: "x".repeat(2000) }));
+  const state = makeState(ids.map((_, i) => `id${i}`));
+  const ranges = [
+    makeRange("m00000", "m00001", 100),
+    makeRange("m00003", "m00005", 400),
+    makeRange("m00007", "m00007", 50),
+  ];
+  const span = selectRangeSpan(ranges, msgs as never, state as never, 5000);
+  assert.ok(span, "expected a span");
+  assert.equal(span!.startRef, "m00003");
+  assert.ok(span!.endRef === "m00005" || span!.endRef === "m00007", `endRef=${span!.endRef}`);
+  assert.ok(span!.tokens >= 1250, `tokens=${span!.tokens}`);
+});
+
+test("selectRangeSpan handles empty ranges", () => {
+  const span = selectRangeSpan([], [], { messageRefs: { byRaw: {} } } as never, 5000);
+  assert.equal(span, null);
+});
+
+test("formatSlice annotates refs and truncates oversized single messages", () => {
+  const ids = ["a", "b"];
+  const big = "y".repeat(10000);
+  const msgs: CoreMessageLite[] = [{ id: "a", role: "assistant", text: "short" }, { id: "b", role: "tool", text: big, toolName: "bash" }];
+  const state = makeState(ids);
+  const out = formatSlice(msgs as never, state as never);
+  assert.ok(out.includes("[m00000] assistant: short"));
+  assert.ok(out.includes("[m00001] tool result (bash):"));
+  assert.ok(out.includes("…[truncated]"));
+  assert.ok(!out.includes("y".repeat(10000)));
+});
+
+test("buildSummaryPrompt embeds the kernel compressPhilosophy and howToCompressRules", () => {
+  const prompt = buildSummaryPrompt(defaultPrompts);
+  assert.ok(prompt.includes(defaultPrompts.compressPhilosophy), "must include compressPhilosophy");
+  assert.ok(prompt.includes(defaultPrompts.howToCompressRules), "must include howToCompressRules");
+  assert.ok(prompt.includes('{"summary": "..."}'), "must instruct JSON output shape");
+  assert.ok(!prompt.includes("tier 2") && !prompt.includes("TIER 2"), "must NOT pull in tier-2 distillation rules");
+});
+
+test("buildSummaryPrompt reflects acp.json prompt overrides (not a hard-coded constant)", () => {
+  const custom = {
+    compressPhilosophy: "CUSTOM-PHILOSOPHY-MARKER",
+    howToCompressRules: "CUSTOM-RULES-MARKER",
+    tier2DistillRules: defaultPrompts.tier2DistillRules,
+    tier3CondenseRules: defaultPrompts.tier3CondenseRules,
+  };
+  const prompt = buildSummaryPrompt(custom);
+  assert.ok(prompt.includes("CUSTOM-PHILOSOPHY-MARKER"));
+  assert.ok(prompt.includes("CUSTOM-RULES-MARKER"));
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -57,11 +57,12 @@ test("factory registers the compress tool and 4 flat commands", () => {
   assert.ok(handlers.has("before_agent_start"), "system-prompt wired");
 });
 
-test("session_before_compact cancels Pi's auto-compaction", () => {
+test("session_before_compact falls back to Pi native compaction on failure", async () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);
-  const result = handlers.get("session_before_compact")![0]!({}, {});
-  assert.deepEqual(result, { cancel: true });
+  const handler = handlers.get("session_before_compact")![0]!;
+  const result = await handler({ preparation: { firstKeptEntryId: "x", tokensBefore: 100 } }, {} as any);
+  assert.equal(result, undefined, "no usable state → undefined → Pi falls back to native compaction");
 });
 
 test("before_agent_start appends the ACP system prompt", () => {


### PR DESCRIPTION
## What

Intercept Pi's `session_before_compact` and route it through the ACP compression pipeline instead of cancelling native compaction: pick a compressible span, summarize it with a model, `applyCompression`, then hand the summary back to Pi as the compaction result.

## How

1. `processTurn` → get compressible ranges
2. `selectRangeSpan` → pick a span ≥ `minCompressRange` (seeds on largest range, expands by smallest gap)
3. `summarizeRange` → call a model (`compressModel` or session model) with the slice
4. `applyCompression` → create an ACP block
5. return `{ compaction: { summary, firstKeptEntryId, tokensBefore } }` so Pi stores it

**Fallback**: on any failure (no compressible ranges, no usable model, unparseable response, kernel rejection, exception) return `undefined` → Pi falls back to its own compaction. Context is never lost.

## Summary prompt uses the kernel `Prompts` (key design choice)

The summary-generation system prompt is built **from the kernel's load-bearing compression rules** (`compressPhilosophy` + `howToCompressRules`) via the `Prompts` interface — **not** a hand-rolled constant. This means:

- `/compact` honors `acp.json` prompt overrides (the same `Prompts` the compress tool + tier-1 compression use)
- stays consistent with the rest of the ACP pipeline (no drift between `/compact` and the `compress` tool)
- tier-1 `howToCompressRules` are the right rule set (`/compact` compresses an old contiguous range, not a tier-2/3 distillation)

## Config

`compressModel` in `~/.pi/acp.json` as `provider:modelId` (e.g. `"openai:gpt-4o"`). When unset, falls back to the current session model — so `/compact` works with **zero config**.

## Dependency

Adds `@earendil-works/pi-ai` as a devDependency for the `complete()` type (kept `external` at runtime via tsup — resolves inside Pi where pi-ai is installed). `ctx.modelRegistry` is a synchronous facade that deliberately does not expose `complete()`/`stream()`, so the standalone import is the supported path.

## Files

- `src/auto-compress.ts` (new) — range helpers + `summarizeRange` + `buildSummaryPrompt`
- `src/index.ts` — `wireCompactionDisable` interception
- `tests/auto-compress.test.ts` (new) — 19 tests
- `tests/integration.test.ts` — updated compaction-contract test

## Validation

typecheck ✓ / **294 tests pass** (19 new) ✓ / build ✓

## Not included (split into separate PRs)

- `usageTriggerPercent` auto-nudge (dropped — redundant with kernel growth/overLimit triggers)
- `acp_summary_` surfaced as inline `user` message (dropped — redundant with the block; compress tool is the compression)
- `capToolOutput` refactor (separate concern)
- i18n, clean-output, symlink fix → #142 / #141 / #140

Extracted from #119 (thanks @21307369).