### PR TITLE
fix(/acp): separate session accounting from sent-to-LLM view in the panel

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -97,16 +97,23 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   const nudge = turn.nudge;
   const bd = nudge?.contextBreakdown;
   const limit = config.modelContextLimit;
-  // displayTotal must reflect the REAL context size (what the footer shows),
-  // not just the sum of message-text categories. contextBreakdown only
-  // classifies message text via chars/4 and never sees pi's system prompt
-  // or tool schemas, so summing its fields undercounts. Split the gap into
-  // the real system prompt (measured) and the rest (tool schemas + the
-  // inevitable chars/4-vs-real-tokenizer drift).
+  // Two different token accountings, honestly labeled:
+  //  - Session accounting (pi getContextUsage): the append-only session tree
+  //    INCLUDING compressed originals. It never shrinks — our pruning is a
+  //    per-request transform view the host cannot see. The footer reads this.
+  //  - Sent view: what actually reaches the LLM after compression (kernel's
+  //    chars/4 classification over the pruned projection + measured system
+  //    prompt). This is the number compression controls.
+  // The old panel subtracted one from the other and dumped the difference
+  // into a fake "Framework" bucket — on a well-compressed session (or when
+  // the host cannot anchor on provider usage and falls back to summing the
+  // whole tree) that bucket swallowed the compressed originals and read as
+  // "Framework 90%" — see billion-context-omp issue #16.
   const classified = bd ? bd.system + bd.tool + bd.summaries + bd.code + bd.text : 0;
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-  const framework = bd ? Math.max(0, tokenCount - classified - systemPromptTokens) : 0;
+  const sentTotal = classified + systemPromptTokens;
+  const sessionOnly = Math.max(0, tokenCount - sentTotal);
   const displayTotal = tokenCount;
   const displayPct = limit > 0 ? Math.round((displayTotal / limit) * 100) : 0;
   const activeBlocksList = state.blocks.filter((b) => b.active);
@@ -121,32 +128,34 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   lines.push("╰─────────────────────────────────────────────╯");
   if (versionStr) lines.push(versionStr);
   lines.push("");
-  lines.push(`Context: ${displayPct}% (${fmtTokens(displayTotal)} / ${fmtTokens(limit)})`);
+  lines.push(`Context (session accounting): ${displayPct}% (${fmtTokens(displayTotal)} / ${fmtTokens(limit)})`);
 
   if (nudge && bd) {
     const growth = bd.growth;
     if (growth > 0 && displayTotal > 0) {
       lines.push(`Growth: +${fmtTokens(growth)} since last nudge`);
     }
-    if (displayTotal > 0) {
-      lines.push("");
-      lines.push("Token Breakdown:");
+    lines.push("");
+    lines.push(`Sent to LLM (after compression): ${fmtTokens(sentTotal)}`);
+    if (sessionOnly > 0) {
+      lines.push(`Session-only (compressed originals + host overhead): ${fmtTokens(sessionOnly)} — pruned from every request; the footer counts it`);
+    }
+    lines.push("");
+    lines.push("Token Breakdown (sent view):");
 
-      const categories: Array<{ label: string; value: number }> = [
-        { label: "Tool", value: bd.tool },
-        { label: "SysPrompt", value: systemPromptTokens },
-        { label: "Framework", value: framework },
-        { label: "Text", value: bd.text },
-        { label: "Code", value: bd.code },
-        { label: "Summaries", value: bd.summaries },
-      ];
+    const categories: Array<{ label: string; value: number }> = [
+      { label: "Tool", value: bd.tool },
+      { label: "SysPrompt", value: systemPromptTokens },
+      { label: "Text", value: bd.text },
+      { label: "Code", value: bd.code },
+      { label: "Summaries", value: bd.summaries },
+    ];
 
-      for (const cat of categories) {
-        if (cat.value <= 0) continue;
-        const pct = displayTotal > 0 ? Math.round((cat.value / displayTotal) * 100) : 0;
-        const b = bar(cat.value, displayTotal);
-        lines.push(`  ${cat.label.padEnd(10)} ${b} ${String(pct).padStart(3)}%  ${fmtTokens(cat.value)}`);
-      }
+    for (const cat of categories) {
+      if (cat.value <= 0) continue;
+      const pct = sentTotal > 0 ? Math.round((cat.value / sentTotal) * 100) : 0;
+      const b = bar(cat.value, sentTotal);
+      lines.push(`  ${cat.label.padEnd(10)} ${b} ${String(pct).padStart(3)}%  ${fmtTokens(cat.value)}`);
     }
   }
 

--- a/tests/commands-panel.test.ts
+++ b/tests/commands-panel.test.ts
@@ -1,9 +1,9 @@
-import { test } from "bun:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { AcpRuntime } from "../src/runtime.js";
 import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 
-// tsup defines CURRENT_VERSION at build time; under `bun test` it is bare.
+// tsup defines CURRENT_VERSION at build time; under the node runner it is bare.
 (globalThis as Record<string, unknown>).CURRENT_VERSION ??= "0.0.0-test";
 const { makeCommands } = await import("../src/commands.js");
 

--- a/tests/commands-panel.test.ts
+++ b/tests/commands-panel.test.ts
@@ -1,0 +1,52 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import type { AcpRuntime } from "../src/runtime.js";
+import type { ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+
+// tsup defines CURRENT_VERSION at build time; under `bun test` it is bare.
+(globalThis as Record<string, unknown>).CURRENT_VERSION ??= "0.0.0-test";
+const { makeCommands } = await import("../src/commands.js");
+
+function fakeRuntime(): AcpRuntime {
+  return {
+    configFor: () => ({ modelContextLimit: 1_000_000, nudge: { growthFloorTokens: 20_000, thresholdPct: 0.2 } }),
+    stateFor: async () => ({
+      state: { blocks: [], stats: { tokensCompressed: 0 }, messageRefs: { byRaw: {}, byRef: {} } },
+      coreMessages: [],
+    }),
+    // Stub processTurn: we only exercise the panel's rendering of the
+    // breakdown, not the kernel's classification logic.
+    core: {
+      processTurn: () => ({
+        state: { blocks: [], stats: { tokensCompressed: 0 }, messageRefs: { byRaw: {}, byRef: {} } },
+        nudge: {
+          contextUsage: 0.43,
+          reason: "idle — max compressible 8106 < threshold 50000",
+          contextBreakdown: { tool: 20_000, system: 0, text: 4_000, code: 0, summaries: 0, growth: 6_100 },
+        },
+      }),
+    },
+  } as unknown as AcpRuntime;
+}
+
+test("/acp panel separates session accounting from sent-to-LLM view", async () => {
+  const notified: string[] = [];
+  const ctx = {
+    ui: { notify: (t: string) => notified.push(t) },
+    getContextUsage: () => ({ tokens: 430_000 }),
+    model: { contextWindow: 1_000_000 },
+    sessionManager: { getSessionId: () => "s", getSessionFile: () => "/tmp/s.json" },
+  } as unknown as ExtensionCommandContext;
+
+  const acp = makeCommands(fakeRuntime()).find((c) => c.name === "acp")!;
+  await acp.options.handler!("", ctx);
+
+  const text = notified[0] ?? "";
+  assert.match(text, /Context \(session accounting\): 43% \(430k \/ 1\.0M\)/);
+  assert.match(text, /Sent to LLM \(after compression\): 24k/, text);
+  assert.match(text, /Session-only \(compressed originals \+ host overhead\): 406k/, text);
+  assert.match(text, /Token Breakdown \(sent view\):/, text);
+  assert.doesNotMatch(text, /Framework/, "fake Framework bucket must be gone");
+  const toolLine = text.split("\n").find((l) => l.trim().startsWith("Tool"))!;
+  assert.match(toolLine, / 83%/, `bar percentages must use the sent view: ${toolLine}`);
+});


### PR DESCRIPTION
Backport of billion-context-omp #13 (context: ranxianglei/billion-context-omp#16).

## Problem

The `/acp` panel computed `Framework = hostUsage − Σ(breakdown categories) − systemPrompt`. The breakdown categories classify the **pruned view we send to the LLM**, while `getContextUsage()` is the host's **session-tree accounting** — which includes the originals of everything already compressed (append-only tree, by design). When the host cannot anchor on a real provider usage report (bridge-style providers that don't surface usage), that accounting never decreases, and the subtraction dumps the compressed originals into a fake Framework bucket. Observed in the wild (omp sibling): Framework 92% 397k on a session whose actual sent view was ~24k.

## Change

Honest dual accounting, same shape as the omp fix: session-accounting header (same source as the footer), Sent to LLM line, Session-only line (pruned from every request), breakdown bars/percentages relative to the sent view. Removes the fake Framework bucket. No behavior change: nudge/compression decisions untouched.

## Test

tests/commands-panel.test.ts asserts the labels, the 24k-vs-406k split from a stubbed 430k host usage, that Framework is gone, and sent-view-relative bars. Suite: 154 pass / 17 fail — the 17 pre-exist on master (env-dependent) and are unaffected.