### PR TITLE
feat(config): three-level compress cascade (global > provider > model)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -223,6 +223,35 @@ The flow is:
 - **Status:** 🟢 ACTIVE
 - **Description:** The token-growth threshold that controls the cadence of **soft** compression nudges. A soft nudge fires roughly every time this many tokens of new compressible content accumulate. A lower value means the model is nudged to compress more often; a higher value means less frequent nudges. This only governs *growth-driven* nudges — once usage crosses `compress.maxContextLimit`, forced nudges take over regardless of this setting. Maps to the kernel settings `nudge.growthFloor` and `nudge.growthCap`.
 
+### `compress.providers` — per-provider & per-model overrides
+
+- **Type:** object — a map of provider name → `{ ...<compress fields>, models: { modelId → <compress fields> } }`
+- **Default:** *(unset — global `compress.*` applies to all models)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Narrows the global thresholds for a specific Pi **provider** and/or a specific **model**, resolved live each turn from the active model. The three levels cascade **per-field, deepest-wins**: `model > provider > global`. A field left undefined at a deeper level does **not** clear a shallower value — only a field you actually set overrides. Unknown providers/models fall back to the global thresholds.
+
+The provider key is the **Pi provider name** (e.g. `"anthropic"`, `"openai"`, `"zhipu"`) — the same name used in `models.json` and `pi --provider`. The model key is the **model id** (`ctx.model.id`). The adapter sits at Pi's model layer and never sees the upstream URL, so it matches providers by **name**, not by URL prefix like the billion-context proxy does.
+
+```json
+{
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000,
+    "providers": {
+      "anthropic": {
+        "maxContextLimit": "80%",
+        "models": {
+          "claude-sonnet-4-5": { "maxContextLimit": "70%", "nudgeGrowthTokens": 30000 }
+        }
+      }
+    }
+  }
+}
+```
+
+On `anthropic` / `claude-sonnet-4-5` the effective thresholds become `maxContextLimit=70%`, `nudgeGrowthTokens=30000`, and `emergencyThresholdPercent=95%` (inherited from global).
+
 ---
 
 ## Prompts Customization

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -223,6 +223,35 @@
 - **状态：** 🟢 ACTIVE
 - **说明：** 控制**软**压缩 nudge 频率的 token 增长阈值。每当积累约这么多新可压缩内容时，触发一次软 nudge。值越低模型被 nudge 压缩的频率越高；值越低频率越低。此设置只控制*基于增长的* nudge——用量越过 `compress.maxContextLimit` 后，强制 nudge 接管，不受此设置影响。映射到内核设置 `nudge.growthFloor` 和 `nudge.growthCap`。
 
+### `compress.providers` —— 按 provider / 按 model 覆盖
+
+- **类型：** object —— provider 名 → `{ ...<compress 字段>, models: { modelId → <compress 字段> } }` 的映射
+- **默认值：** *(未设置——全局 `compress.*` 对所有模型生效)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 为某个特定的 Pi **provider** 和/或某个特定的 **model** 收窄全局阈值,每轮根据当前模型实时解析。三级**逐字段、深层优先**级联:`model > provider > global`。深层中未设置的字段**不会**清除浅层的值——只有你显式设置的字段才会覆盖。未知的 provider/model 回退到全局阈值。
+
+provider 的 key 是 **Pi provider 名**(如 `"anthropic"`、`"openai"`、`"zhipu"`)——即 `models.json` 和 `pi --provider` 使用的同一个名字。model 的 key 是 **model id**(`ctx.model.id`)。适配器工作在 Pi 的模型层,看不到 upstream URL,因此按**名字**匹配 provider,而不是像 billion-context 代理那样按 URL 前缀匹配。
+
+```json
+{
+  "compress": {
+    "maxContextLimit": "75%",
+    "emergencyThresholdPercent": "95%",
+    "nudgeGrowthTokens": 50000,
+    "providers": {
+      "anthropic": {
+        "maxContextLimit": "80%",
+        "models": {
+          "claude-sonnet-4-5": { "maxContextLimit": "70%", "nudgeGrowthTokens": 30000 }
+        }
+      }
+    }
+  }
+}
+```
+
+在 `anthropic` / `claude-sonnet-4-5` 下,生效阈值变为 `maxContextLimit=70%`、`nudgeGrowthTokens=30000`、`emergencyThresholdPercent=95%`(继承自全局)。
+
 ---
 
 ## 提示词自定义

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,11 @@ export interface DelegateConfig {
   displayUsage?: "merged" | "separate";
 }
 
-/** Compression tuning. All fields accept a ratio (0.75) or percent string
- *  ("75%") where noted. */
-export interface CompressConfig {
+/** Compression tuning fields, shared by all three levels (global, provider,
+ *  model). Percentage fields accept a ratio (0.75) or percent string ("75%").
+ *  Resolution is per-field, deepest-wins (model > provider > global); an
+ *  undefined field at a deeper level does NOT clear a shallower value. */
+export interface CompressSettings {
   /** Context usage percentage that triggers forced compression nudges
    *  (bypasses growth-gate + cadence). Accepts a ratio (0.75) or percent
    *  string ("75%"). Default: 0.75. Maps to kernel nudge.maxContextLimitPct. */
@@ -29,6 +31,25 @@ export interface CompressConfig {
   /** Token growth threshold for soft compression nudges. Default: 50000.
    *  Maps to kernel nudge.growthFloor + nudge.growthCap. */
   nudgeGrowthTokens?: number;
+}
+
+/** Per-provider compression overrides. Carries the same tuning fields as the
+ *  global level, plus an optional per-model map keyed by model id. */
+export interface ProviderCompress extends CompressSettings {
+  /** Per-model overrides within this provider, keyed by model id
+   *  (e.g. "claude-sonnet-4-5"). */
+  models?: Record<string, CompressSettings>;
+}
+
+/** Compression tuning. Top-level fields are global defaults; `providers`
+ *  optionally narrows them per Pi provider name and per model id. The active
+ *  entry is resolved live each turn from the current model
+ *  (`ctx.model.provider` / `ctx.model.id`). */
+export interface CompressConfig extends CompressSettings {
+  /** Per-provider (and per-model) overrides, keyed by Pi provider name
+   *  (e.g. "anthropic", "openai", "zhipu") — the same name used in
+   *  models.json and `pi --provider`. */
+  providers?: Record<string, ProviderCompress>;
 }
 
 /**
@@ -106,7 +127,38 @@ export function resolveDelegate(adapter: AdapterConfig): { enabled: boolean; dis
   };
 }
 
-export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number): Config {
+/** Per-field deepest-wins merge of the three compression levels (global →
+ *  provider → model). An undefined field at a deeper level does NOT clear a
+ *  value set at a shallower level — only a defined value overrides. */
+export function mergeCompress(
+  global?: CompressSettings,
+  provider?: CompressSettings,
+  model?: CompressSettings,
+): CompressSettings {
+  return {
+    maxContextLimit: model?.maxContextLimit ?? provider?.maxContextLimit ?? global?.maxContextLimit,
+    emergencyThresholdPercent: model?.emergencyThresholdPercent ?? provider?.emergencyThresholdPercent ?? global?.emergencyThresholdPercent,
+    nudgeGrowthTokens: model?.nudgeGrowthTokens ?? provider?.nudgeGrowthTokens ?? global?.nudgeGrowthTokens,
+  };
+}
+
+/** Resolve the effective compression settings for the active model: global →
+ *  provider (matched by Pi provider name) → model (matched by model id).
+ *  Returns a CompressSettings whose fields are undefined when nothing is set
+ *  at any level. The Pi adapter keys providers by name (ctx.model.provider),
+ *  not URL — it never sees the upstream URL the way the proxy does. */
+export function resolveCompress(
+  compress: CompressConfig | undefined,
+  provider: string | undefined,
+  modelId: string | undefined,
+): CompressSettings {
+  if (!compress) return {};
+  const prov = provider ? compress.providers?.[provider] : undefined;
+  const model = prov && modelId ? prov.models?.[modelId] : undefined;
+  return mergeCompress(compress, prov, model);
+}
+
+export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number, provider?: string, modelId?: string): Config {
   const envLimit = process.env.ACP_MODEL_CONTEXT_LIMIT;
   const envLimitNum = envLimit ? Number(envLimit) : NaN;
   const FALLBACK_LIMIT = 150_000;
@@ -123,14 +175,14 @@ export function resolveConfig(adapter: AdapterConfig, liveContextLimit: number):
     preserveRecentMessages: adapter.preserveRecentMessages ?? 5,
     ...adapter.coreOverrides,
   });
-  const c = adapter.compress;
-  if (c?.maxContextLimit !== undefined) config.nudge.maxContextLimitPct = parsePercent(c.maxContextLimit);
-  if (c?.emergencyThresholdPercent !== undefined) {
+  const c = resolveCompress(adapter.compress, provider, modelId);
+  if (c.maxContextLimit !== undefined) config.nudge.maxContextLimitPct = parsePercent(c.maxContextLimit);
+  if (c.emergencyThresholdPercent !== undefined) {
     const pct = parsePercent(c.emergencyThresholdPercent);
     config.nudge.emergencyThresholdPct = pct;
     config.truncate.threshold = pct;
   }
-  if (c?.nudgeGrowthTokens !== undefined) {
+  if (c.nudgeGrowthTokens !== undefined) {
     config.nudge.growthFloor = c.nudgeGrowthTokens;
     config.nudge.growthCap = c.nudgeGrowthTokens;
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -207,7 +207,8 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   }
 
   function configFor(ctx: ExtensionContext): Config {
-    return resolveConfig(adapterRef, liveContextLimit(ctx));
+    const m = ctx.model as { provider?: string; id?: string } | undefined;
+    return resolveConfig(adapterRef, liveContextLimit(ctx), m?.provider, m?.id);
   }
 
   async function stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]) {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveConfig, resolveDelegate, type AdapterConfig } from "../src/config.js";
+import { resolveConfig, resolveCompress, mergeCompress, resolveDelegate, type AdapterConfig } from "../src/config.js";
 
 const EMPTY: AdapterConfig = {};
 
@@ -136,4 +136,66 @@ test("resolveDelegate: legacy flat displayUsage still works with undefined deleg
 test("resolveDelegate: object displayUsage takes priority over legacy flat", () => {
   const r = resolveDelegate({ delegate: { displayUsage: "separate" }, displayUsage: "merged" });
   assert.equal(r.displayUsage, "separate");
+});
+
+test("resolveCompress returns {} when no compress configured", () => {
+  assert.deepEqual(resolveCompress(undefined, "anthropic", "claude"), {});
+});
+
+test("resolveCompress falls back to global when provider/model unknown", () => {
+  const c = resolveCompress({ maxContextLimit: "75%" }, "unknown", "unknown");
+  assert.equal(c.maxContextLimit, "75%");
+});
+
+test("resolveCompress provider override wins over global", () => {
+  const compress = { maxContextLimit: "75%", providers: { anthropic: { maxContextLimit: "80%" } } };
+  assert.equal(resolveCompress(compress, "anthropic", undefined).maxContextLimit, "80%");
+  assert.equal(resolveCompress(compress, "openai", undefined).maxContextLimit, "75%");
+});
+
+test("resolveCompress model override wins over provider and global", () => {
+  const compress = {
+    maxContextLimit: "75%",
+    providers: { anthropic: { maxContextLimit: "80%", models: { "claude-sonnet-4": { maxContextLimit: "70%" } } } },
+  };
+  const c = resolveCompress(compress, "anthropic", "claude-sonnet-4");
+  assert.equal(c.maxContextLimit, "70%");
+});
+
+test("resolveCompress merges per-field (global/provider/model each set a different field)", () => {
+  const compress = {
+    maxContextLimit: "75%",
+    emergencyThresholdPercent: "95%",
+    providers: { anthropic: { emergencyThresholdPercent: "90%", models: { "claude-sonnet-4": { nudgeGrowthTokens: 30000 } } } },
+  };
+  const c = resolveCompress(compress, "anthropic", "claude-sonnet-4");
+  assert.equal(c.maxContextLimit, "75%", "global field inherited");
+  assert.equal(c.emergencyThresholdPercent, "90%", "provider field inherited");
+  assert.equal(c.nudgeGrowthTokens, 30000, "model field applied");
+});
+
+test("mergeCompress: undefined deeper field does not clear shallower value", () => {
+  const merged = mergeCompress({ maxContextLimit: "75%", nudgeGrowthTokens: 50000 }, { emergencyThresholdPercent: "90%" }, {});
+  assert.equal(merged.maxContextLimit, "75%");
+  assert.equal(merged.emergencyThresholdPercent, "90%");
+  assert.equal(merged.nudgeGrowthTokens, 50000);
+});
+
+test("resolveConfig applies provider/model cascade to kernel config", () => {
+  const adapter: AdapterConfig = {
+    compress: {
+      maxContextLimit: "75%",
+      providers: { anthropic: { models: { "claude-sonnet-4": { maxContextLimit: "70%", nudgeGrowthTokens: 30000 } } } },
+    },
+  };
+  const cfg = resolveConfig(adapter, 1_000_000, "anthropic", "claude-sonnet-4");
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.7, "model-level maxContextLimit wins");
+  assert.equal(cfg.nudge.growthFloor, 30000);
+  assert.equal(cfg.nudge.growthCap, 30000);
+  assert.equal(cfg.nudge.emergencyThresholdPct, 0.95, "unset field inherits kernel default");
+});
+
+test("resolveConfig without provider/modelId behaves as before (global only)", () => {
+  const cfg = resolveConfig({ compress: { maxContextLimit: "80%" } }, 1_000_000);
+  assert.equal(cfg.nudge.maxContextLimitPct, 0.8);
 });

--- a/tests/e2e-compress-config.test.ts
+++ b/tests/e2e-compress-config.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONFIG_DIR_NAME, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createRuntime } from "../src/runtime.js";
+import { loadUserConfig, applyUserConfig } from "../src/user-config.js";
+
+// E2E for the three-level compress cascade: writes a REAL acp.json and drives
+// the REAL production pipeline (loadUserConfig → applyUserConfig → setAdapter →
+// configFor, the exact functions wired at src/index.ts:71-72,117), as opposed
+// to the resolveCompress unit tests in config.test.ts.
+
+function ctxFor(provider: string | undefined, id: string | undefined, contextWindow: number): ExtensionContext {
+    return { model: { provider, id, contextWindow } } as unknown as ExtensionContext;
+}
+
+const ACP_JSON = {
+    compress: {
+        maxContextLimit: "75%",
+        emergencyThresholdPercent: "92%",
+        nudgeGrowthTokens: 50000,
+        providers: {
+            anthropic: {
+                maxContextLimit: "80%",
+                models: {
+                    "claude-sonnet-4-5": { maxContextLimit: "70%", nudgeGrowthTokens: 30000 },
+                },
+            },
+        },
+    },
+};
+
+async function withConfigDir(json: unknown, fn: (cwd: string) => Promise<void>): Promise<void> {
+    const cwd = await mkdtemp(join(tmpdir(), "pai-acp-e2e-compress-"));
+    if (json !== undefined) {
+        await mkdir(join(cwd, CONFIG_DIR_NAME), { recursive: true });
+        await writeFile(join(cwd, CONFIG_DIR_NAME, "acp.json"), JSON.stringify(json));
+    }
+    try {
+        await fn(cwd);
+    } finally {
+        await rm(cwd, { recursive: true, force: true });
+    }
+}
+
+test("e2e compress config: acp.json provider/model overrides take effect through the real pipeline", async () => {
+    await withConfigDir(ACP_JSON, async (cwd) => {
+        const user = await loadUserConfig(cwd);
+        assert.ok(user.compress, "acp.json compress block loaded from disk");
+
+        const runtime = createRuntime({});
+        runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+
+        const sonnet = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
+        assert.equal(sonnet.nudge.maxContextLimitPct, 0.7, "model-level maxContextLimit 70% reaches the kernel");
+        assert.equal(sonnet.nudge.growthFloor, 30000, "model-level nudgeGrowthTokens reaches the kernel");
+        assert.equal(sonnet.nudge.growthCap, 30000);
+        assert.equal(sonnet.nudge.emergencyThresholdPct, 0.92, "global emergencyThresholdPercent inherited (model omitted it)");
+        assert.equal(sonnet.truncate.threshold, 0.92);
+
+        const haiku = runtime.configFor(ctxFor("anthropic", "claude-haiku", 200_000));
+        assert.equal(haiku.nudge.maxContextLimitPct, 0.8, "provider-level maxContextLimit 80% for an unlisted anthropic model");
+        assert.equal(haiku.nudge.growthFloor, 50000, "global nudgeGrowthTokens inherited at the provider level");
+
+        const openai = runtime.configFor(ctxFor("openai", "gpt-4o", 128_000));
+        assert.equal(openai.nudge.maxContextLimitPct, 0.75, "unknown provider falls back to global 75%");
+        assert.equal(openai.nudge.emergencyThresholdPct, 0.92);
+        assert.equal(openai.modelContextLimit, 128_000, "live model context window passed through");
+    });
+});
+
+test("e2e compress config: a single runtime resolves differently per model (proves per-turn, not static)", async () => {
+    await withConfigDir(ACP_JSON, async (cwd) => {
+        const runtime = createRuntime({});
+        runtime.setAdapter(applyUserConfig(runtime.adapter, await loadUserConfig(cwd)));
+        const sonnet = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
+        const haiku = runtime.configFor(ctxFor("anthropic", "claude-haiku", 200_000));
+        const openai = runtime.configFor(ctxFor("openai", "gpt-4o", 200_000));
+        assert.notEqual(sonnet.nudge.maxContextLimitPct, haiku.nudge.maxContextLimitPct, "sonnet (70%) != haiku (80%)");
+        assert.notEqual(haiku.nudge.maxContextLimitPct, openai.nudge.maxContextLimitPct, "haiku (80%) != openai (75%)");
+    });
+});
+
+test("e2e compress config: without a config file the kernel defaults apply", async () => {
+    const savedHome = process.env.HOME;
+    await withConfigDir(undefined, async (cwd) => {
+        process.env.HOME = cwd;
+        const user = await loadUserConfig(cwd);
+        assert.deepEqual(user, {}, "no acp.json anywhere (HOME + cwd) → empty user config");
+        const runtime = createRuntime({});
+        runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+        const cfg = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
+        assert.equal(cfg.nudge.maxContextLimitPct, 0.75, "kernel default maxContextLimitPct");
+        assert.equal(cfg.nudge.emergencyThresholdPct, 0.95, "kernel default emergencyThresholdPct");
+        assert.equal(cfg.nudge.growthFloor, 50000, "kernel default growthFloor");
+    });
+    process.env.HOME = savedHome;
+});

--- a/tests/e2e-compress-config.test.ts
+++ b/tests/e2e-compress-config.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CONFIG_DIR_NAME, type ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { createInitialState, type CoreMessage } from "acp-kernel";
 import { createRuntime } from "../src/runtime.js";
 import { loadUserConfig, applyUserConfig } from "../src/user-config.js";
 
@@ -95,6 +96,53 @@ test("e2e compress config: without a config file the kernel defaults apply", asy
         assert.equal(cfg.nudge.maxContextLimitPct, 0.75, "kernel default maxContextLimitPct");
         assert.equal(cfg.nudge.emergencyThresholdPct, 0.95, "kernel default emergencyThresholdPct");
         assert.equal(cfg.nudge.growthFloor, 50000, "kernel default growthFloor");
+    });
+    process.env.HOME = savedHome;
+});
+
+// Behavioral: feed the real configFor() output into runtime.core.processTurn()
+// (src/index.ts:142) and assert shouldInject flips with the limit. The nudge
+// needs recommendedRanges > 0, not just a high usage ratio — hence the bulk text.
+function compressibleMessages(): CoreMessage[] {
+    const msgs: CoreMessage[] = [];
+    for (let i = 0; i < 12; i++) {
+        msgs.push({
+            id: `h_${i}`,
+            role: i % 2 === 0 ? "user" : "assistant",
+            contentType: "text",
+            text: `historical detail ${i}. ${"x".repeat(2000)}`,
+        });
+    }
+    return msgs;
+}
+
+test("e2e compress config: a 2w limit fires the compress nudge at 2w tokens; a 100w limit does not", async () => {
+    const savedHome = process.env.HOME;
+    await withConfigDir(ACP_JSON, async (cwd) => {
+        process.env.HOME = cwd;
+        const runtime = createRuntime({});
+        runtime.setAdapter(applyUserConfig(runtime.adapter, await loadUserConfig(cwd)));
+        const tokenCount = 20_000;
+
+        const small = runtime.configFor(ctxFor("openai", "gpt-4o", 20_000));
+        assert.equal(small.modelContextLimit, 20_000, "live 2w window becomes the kernel context limit");
+        const smallTurn = runtime.core.processTurn({
+            messages: compressibleMessages(),
+            state: createInitialState(),
+            config: small,
+            tokenCount,
+        });
+        assert.ok(smallTurn.nudge?.shouldInject, "2w tokens at a 2w limit crosses the threshold → compress nudge fires");
+
+        const large = runtime.configFor(ctxFor("openai", "gpt-4o", 1_000_000));
+        assert.equal(large.modelContextLimit, 1_000_000, "live 100w window becomes the kernel context limit");
+        const largeTurn = runtime.core.processTurn({
+            messages: compressibleMessages(),
+            state: createInitialState(),
+            config: large,
+            tokenCount,
+        });
+        assert.ok(!largeTurn.nudge?.shouldInject, "2w tokens at a 100w limit stays under threshold → no compression");
     });
     process.env.HOME = savedHome;
 });


### PR DESCRIPTION
## 背景

#35:pi 适配器配置目前是单级的;billion-context(代理)支持 `global > provider > model` 三级。本 PR 把同样的三级压缩调优移植到 pi 适配器。

## 改动

镜像 billion-context 的 `compress-settings.ts`:现有的全局 `compress.*` 字段现在还可按 provider / 按 model 覆盖:

```json
"compress": {
  "maxContextLimit": "75%", "emergencyThresholdPercent": "95%", "nudgeGrowthTokens": 50000,
  "providers": {
    "anthropic": {
      "maxContextLimit": "80%",
      "models": { "claude-sonnet-4-5": { "maxContextLimit": "70%", "nudgeGrowthTokens": 30000 } }
    }
  }
}
```

- **解析**:`config.ts` 拆出 `CompressSettings` / `ProviderCompress` / `CompressConfig`,新增 `mergeCompress` + `resolveCompress`;`resolveConfig` 增加可选 `provider` + `modelId`(向后兼容,旧调用不变)。
- **接线**:`runtime.ts` 的 `configFor` 把 `ctx.model.provider` / `.id` 传给 `resolveConfig`。
- **级联**:逐字段、深层优先 `model > provider > global`;深层未设置的字段不清除浅层值。未知 provider/model 回退全局。
- **provider 匹配键**:按 **Pi provider 名**(models.json / `pi --provider` 的名字),**不是 URL**——适配器工作在模型层,看不到 upstream URL(代理按 URL 匹配是因为它在 HTTP 层有 URL)。详见 issue #35 评论与 CONFIGURATION.md。
- **测试**:9 个新测试(config.test.ts 共 29 个,全套 283 通过)。typecheck + build 通过。
- **文档**:CONFIGURATION.md / zh-CN 新增 `compress.providers` 段落。

## 注意

- `user-config.ts` 无需改动(`compress` 整体透传,嵌套结构原样通过)。
- 按规范,PR 合并由人工完成。

Closes #35
