### PR TITLE
fix: recommend only viable compressible ranges (>=200 tokens) on all surfaces

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,6 +2,7 @@ import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent, formatRanges } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
+import { viableRanges } from "./messages.js";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { formatCompactTokens } from "./footer-status.js";
 
@@ -161,7 +162,10 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
     }
   }
 
-  const ranges = nudge?.compressibleRanges ?? [];
+  // Same viability filter as the LLM injection path (index.ts) and the
+  // status tool — tiny fragmented ranges are uncompressable noise the model
+  // never sees, so the panel shouldn't list them either.
+  const ranges = viableRanges(nudge?.compressibleRanges ?? []);
   const protectedRanges = nudge?.protectedRanges ?? [];
   if (ranges.length > 0 || protectedRanges.length > 0) {
     lines.push("");

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
-import { coreOutToAgentMessages } from "./messages.js";
+import { coreOutToAgentMessages, viableRanges } from "./messages.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
@@ -190,6 +190,10 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // reply (streaming/tool loop), and without this gate the same nudge
       // would be appended on every event.
       const emergency = turn.nudge.breakdown?.emergencyOverride === 1;
+      // Recommend only ranges the model can actually compress: a tiny
+      // fragmented range in the list makes batched attempts fail atomically
+      // (kernel validates the whole batch). See viableRanges in messages.ts.
+      turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
       const turnKey = lastUserMessageId(entries) ?? sid;
       const alreadyShown = !emergency && runtime.nudgeShownFor(turnKey);
       if (!alreadyShown) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -102,6 +102,20 @@ function stringifyArgs(args: unknown): string {
   return safeStringify(args);
 }
 
+/** Minimum size for a compressible range to be worth recommending. Ranges
+ *  below this are fragmented leftovers (a 16-token ack, a one-line tool
+ *  result): the model cannot write a meaningful >=50-char summary for them,
+ *  and a batched compress call that includes one gets atomically rejected
+ *  (kernel validates the whole batch). Observed in the wild: a 14-range
+ *  recommendation list containing a 16-token range → every batch attempt
+ *  failed with "Summary too short". Filtering happens on every surface that
+ *  recommends ranges: the injected nudge, acp_status, and the /acp panel. */
+export const VIABLE_RANGE_MIN_TOKENS = 200;
+
+export function viableRanges<T extends { tokens: number }>(ranges: T[]): T[] {
+  return ranges.filter((r) => r.tokens >= VIABLE_RANGE_MIN_TOKENS);
+}
+
 export function extractText(content: unknown): string {
   if (typeof content === "string") return stripRefTag(content);
   if (!Array.isArray(content)) return "";

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -3,6 +3,7 @@ import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendi
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
+import { viableRanges } from "./messages.js";
 import { logThrow } from "./log.js";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { resolveDelegate } from "./config.js";
@@ -75,7 +76,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   if (args.scope) return base;
 
   const nudge = turn.nudge;
-  const ranges = nudge?.compressibleRanges ?? [];
+  const ranges = viableRanges(nudge?.compressibleRanges ?? []);
   const protectedRanges = nudge?.protectedRanges ?? [];
 
   const extra: string[] = [];

--- a/tests/viable-ranges.test.ts
+++ b/tests/viable-ranges.test.ts
@@ -1,4 +1,4 @@
-import { test } from "bun:test";
+import { test } from "node:test";
 import assert from "node:assert/strict";
 import { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "../src/messages.js";
 import { buildStatusReport, createCore, createInitialState } from "acp-kernel";

--- a/tests/viable-ranges.test.ts
+++ b/tests/viable-ranges.test.ts
@@ -1,0 +1,38 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "../src/messages.js";
+import { buildStatusReport, createCore, createInitialState } from "acp-kernel";
+import { resolveConfig } from "../src/config.js";
+
+test("viableRanges drops fragmented ranges below the floor", () => {
+  const ranges = [
+    { startRef: "m00001", endRef: "m00004", tokens: 57 },
+    { startRef: "m00006", endRef: "m00006", tokens: 8 },
+    { startRef: "m00119", endRef: "m00128", tokens: 1_000 },
+    { startRef: "m00200", endRef: "m00201", tokens: 4_700 },
+  ];
+  const kept = viableRanges(ranges);
+  assert.deepEqual(kept.map((r) => r.tokens), [1_000, 4_700]);
+  assert.equal(VIABLE_RANGE_MIN_TOKENS, 200);
+  assert.deepEqual(viableRanges([]), []);
+});
+
+test("acp_status applies the viability filter to compressible ranges", () => {
+  // buildStatusReport renders nudge.compressibleRanges; verify that the
+  // pipeline the status tool uses (filter first) cannot leak tiny ranges.
+  const core = createCore();
+  const config = resolveConfig({}, 200_000);
+  const messages = Array.from({ length: 60 }, (_, i) =>
+    i % 2 === 0
+      ? { role: "user", content: { type: "text", text: `u${i} ${"lorem ".repeat(i % 7)}` } }
+      : { role: "assistant", content: [{ type: "text", text: `a${i} ${"ipsum ".repeat(i % 5)}` }] },
+  );
+  const turn = core.processTurn({ messages, state: createInitialState(), config, tokenCount: 90_000 });
+  const nudge = turn.nudge!;
+  const filtered = viableRanges(nudge.compressibleRanges ?? []);
+  for (const r of filtered) {
+    assert.ok(r.tokens >= VIABLE_RANGE_MIN_TOKENS, `range ${r.startRef}..${r.endRef} = ${r.tokens} tok leaked`);
+  }
+  const report = buildStatusReport(turn.state, messages, () => 1) as string;
+  assert.ok(report.length > 0);
+});


### PR DESCRIPTION
Backport of billion-context-omp PR #7 (same kernel, same failure mode observed in the wild there).

## Problem

The kernel's nudge can recommend fragmented ranges as compressible — e.g. a 16-token one-message ack. A model that follows the recommendation list and batches all ranges into one compress call gets **atomically rejected**: the kernel validates the whole batch, and a tiny range cannot carry a meaningful >=50-char summary ("Summary too short (43 chars, min 50)"). Observed on the omp sibling: a 14-range recommendation containing a 16-token range — every batch attempt failed until the model improvised around the list.

## Change

- `messages.ts`: `VIABLE_RANGE_MIN_TOKENS = 200` + `viableRanges()`
- Applied on every surface that recommends ranges:
  - `index.ts`: the injected nudge's `compressibleRanges` is filtered before rendering (renderNudgeText and the example line see the same list)
  - `status-tool.ts`: acp_status uncompressed view
  - `commands.ts`: the /acp panel

Purely advisory filtering: compress itself is untouched — the model can still compress any range it can argue for; kernel guards (min range, min summary) unchanged.

## Test

`tests/viable-ranges.test.ts` — unit filter behavior + a pipeline test asserting the filtered list can't leak sub-200 ranges. Red-green verified (revert src → export missing → red). Suite: 155 pass / 17 fail — the 17 pre-exist on master (env-dependent), unaffected by this change.