### PR TITLE
release v0.1.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.37",
+	"version": "0.1.38",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.37",
+			"version": "0.1.38",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.23",
+				"acp-kernel": "0.0.24",
 				"billion-context-kit": "0.2.0",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
@@ -3186,9 +3186,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.23",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
-			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
+			"version": "0.0.24",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.24.tgz",
+			"integrity": "sha512-vuNpkTjeTvNprqTRSlFCRuVpqoqdyHY00ejS+lRfdqQYfrOtA2LgfJNF3Aun7ibu2d+llaA6H5WYznpGkJNC/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3213,6 +3213,16 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/billion-context-kit/node_modules/acp-kernel": {
+			"version": "0.0.23",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
+			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/bundle-require": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.37",
+	"version": "0.1.38",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.23",
+		"acp-kernel": "0.0.24",
 		"billion-context-kit": "0.2.0",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",


### PR DESCRIPTION
## Ships since v0.1.37

- **#148**: recommend only viable compressible ranges (≥200 tokens) on all surfaces — prevents the atomic-batch rejection failure mode.
- **#149** (supersedes #147): adopt billion-context-kit 0.2.0 — shared /acp panel with dual-scale accounting (session-tree vs sent-view), topic fallback on block rows, kit-provided viableRanges.
- **#150**: nudge arbitration on the sent-view estimate — stops permanent false EMERGENCY nudges when getContextUsage falls back to session-tree accounting (compressed originals included, never shrinks; the omp issue #18 report was 366K tree vs 180K window = 204% while the real sent view was ~5%). e2e scenario 03 hardened accordingly.
- **acp-kernel 0.0.23 → 0.0.24**: nudge quality batch — pressure-band restore + effective-pending gating (#70), small-range merge to minCompressRange + tier-aware emergency arbitration (#57), tier-stamp rebaseline reset (#71).

278/278 tests (node runner), typecheck clean, build green.

> Note: pi's realUsage stays provider-anchored when providers report usage (≈ sent view, correct); the sent-view estimate only takes over arbitration, and the tree-scale number remains in logs + the panel's footer-scale line.