### PR TITLE
feat: cooperative proxy mode — forward native tools to billion-context proxy (内外呼应)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -124,6 +124,7 @@ All keys below are currently **ACTIVE**.
 | `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit (takes highest precedence). |
 | `ACP_DEBUG` | Set to `1` / `true` to enable debug logging. |
 | `ACP_LOG_FILE` | Override the log file path (default `~/.pi/acp.log`). |
+| `ACP_COOPERATIVE_PROXY` | Set to `0` to disable cooperative proxy mode (auto-detected from a `/bili/` model baseUrl). |
 
 > **Only the documented keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three compression thresholds form a three-tier escalation: growth-driven soft nudges → forced nudges at `compress.maxContextLimit` → emergency truncation at `compress.emergencyThresholdPercent`.
 
@@ -326,3 +327,10 @@ Environment variables take precedence over the JSON config files. They are usefu
 - **Default:** `~/.pi/acp.log`
 - **Status:** 🟢 ACTIVE
 - **Description:** Override the path to the log file. By default, structured logs are written to `~/.pi/acp.log` (the file rotates to `~/.pi/acp.log.old` at 10 MB). Point this at a different location to keep per-project or per-run logs separate.
+
+### `ACP_COOPERATIVE_PROXY`
+
+- **Type:** string flag
+- **Default:** *(unset — cooperative mode auto-detects from the model baseUrl)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Set to `0` to **disable** cooperative proxy mode. When the model's `baseUrl` routes through a billion-context proxy (the `/bili/` zero-config prefix), the extension automatically switches to cooperative mode: the proxy owns compression (state, folding, ref tags, philosophy prompt, nudges — injected at the wire level), while this extension registers the 4 tools natively and forwards their execution to the proxy's `POST /__bili/plugin/tool` endpoint. Session identity is pi's real session id (sent as `x-bili-plugin-conversation`), which also fixes multi-session collisions. Setting `ACP_COOPERATIVE_PROXY=0` forces the standalone in-process behavior even behind a proxy (then make sure the proxy's own tool injection handles compression — double compression is otherwise possible). Protocol spec: [PLUGIN.md](https://github.com/ranxianglei/billion-context/blob/master/PLUGIN.md).

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -124,7 +124,7 @@ All keys below are currently **ACTIVE**.
 | `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit (takes highest precedence). |
 | `ACP_DEBUG` | Set to `1` / `true` to enable debug logging. |
 | `ACP_LOG_FILE` | Override the log file path (default `~/.pi/acp.log`). |
-| `ACP_COOPERATIVE_PROXY` | Set to `0` to disable cooperative proxy mode (auto-detected from a `/bili/` model baseUrl). |
+| `ACP_COOPERATIVE_PROXY` | Set to `0` to disable cooperative proxy mode (auto-detected from a `/bili/` model baseUrl or the launcher's `BILLION_CONTEXT_PROXY` env). |
 
 > **Only the documented keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three compression thresholds form a three-tier escalation: growth-driven soft nudges → forced nudges at `compress.maxContextLimit` → emergency truncation at `compress.emergencyThresholdPercent`.
 
@@ -331,6 +331,6 @@ Environment variables take precedence over the JSON config files. They are usefu
 ### `ACP_COOPERATIVE_PROXY`
 
 - **Type:** string flag
-- **Default:** *(unset — cooperative mode auto-detects from the model baseUrl)*
+- **Default:** *(unset — cooperative mode auto-detects from the model baseUrl or launcher env)*
 - **Status:** 🟢 ACTIVE
-- **Description:** Set to `0` to **disable** cooperative proxy mode. When the model's `baseUrl` routes through a billion-context proxy (the `/bili/` zero-config prefix), the extension automatically switches to cooperative mode: the proxy owns compression (state, folding, ref tags, philosophy prompt, nudges — injected at the wire level), while this extension registers the 4 tools natively and forwards their execution to the proxy's `POST /__bili/plugin/tool` endpoint. Session identity is pi's real session id (sent as `x-bili-plugin-conversation`), which also fixes multi-session collisions. Setting `ACP_COOPERATIVE_PROXY=0` forces the standalone in-process behavior even behind a proxy (then make sure the proxy's own tool injection handles compression — double compression is otherwise possible). Protocol spec: [PLUGIN.md](https://github.com/ranxianglei/billion-context/blob/master/PLUGIN.md).
+- **Description:** Set to `0` to **disable** cooperative proxy mode. Cooperative mode engages when the model's `baseUrl` routes through a billion-context proxy (the `/bili/` zero-config prefix) **or** when the billion-context launcher started pi (`BILLION_CONTEXT_PROXY` is exported next to `HTTPS_PROXY` in MITM mode). The proxy then owns compression (state, folding, ref tags, philosophy prompt, nudges — injected at the wire level), while this extension registers the 4 tools natively and forwards their execution to the proxy's `POST /__bili/plugin/tool` endpoint. Session identity is pi's real session id (sent as `x-bili-plugin-conversation`), which also fixes multi-session collisions; the model's context window is reported via `x-bili-plugin-context-window` and becomes the authoritative nudge denominator on the proxy side. Setting `ACP_COOPERATIVE_PROXY=0` forces the standalone in-process behavior even behind a proxy (then make sure the proxy's own tool injection handles compression — double compression is otherwise possible). Protocol spec: [PLUGIN.md](https://github.com/ranxianglei/billion-context/blob/master/PLUGIN.md).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ When pi's model `baseUrl` routes through a [billion-context](https://github.com/
 
 - the 4 tools (`compress` / `decompress` / `search_context` / `acp_status`) stay natively registered in pi — native tool UX, permissions and audit — and their execution is forwarded to the proxy (`POST /__bili/plugin/tool`), which runs them under its session lock;
 - every model request carries `x-bili-plugin: pi` + `x-bili-plugin-conversation: <pi session id>`, so the proxy keys state by pi's **real** session identity (no more content-fingerprint collisions) and suppresses its own wire-level tool injection (no double compression);
+- the model's context window is reported from inside pi (`x-bili-plugin-context-window`) — pinned/overridden values the proxy's registry can't know become the authoritative nudge denominator;
 - the extension's in-process pipeline (processTurn, nudges, philosophy prompt) is skipped for that session — the proxy does all of it.
+
+Detection works in both proxy modes: the `/bili/` prefix in the model baseUrl, **and MITM transparent mode** — `bili pi` (the billion-context launcher) exports `BILLION_CONTEXT_PROXY` next to `HTTPS_PROXY`, and the extension trusts it directly, so `bili pi` now gives you the native-tool cooperative experience too.
 
 Without a proxy (or with `ACP_COOPERATIVE_PROXY=0`) behavior is byte-identical to the standalone extension.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Each message gets an invisible `<acp>` ref tag (`m00001`, `m00002`, ...) visible
 
 Pi's built-in auto-compaction is cancelled — billion-context is the sole context manager.
 
+## Cooperative proxy mode (内外呼应)
+
+When pi's model `baseUrl` routes through a [billion-context](https://github.com/ranxianglei/billion-context) proxy (the `/bili/` zero-config prefix), the extension automatically switches to **cooperative mode**: the proxy owns compression end-to-end (session state, history folding, ref tags, philosophy prompt, nudges — all injected at the wire level), while the extension becomes the "inside" half of [the plugin protocol](https://github.com/ranxianglei/billion-context/blob/master/PLUGIN.md):
+
+- the 4 tools (`compress` / `decompress` / `search_context` / `acp_status`) stay natively registered in pi — native tool UX, permissions and audit — and their execution is forwarded to the proxy (`POST /__bili/plugin/tool`), which runs them under its session lock;
+- every model request carries `x-bili-plugin: pi` + `x-bili-plugin-conversation: <pi session id>`, so the proxy keys state by pi's **real** session identity (no more content-fingerprint collisions) and suppresses its own wire-level tool injection (no double compression);
+- the extension's in-process pipeline (processTurn, nudges, philosophy prompt) is skipped for that session — the proxy does all of it.
+
+Without a proxy (or with `ACP_COOPERATIVE_PROXY=0`) behavior is byte-identical to the standalone extension.
+
 ## Plugin compatibility & ordering
 
 billion-context takes over context management by intercepting Pi's `context` event. **Pi has no plugin priority mechanism** — when multiple extensions register handlers for the same event, they run in a fixed sequence (load order), with no `priority`/`weight` field and no way for the user to control the order. The `context` event specifically is a *pipeline*: every handler receives the previous handler's output, there is no short-circuit, and the **last** handler has the final say over what reaches the model.

--- a/devlog/2026-08-16_cooperative-proxy-mode/DESIGN.md
+++ b/devlog/2026-08-16_cooperative-proxy-mode/DESIGN.md
@@ -1,0 +1,31 @@
+# DESIGN - Cooperative proxy mode
+
+- Task ID: `2026-08-16_cooperative-proxy-mode`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-16
+- Status: Accepted
+
+## 1. Goals & Non-Goals
+
+- **Goals**: proxy-owns-compression when behind the proxy; native tools forwarded; real session identity; zero change when standalone.
+- **Non-Goals**: MITM detection; config keys; changes to delegate tools (they keep working — their prompt is injected locally even in cooperative mode).
+
+## 2. Mechanism
+
+Detection is **stateless and per-call**: `proxyBaseForContext(ctx)` reads `ctx.model.baseUrl` (typed on pi-ai's `Model`) and matches a `bili` path segment (`http://host[:port]/bili/...` → `http://host[:port]`). No cached mode flag → model switches mid-session are picked up on the very next call. `ACP_COOPERATIVE_PROXY=0` short-circuits detection off.
+
+Four integration points:
+
+1. **`before_provider_headers`** (pi SDK hook, types.d.ts:869 — headers mutate-in-place): sets `x-bili-plugin: pi` + `x-bili-plugin-conversation: ctx.sessionManager.getSessionId()`. No-op unless proxied.
+2. **`context` event**: early return `{ messages: event.messages }` (identity) — the proxy runs processTurn (tags/folding/nudges) at the wire level; running it locally too would double-transform.
+3. **`before_agent_start`**: skip `buildAcpSystemPrompt` (the proxy injects the philosophy); keep `ACP_DELEGATE_PROMPT` (pi-side feature) when delegate enabled; return `undefined` otherwise.
+4. **Tool `execute` (×4)**: `tryForwardTool(name, params, ctx)` → POST `${proxyBase}/__bili/plugin/tool` `{conversationId, tool, args}` → return `result` as the native tool-result text. `undefined` return = not proxied → local handler runs unchanged. Proxy errors throw (consistent with local handlers, which re-throw after logThrow).
+
+`session_before_compact` cancel stays unconditional: pi's compaction must never run — the proxy manages context in cooperative mode too.
+
+## 3. Alternatives considered
+
+- **Cached mode flag set on `session_start`/`model_select`**: rejected — stale on mid-session model switches; per-call read is O(len(url)) and always fresh.
+- **Fetch patching for headers**: rejected — pi-ai owns the HTTP stack; the SDK provides the exact hook (`before_provider_headers`).
+- **Forwarding inside the `handleX` functions**: rejected — the forward must bypass local state entirely (the proxy executes against ITS remembered view); putting it at the top of `execute` makes that structural.
+- **Keeping local compression when proxied**: rejected — double compression; exactly what the protocol exists to prevent.

--- a/devlog/2026-08-16_cooperative-proxy-mode/REQ.md
+++ b/devlog/2026-08-16_cooperative-proxy-mode/REQ.md
@@ -1,0 +1,25 @@
+# REQ - Cooperative proxy mode (内外呼应)
+
+- Task ID: `2026-08-16_cooperative-proxy-mode`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-16
+- Status: Done
+- Priority: P1
+- Owner: awork
+- References: dog/billion-context#1, ranxianglei/billion-context#161 (protocol half), PLUGIN.md spec in billion-context
+
+## 1. Background & Problem Statement
+
+- **Context**: billion-context issue #1 asks for inside/outside cooperation: keep the external proxy but install a plugin inside the agent so the combination feels native. The proxy-side protocol (`/__bili/plugin/manifest`, `/__bili/plugin/tool`, `x-bili-plugin` headers) landed in billion-context PR #161. This repo is the fully in-process implementation — the natural first "inside" adopter.
+- **Current behavior (symptom)**: the extension is either/or: it runs its own in-process pipeline, and the only proxy-related behavior is mutual exclusion by convention (users must disable one side manually).
+- **Expected behavior**: when the model baseUrl routes through the proxy (`/bili/` prefix), the extension keeps its 4 native tools but forwards execution to the proxy, skips its own in-process pipeline, and announces pi's real session identity. Without a proxy, byte-identical standalone behavior.
+- **Impact**: native tool UX + real session identity + zero schema drift (proxy serves schemas), with the proxy as single compression authority.
+
+## 2. Reproduction
+
+N/A (feature).
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**: no behavior change without a `/bili/` baseUrl; no `as any`; no comments unless necessary; pi SDK hooks only (no fetch patching).
+- **Non-Goals**: changing the delegate subsystem (kept working in cooperative mode via its own prompt); MITM-mode proxy detection (no `/bili/` prefix to detect — out of scope for v1); a config-file key for cooperative mode (env kill-switch suffices for v1).

--- a/devlog/2026-08-16_cooperative-proxy-mode/WORKLOG.md
+++ b/devlog/2026-08-16_cooperative-proxy-mode/WORKLOG.md
@@ -32,6 +32,9 @@
 
 ## 4. Notes / Follow-ups
 
-- MITM-mode (transparent proxy, no `/bili/` prefix) is NOT detected — cooperative mode requires the zero-config prefix baseURL (documented). MITM + extension would still double-compress; users on MITM should disable the extension or set the prefix.
+- ~~MITM-mode (transparent proxy, no `/bili/` prefix) is NOT detected~~ — **landed in this PR (follow-up commit)**: the billion-context launcher now exports `BILLION_CONTEXT_PROXY` next to `HTTPS_PROXY` for `bili pi`/`codex`/`claude`; `proxyBaseForContext` falls back to it (trusted without probing — a stale value surfaces as a tool-forward error). MITM cooperative mode works end-to-end.
+- `x-bili-plugin-context-window` (new): `before_provider_headers` reports `ctx.model.contextWindow` from inside pi; the proxy treats it as the authoritative native window (outranks its table/registry; operator `compress.modelContextLimit` still wins).
+- `GET /__bili/plugin/status?conversationId=` (new proxy endpoint): context-level visibility (contextTokens = input+cache-read, contextLimit, blocks, requests) for plugin status UIs.
+- Fixed a usage-application race in the proxy's plugin stream passthrough: usage is applied BEFORE `res.end()` so the client's next request (status fetch / follow-up turn reading `lastInputTokens` for nudges) always sees it.
 - `before_provider_headers` exists in the pi SDK as of this version; if an older pi host lacks it, registration is ignored harmlessly (extension `on` overloads).
 - Cross-repo dependency: the proxy half must merge first (ranxianglei/billion-context#161) — the endpoints this forwards to only exist there. No code-level version coupling (protocol is HTTP + manifest).

--- a/devlog/2026-08-16_cooperative-proxy-mode/WORKLOG.md
+++ b/devlog/2026-08-16_cooperative-proxy-mode/WORKLOG.md
@@ -1,0 +1,37 @@
+# WORKLOG - Cooperative proxy mode
+
+- Task ID: `2026-08-16_cooperative-proxy-mode`
+- Home Repo: `billion-context-pi`
+- Status: Done
+- Updated: 2026-08-16 02:55
+
+## 1. Summary
+
+- **What was done**: Added cooperative proxy mode ("有外用外"): when the model baseUrl routes through a billion-context proxy (`/bili/` prefix), the extension forwards its 4 native tools to the proxy's tool endpoint, announces pi's session identity via `x-bili-plugin*` headers, and skips its own in-process pipeline. Standalone behavior unchanged.
+- **Why**: billion-context issue #1 (内外呼应) — native tool UX + real session identity with the proxy as single compression authority. First adopter of the plugin protocol shipped in ranxianglei/billion-context#161.
+- **Behavior / compatibility changes**: Yes, additive. Without `/bili/` in the model baseUrl (or with `ACP_COOPERATIVE_PROXY=0`) every path is byte-identical to before.
+- **Risk level**: Low (detection is a pure URL check per call; all gated branches early-return).
+
+## 2. Change Log
+
+### Key Files
+
+- `src/cooperative.ts` (new) — `proxyBaseFromUrl` / `proxyBaseForContext` (stateless per-call detection), `forwardToolToProxy` (POST `/__bili/plugin/tool`, error surfaces), `tryForwardTool` (undefined = run local handler).
+- `src/index.ts` — `wireProviderHeaders` (`before_provider_headers` hook); cooperative early-return in `wireContextTransform` (identity messages) and `wireSystemPrompt` (philosophy from proxy, delegate prompt kept).
+- `src/compress-tool.ts` / `src/decompress-tool.ts` / `src/search-tool.ts` / `src/status-tool.ts` — `tryForwardTool` branch at top of `execute`.
+- `tests/cooperative.test.ts` (new, 7 tests) — URL detection matrix; header injection (+absence without proxy); context identity passthrough; system-prompt ownership; live HTTP forward (conversation id, tool name, args passthrough, result text); proxy error propagation; `ACP_COOPERATIVE_PROXY=0` kill switch (local pipeline runs).
+- `README.md` — "Cooperative proxy mode (内外呼应)" section.
+- `CONFIGURATION.md` — `ACP_COOPERATIVE_PROXY` env var (summary table + full section).
+
+## 3. Verification
+
+- `npm run typecheck` clean.
+- `npm test`: 300 tests, 299 pass + 1 **pre-existing failure on pristine master** (`e2e-compress-config.test.ts`: "a 2w limit fires the compress nudge at 2w tokens" — verified failing on clean master checkout before my changes; unrelated to this feature).
+- `npm run build` OK (dist 477 KB).
+- New suite: 7/7.
+
+## 4. Notes / Follow-ups
+
+- MITM-mode (transparent proxy, no `/bili/` prefix) is NOT detected — cooperative mode requires the zero-config prefix baseURL (documented). MITM + extension would still double-compress; users on MITM should disable the extension or set the prefix.
+- `before_provider_headers` exists in the pi SDK as of this version; if an older pi host lacks it, registration is ignored harmlessly (extension `on` overloads).
+- Cross-repo dependency: the proxy half must merge first (ranxianglei/billion-context#161) — the endpoints this forwards to only exist there. No code-level version coupling (protocol is HTTP + manifest).

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -6,6 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow } from "./log.js";
+import { tryForwardTool } from "./cooperative.js";
 import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 import { defaultCountTokens } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
@@ -44,6 +45,10 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
     ],
     parameters: CompressParams,
     async execute(toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      const forwarded = await tryForwardTool("compress", params, ctx);
+      if (forwarded !== undefined) {
+        return { details: undefined, content: [{ type: "text", text: forwarded }] };
+      }
       let result: string;
       try {
         result = await handleCompress(params as CompressArgs, runtime, ctx, toolCallId);

--- a/src/cooperative.ts
+++ b/src/cooperative.ts
@@ -1,0 +1,64 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { logInfo } from "./log.js";
+
+// Cooperative proxy mode ("内外呼应", billion-context issue #1): when the
+// model's baseUrl routes through a billion-context proxy (the `/bili/`
+// zero-config prefix), the proxy owns compression end-to-end (state, folding,
+// ref tags, philosophy prompt, nudges — it injects them at the wire level).
+// This extension then becomes the "inside" half: it announces itself on every
+// provider request (x-bili-plugin headers), skips its own in-process
+// pipeline, and forwards the 4 native tools to the proxy's
+// POST /__bili/plugin/tool. Protocol spec: billion-context PLUGIN.md.
+// Without a `/bili/` baseUrl (or with ACP_COOPERATIVE_PROXY=0) behavior is
+// byte-identical to the standalone extension.
+
+export const PLUGIN_AGENT_NAME = "pi";
+
+const BILI_SEGMENT = "bili";
+
+export function proxyBaseFromUrl(baseUrl: string | undefined): string | undefined {
+    if (!baseUrl) return undefined;
+    try {
+        const url = new URL(baseUrl);
+        const segments = url.pathname.split("/").filter((s) => s.length > 0);
+        if (!segments.includes(BILI_SEGMENT)) return undefined;
+        return `${url.protocol}//${url.host}`;
+    } catch {
+        return undefined;
+    }
+}
+
+export function proxyBaseForContext(ctx: ExtensionContext): string | undefined {
+    if (process.env.ACP_COOPERATIVE_PROXY === "0") return undefined;
+    return proxyBaseFromUrl(ctx.model?.baseUrl);
+}
+
+export async function forwardToolToProxy(proxyBase: string, conversationId: string, tool: string, args: unknown): Promise<string> {
+    const resp = await fetch(`${proxyBase}/__bili/plugin/tool`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ conversationId, tool, args }),
+    });
+    const text = await resp.text();
+    let json: { ok?: boolean; result?: string; error?: string };
+    try {
+        json = JSON.parse(text) as { ok?: boolean; result?: string; error?: string };
+    } catch {
+        throw new Error(`bili proxy tool ${tool} failed (${resp.status}): ${text.slice(0, 200)}`);
+    }
+    if (!resp.ok || !json.ok) {
+        throw new Error(`bili proxy tool ${tool} failed (${resp.status}): ${json.error ?? "unknown error"}`);
+    }
+    return json.result ?? "";
+}
+
+/** Forward a tool execution to the proxy when this session is in cooperative
+ *  mode. Returns undefined when NOT behind a proxy (caller runs the local
+ *  handler); returns the proxy's result text otherwise. */
+export async function tryForwardTool(tool: string, params: unknown, ctx: ExtensionContext): Promise<string | undefined> {
+    const proxyBase = proxyBaseForContext(ctx);
+    if (proxyBase === undefined) return undefined;
+    const conversationId = ctx.sessionManager.getSessionId();
+    logInfo("cooperative", { event: "tool-forward", tool, conversationId, proxyBase });
+    return forwardToolToProxy(proxyBase, conversationId, tool, params);
+}

--- a/src/cooperative.ts
+++ b/src/cooperative.ts
@@ -30,7 +30,22 @@ export function proxyBaseFromUrl(baseUrl: string | undefined): string | undefine
 
 export function proxyBaseForContext(ctx: ExtensionContext): string | undefined {
     if (process.env.ACP_COOPERATIVE_PROXY === "0") return undefined;
-    return proxyBaseFromUrl(ctx.model?.baseUrl);
+    return proxyBaseFromUrl(ctx.model?.baseUrl) ?? proxyBaseFromEnv();
+}
+
+/** MITM transparent-proxy mode has no `/bili/` prefix to detect (the baseUrl
+ *  is the real provider URL). The proxy's own launcher (`bili pi`) exports
+ *  BILLION_CONTEXT_PROXY alongside HTTPS_PROXY + the CA vars; trusting it
+ *  requires no probe — a stale value surfaces as a tool-forward error. */
+export function proxyBaseFromEnv(): string | undefined {
+    const raw = process.env.BILLION_CONTEXT_PROXY?.trim();
+    if (!raw) return undefined;
+    try {
+        const url = new URL(raw);
+        return url.protocol === "http:" || url.protocol === "https:" ? `${url.protocol}//${url.host}` : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 export async function forwardToolToProxy(proxyBase: string, conversationId: string, tool: string, args: unknown): Promise<string> {

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -2,6 +2,7 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow } from "./log.js";
+import { tryForwardTool } from "./cooperative.js";
 import { parseBlockIdArg, collectBlockContent, type CompressionBlock } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
 import { writeFile, mkdir } from "node:fs/promises";
@@ -44,6 +45,10 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     ],
     parameters: DecompressParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      const forwarded = await tryForwardTool("decompress", params, ctx);
+      if (forwarded !== undefined) {
+        return { details: undefined, content: [{ type: "text", text: forwarded }] };
+      }
       let result: string;
       try {
         result = await handleDecompress(params as DecompressArgs, runtime, ctx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,13 +61,19 @@ function wireCompactionDisable(pi: ExtensionAPI): void {
 
 // Cooperative proxy mode: announce this session to the billion-context proxy
 // so it keys state by pi's real session id and switches the session to
-// plugin mode (no wire tool injection — tools are native here). No-op unless
-// the model's baseUrl routes through the proxy (`/bili/` prefix).
+// plugin mode (no wire tool injection — tools are native here). Also reports
+// the model's context window from inside pi (pinned/overridden values the
+// proxy's registry can't know, e.g. private relays in MITM mode). No-op
+// unless proxied (`/bili/` baseUrl or BILLION_CONTEXT_PROXY from `bili pi`).
 function wireProviderHeaders(pi: ExtensionAPI): void {
   pi.on("before_provider_headers", (event, ctx) => {
     if (proxyBaseForContext(ctx) === undefined) return;
     event.headers["x-bili-plugin"] = PLUGIN_AGENT_NAME;
     event.headers["x-bili-plugin-conversation"] = ctx.sessionManager.getSessionId();
+    const window = ctx.model?.contextWindow;
+    if (typeof window === "number" && Number.isFinite(window) && window > 0) {
+      event.headers["x-bili-plugin-context-window"] = String(Math.floor(window));
+    }
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
+import { PLUGIN_AGENT_NAME, proxyBaseForContext, tryForwardTool } from "./cooperative.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -35,6 +36,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
   return (pi: ExtensionAPI) => {
     const runtime = createRuntime(adapter);
     wireCompactionDisable(pi);
+    wireProviderHeaders(pi);
     wireSessionLifecycle(pi, runtime);
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
@@ -55,6 +57,18 @@ export default createAcpExtension();
 // opencode-acp requiring opencode's compaction.auto = false).
 function wireCompactionDisable(pi: ExtensionAPI): void {
   pi.on("session_before_compact", () => ({ cancel: true }));
+}
+
+// Cooperative proxy mode: announce this session to the billion-context proxy
+// so it keys state by pi's real session id and switches the session to
+// plugin mode (no wire tool injection — tools are native here). No-op unless
+// the model's baseUrl routes through the proxy (`/bili/` prefix).
+function wireProviderHeaders(pi: ExtensionAPI): void {
+  pi.on("before_provider_headers", (event, ctx) => {
+    if (proxyBaseForContext(ctx) === undefined) return;
+    event.headers["x-bili-plugin"] = PLUGIN_AGENT_NAME;
+    event.headers["x-bili-plugin-conversation"] = ctx.sessionManager.getSessionId();
+  });
 }
 
 // (acp_delegate injection is best-effort: sendUserMessage is fire-and-forget
@@ -112,6 +126,12 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
 // nudge decision) and return the transformed AgentMessage[].
 function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("context", async (event, ctx) => {
+    // Cooperative proxy mode: the proxy runs processTurn (ref tags, folding,
+    // nudges) at the wire level against its own session state. Doing it here
+    // too would double-transform — return pi's messages untouched.
+    if (proxyBaseForContext(ctx) !== undefined) {
+      return { messages: event.messages };
+    }
     const sid = ctx.sessionManager.getSessionId();
     const release = await runtime.acquireLock(sid);
     try {
@@ -243,8 +263,15 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 }
 
 function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
-  pi.on("before_agent_start", (event) => {
+  pi.on("before_agent_start", (event, ctx) => {
     const delegate = runtime.adapter.delegate !== false;
+    // Cooperative proxy mode: the ACP context prompt is injected by the proxy
+    // at the wire level — only the delegate prompt (a pi-side feature) stays
+    // local. Returning undefined leaves the system prompt untouched.
+    if (proxyBaseForContext(ctx) !== undefined) {
+      if (!delegate) return undefined;
+      return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, ACP_DELEGATE_PROMPT) };
+    }
     const acp = buildAcpSystemPrompt(runtime.prompts);
     const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;
     return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, prompt) };

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -4,6 +4,7 @@ import { searchBlocks, type SearchResult } from "acp-kernel";
 import type { AcpRuntime } from "./runtime.js";
 import { buildSearchDocs } from "./search-index.js";
 import { logThrow } from "./log.js";
+import { tryForwardTool } from "./cooperative.js";
 
 const SearchParams = Type.Object({
     query: Type.String({ description: "Keywords to locate detail folded into compressed summaries or historical messages." }),
@@ -26,6 +27,10 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
         ],
         parameters: SearchParams,
         async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      const forwarded = await tryForwardTool("search_context", params, ctx);
+      if (forwarded !== undefined) {
+        return { details: undefined, content: [{ type: "text", text: forwarded }] };
+      }
             let result: string;
             try {
                 result = await handleSearch(params as SearchArgs, runtime, ctx);

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -6,6 +6,7 @@ import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
 import { getSystemPromptText } from "./compat.js";
 import { viableRanges } from "billion-context-kit";
 import { logThrow } from "./log.js";
+import { tryForwardTool } from "./cooperative.js";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { resolveDelegate } from "./config.js";
 
@@ -33,6 +34,10 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
     ],
     parameters: StatusParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      const forwarded = await tryForwardTool("acp_status", params, ctx);
+      if (forwarded !== undefined) {
+        return { details: undefined, content: [{ type: "text", text: forwarded }] };
+      }
       let result: string;
       try {
         result = await handleStatus(params as StatusArgs, runtime, ctx);

--- a/tests/cooperative.test.ts
+++ b/tests/cooperative.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { createAcpExtension } from "../src/index.js";
-import { proxyBaseFromUrl, forwardToolToProxy } from "../src/cooperative.js";
+import { proxyBaseFromUrl, proxyBaseFromEnv, forwardToolToProxy } from "../src/cooperative.js";
 
 function captureApi() {
   const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
@@ -62,11 +62,42 @@ test("before_provider_headers announces plugin mode with pi's session id", async
   await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers }, fakeCtx([], PROXY_URL));
   assert.equal(headers["x-bili-plugin"], "pi");
   assert.equal(headers["x-bili-plugin-conversation"], "test-session");
+  assert.equal(headers["x-bili-plugin-context-window"], "200000");
 
   const plain: Record<string, string | null> = {};
   await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers: plain }, fakeCtx([], "https://api.anthropic.com"));
   assert.equal(plain["x-bili-plugin"], undefined);
   assert.equal(plain["x-bili-plugin-conversation"], undefined);
+  assert.equal(plain["x-bili-plugin-context-window"], undefined);
+});
+
+test("BILLION_CONTEXT_PROXY enables cooperative mode without a /bili/ baseUrl (MITM launcher)", async () => {
+  const prev = process.env.BILLION_CONTEXT_PROXY;
+  process.env.BILLION_CONTEXT_PROXY = "http://127.0.0.1:8787";
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+
+    const headers: Record<string, string | null> = {};
+    await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers }, fakeCtx([], "https://api.anthropic.com"));
+    assert.equal(headers["x-bili-plugin"], "pi");
+    assert.equal(headers["x-bili-plugin-conversation"], "test-session");
+    assert.equal(headers["x-bili-plugin-context-window"], "200000");
+
+    assert.equal(proxyBaseFromEnv(), "http://127.0.0.1:8787");
+    process.env.BILLION_CONTEXT_PROXY = "http://127.0.0.1:9999/some/path";
+    assert.equal(proxyBaseFromEnv(), "http://127.0.0.1:9999", "path is stripped to the origin");
+    process.env.BILLION_CONTEXT_PROXY = "not a url";
+    assert.equal(proxyBaseFromEnv(), undefined);
+    delete process.env.BILLION_CONTEXT_PROXY;
+
+    const plain: Record<string, string | null> = {};
+    await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers: plain }, fakeCtx([], "https://api.anthropic.com"));
+    assert.equal(plain["x-bili-plugin"], undefined, "without env or /bili/ prefix cooperative mode is off");
+  } finally {
+    if (prev === undefined) delete process.env.BILLION_CONTEXT_PROXY;
+    else process.env.BILLION_CONTEXT_PROXY = prev;
+  }
 });
 
 test("context handler passes messages through untouched in cooperative mode", async () => {

--- a/tests/cooperative.test.ts
+++ b/tests/cooperative.test.ts
@@ -1,0 +1,182 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { createAcpExtension } from "../src/index.js";
+import { proxyBaseFromUrl, forwardToolToProxy } from "../src/cooperative.js";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) {
+      this.tools.push(tool);
+    },
+    registerCommand(name: string, options: any) {
+      this.commands.set(name, options);
+    },
+  };
+  return { api, handlers };
+}
+
+function fakeCtx(entries: any[], baseUrl?: string) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000, baseUrl },
+    sessionManager: {
+      getBranch: () => entries,
+      getSessionId: () => "test-session",
+      getSessionFile: () => "/tmp/nonexistent-pai-cooperative.session.json",
+    },
+  };
+}
+
+function userMsg(id: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
+}
+
+const PROXY_URL = "http://127.0.0.1:8787/bili/https://api.anthropic.com";
+
+test("proxyBaseFromUrl extracts the proxy origin only from /bili/ base URLs", () => {
+  assert.equal(proxyBaseFromUrl(PROXY_URL), "http://127.0.0.1:8787");
+  assert.equal(proxyBaseFromUrl("http://127.0.0.1:8787/bili/openai/https://api.openai.com/v1"), "http://127.0.0.1:8787");
+  assert.equal(proxyBaseFromUrl("https://api.anthropic.com/v1/messages"), undefined);
+  assert.equal(proxyBaseFromUrl("http://127.0.0.1:8787/v1/messages"), undefined);
+  assert.equal(proxyBaseFromUrl(undefined), undefined);
+  assert.equal(proxyBaseFromUrl("not a url"), undefined);
+});
+
+test("before_provider_headers announces plugin mode with pi's session id", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension()(api as any);
+  assert.ok(handlers.has("before_provider_headers"), "before_provider_headers wired");
+
+  const headers: Record<string, string | null> = {};
+  await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers }, fakeCtx([], PROXY_URL));
+  assert.equal(headers["x-bili-plugin"], "pi");
+  assert.equal(headers["x-bili-plugin-conversation"], "test-session");
+
+  const plain: Record<string, string | null> = {};
+  await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers: plain }, fakeCtx([], "https://api.anthropic.com"));
+  assert.equal(plain["x-bili-plugin"], undefined);
+  assert.equal(plain["x-bili-plugin-conversation"], undefined);
+});
+
+test("context handler passes messages through untouched in cooperative mode", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension()(api as any);
+
+  const entries = [userMsg("e1", "first"), userMsg("e2", "second")];
+  const messages = entries.map((e) => e.message);
+  const result = await handlers.get("context")![0]!({ type: "context", messages }, fakeCtx(entries, PROXY_URL));
+  assert.equal(result.messages, messages, "must return the SAME array untransformed — the proxy owns tags/folding/nudges");
+});
+
+test("before_agent_start drops the local ACP prompt in cooperative mode (proxy injects it)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension()(api as any);
+
+  const result = await handlers.get("before_agent_start")![0]!({ systemPrompt: "BASE" }, fakeCtx([], PROXY_URL));
+  assert.ok(!result.systemPrompt.includes("ACP context management"), "philosophy must come from the proxy, not locally");
+  assert.ok(result.systemPrompt.startsWith("BASE"));
+
+  const local = await handlers.get("before_agent_start")![0]!({ systemPrompt: "BASE" }, fakeCtx([], "https://api.anthropic.com"));
+  assert.ok(local.systemPrompt.includes("ACP context management"), "standalone mode keeps the local prompt");
+});
+
+test("native tools forward to the proxy tool endpoint in cooperative mode", async () => {
+  const received: Array<{ conversationId?: string; tool?: string; args?: any }> = [];
+  const server = createServer((req, res) => {
+    let body = "";
+    req.on("data", (c: string) => { body += c; });
+    req.on("end", () => {
+      if (req.url === "/__bili/plugin/tool") {
+        received.push(JSON.parse(body));
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, tool: "compress", result: "[proxied] compressed m00001–m00002" }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+
+  const { api } = captureApi();
+  createAcpExtension()(api as any);
+  const compress = api.tools.find((t: any) => t.name === "compress");
+  assert.ok(compress, "compress tool registered");
+
+  const args = { content: [{ startId: "m00001", endId: "m00002", summary: "x".repeat(60) }] };
+  const out = await compress.execute(
+    "call_1",
+    args,
+    undefined,
+    undefined,
+    fakeCtx([], `http://127.0.0.1:${port}/bili/https://api.anthropic.com`),
+  );
+  assert.equal(out.content[0].type, "text");
+  assert.equal(out.content[0].text, "[proxied] compressed m00001–m00002");
+  assert.equal(received.length, 1);
+  assert.equal(received[0].conversationId, "test-session");
+  assert.equal(received[0].tool, "compress");
+  assert.equal(received[0].args.content[0].startId, "m00001");
+
+  const localOut = await compress.execute(
+    "call_2",
+    args,
+    undefined,
+    undefined,
+    fakeCtx([], `http://127.0.0.1:${port}/no-bili/https://api.anthropic.com`),
+  );
+  assert.notEqual(localOut.content[0].text, "[proxied] compressed m00001–m00002", "no /bili/ prefix → local handler runs");
+
+  server.close();
+});
+
+test("proxy tool errors surface as tool failures", async () => {
+  const server = createServer((req, res) => {
+    res.writeHead(500, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: "unknown plugin conversation" }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+
+  await assert.rejects(
+    forwardToolToProxy(`http://127.0.0.1:${port}`, "missing-conv", "compress", {}),
+    /unknown plugin conversation/,
+  );
+  server.close();
+});
+
+test("ACP_COOPERATIVE_PROXY=0 disables cooperative mode entirely", async () => {
+  const prev = process.env.ACP_COOPERATIVE_PROXY;
+  process.env.ACP_COOPERATIVE_PROXY = "0";
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+
+    const headers: Record<string, string | null> = {};
+    await handlers.get("before_provider_headers")![0]!({ type: "before_provider_headers", headers }, fakeCtx([], PROXY_URL));
+    assert.equal(headers["x-bili-plugin"], undefined);
+
+    const entries = [userMsg("e1", "first"), userMsg("e2", "second")];
+    const messages = entries.map((e) => e.message);
+    const result = await handlers.get("context")![0]!({ type: "context", messages }, fakeCtx(entries, PROXY_URL));
+    assert.notEqual(result.messages, messages, "local pipeline must run (tagged output, not identity)");
+    const first = (result.messages[0] as any).content;
+    const textBlocks = Array.isArray(first) ? first.filter((b: any) => b.type === "text") : [];
+    assert.ok(textBlocks.length > 0 && /m\d+/.test(textBlocks[0].text), "messages ref-tagged locally");
+  } finally {
+    if (prev === undefined) delete process.env.ACP_COOPERATIVE_PROXY;
+    else process.env.ACP_COOPERATIVE_PROXY = prev;
+  }
+});

--- a/tests/e2e-compress-config.test.ts
+++ b/tests/e2e-compress-config.test.ts
@@ -103,6 +103,11 @@ test("e2e compress config: without a config file the kernel defaults apply", asy
 // Behavioral: feed the real configFor() output into runtime.core.processTurn()
 // (src/index.ts:142) and assert shouldInject flips with the limit. The nudge
 // needs recommendedRanges > 0, not just a high usage ratio — hence the bulk text.
+// Bulk size matters: the kernel only counts merged ranges with tokens*4 >=
+// minCompressRange (5000 chars, the #148 viable-ranges rule), so each message
+// must be large enough for its merged range to clear the gate — with 2000-char
+// messages every range stays under the minimum and the nudge is correctly
+// suppressed ("no tier has effective compressible content").
 function compressibleMessages(): CoreMessage[] {
     const msgs: CoreMessage[] = [];
     for (let i = 0; i < 12; i++) {
@@ -110,7 +115,7 @@ function compressibleMessages(): CoreMessage[] {
             id: `h_${i}`,
             role: i % 2 === 0 ? "user" : "assistant",
             contentType: "text",
-            text: `historical detail ${i}. ${"x".repeat(2000)}`,
+            text: `historical detail ${i}. ${"x".repeat(3000)}`,
         });
     }
     return msgs;


### PR DESCRIPTION
## What

The "inside" half of the cooperative plugin protocol (billion-context issue dog/billion-context#1, gitea; protocol half = ranxianglei/billion-context#161). When pi's model `baseUrl` routes through a billion-context proxy (the `/bili/` zero-config prefix), the extension automatically switches to cooperative mode — 有外用外:

- **Tools stay native, execution forwards**: `compress` / `decompress` / `search_context` / `acp_status` keep their native pi registration (native UX, permissions, audit), but `execute` POSTs to the proxy's `/__bili/plugin/tool`, which runs them under its session lock against the same view the model saw. Result text returns as the native tool result.
- **Real session identity**: every provider request carries `x-bili-plugin: pi` + `x-bili-plugin-conversation: <pi session id>` (via the SDK's `before_provider_headers` hook). The proxy keys state by pi's real session id — no more content-fingerprint collisions — and suppresses its own wire tool injection (no double compression).
- **In-process pipeline skipped**: `context` returns pi's messages untouched (the proxy runs processTurn — tags, folding, nudges — at the wire level); `before_agent_start` drops the local philosophy prompt (proxy injects it) while keeping the delegate prompt (pi-side feature).

### Detection

Stateless per-call check: `bili` path segment in `ctx.model.baseUrl` → proxy origin. Model switches mid-session are picked up on the next call; nothing is cached. `ACP_COOPERATIVE_PROXY=0` disables entirely.

## Compatibility

Without a `/bili/` baseUrl every path is byte-identical to before (early-return branches only). MITM-mode (transparent proxy, no prefix) is NOT detected — documented; use the `/bili/` prefix baseURL for cooperative mode.

## Verification

- `npm run typecheck` ✅
- New suite `tests/cooperative.test.ts` 7/7 (URL matrix, header injection + absence, context identity passthrough, prompt ownership, live HTTP forward with conversation-id/args/result assertions, error propagation, kill switch)
- `npm test`: 300 tests — 299 pass + 1 **pre-existing failure on pristine master** (`e2e-compress-config.test.ts` "2w limit fires nudge" — verified failing on a clean master checkout before these changes; unrelated)
- `npm run build` ✅

## Files

- `src/cooperative.ts` (new) — detection + `forwardToolToProxy` / `tryForwardTool`
- `src/index.ts` — `wireProviderHeaders` + cooperative early-returns in context/system-prompt wiring
- 4 tool files — `tryForwardTool` branch at top of `execute`
- `tests/cooperative.test.ts`, README.md section, CONFIGURATION.md `ACP_COOPERATIVE_PROXY`
- `devlog/2026-08-16_cooperative-proxy-mode/` — REQ + DESIGN + WORKLOG

## Ordering note

No code-level coupling, but the endpoints this forwards to land with ranxianglei/billion-context#161 — merge that first for the combination to work end-to-end.

Refs: dog/billion-context#1 (gitea)