### PR TITLE
fix(density): post-compression re-anchor + out-of-block detection + calibrated usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased (master, since v0.1.38)
+
+- Density calibration (Phase 2 of token calibration) + token-count snapshot: kernel 0.0.24→0.0.27 (`acp-kernel`), `src/density.ts` 累积锚点密度估计器（clamp [0.5,2.5]、Δest≥50、±20% 双轮确认、per-model 隔离、压缩后重锚），`countTokens` 注入 kernel；`tokenSnapshot` 跨重启稳定 `<acp>` 标签数字，修复校准期前缀缓存反复重建（closes #146）(#155)
+- Three-level compress cascade (global > provider > model, per-field deepest-wins): `compress.providers` in acp.json (#145)
+- `decompress` `toFile` 加固：拒绝经符号链接逃出 `tmpdir()`/`~/.cache/opencode`/`~/.cache/pi` 的路径（含悬空链接）(#140)
+- **fix(density)**: 压缩后密度重锚定 — 原实现锚点跨压缩事件不重置，重采样被阻断直到 est 涨回压缩前水平（长死区）；现于 post-compression 跳过轮在干净基准上重锚并丢弃旧 pending 确认
+- **fix(density)**: `postCompression` 检测改为 runtime 按 session 跟踪新 active block（原实现比较单次 processTurn 输入/输出 state，而 block 只能由 applyCompression 在事件间创建，标志生产路径永远不触发）
+- **fix(usage)**: 四个 processTurn 调用点的 `tokenCount` 改为 `rawSentTokens × density`（`calibrateTokens`）— 75% 强制 nudge / 95% emergency truncate 在 provider 锚定尺度上仲裁，CJK 会话不再偏晚触发（估计器样本仍用 RAW 口径）
+- docs: token-calibration-plan 对齐实现（T2/T3 随 density 放大、mid-session 模型切换为 per-model 隔离、重锚时机、postCompression 检测方式）
+
+## v0.1.38
+
+- **fix: sent-view nudge arbitration** — 四个 processTurn 调用点统一用发送视图估算（`estimateTokens + sysPrompt`）仲裁 nudge/usage，不再用 `getContextUsage` 的 session-tree 口径（provider 不报 usage 时树总量只增不减 → 永久假 EMERGENCY；omp issue #18 同类）(#150)
+- **adopt billion-context-kit 0.2.0** — `/acp` 面板改用共享 `buildStatusPanel`（双账本：session accounting / sent view、viability 过滤、bar 用 sent 视图、block 列表 topic 回退），`viableRanges` 移入 kit (#149)
+- **fix: 只推荐 viable 可压缩范围（≥200 tokens）** — 注入 nudge / `acp_status` / `/acp` 面板三处统一过滤碎片小范围（小范围进批量 compress 会因 summary 过短整体失败）(#148)
+- docs(readme): 配置参考指向 CONFIGURATION.md (closes #35) (#144)
+- acp-kernel 0.0.23 → 0.0.24
+
+## v0.1.37
+
+- feat(prompts): acp.json 可定制提示词（Layer 2，默认提示词字节级不变）(#128)
+- fix(omp): 转换上下文/分支切换后保留压缩状态；provider 前缀后保留压缩 ref (#138 + omp 系列修复)
+- fix: block decompress 在树导航后回退到完整 session 树 (#133)
+- fix: delegate 子代理在嵌入宿主（如 pi-web）下解析正确的 pi CLI 入口 (#130)
+- ci: Windows 加入测试矩阵 + 跨平台 e2e runner（真实 `pi -p`）(#132, #134)
+
 ## v0.1.36
 
 - Bump acp-kernel to 0.0.21 (two-tier gating: maxContextLimitPct 75% force-nudge + emergencyThresholdPct 95% truncate, spam fix when no compressible content, over-limit emergency voice)

--- a/docs/token-calibration-plan.md
+++ b/docs/token-calibration-plan.md
@@ -118,6 +118,8 @@ tokens: countTokens(msg.text ?? "")
 每轮 context 事件：
   if (postCompressionSkip):                     // 压缩后第一轮跳过（D7/F1）
     postCompressionSkip = false
+    anchorReal = realTotal; anchorEst = estTotal // 在干净的压缩后基准上重新锚定
+    pendingDensity = null; confirmCount = 0      // 丢弃压缩前窗口的 pending 确认
     return
   Δreal = realTotal - anchorReal                // provider 累计真实增量（同窗口）
   Δest  = estTotal - anchorEst                  // 估算累计增量（同窗口）
@@ -127,7 +129,10 @@ tokens: countTokens(msg.text ?? "")
     anchorReal = realTotal; anchorEst = estTotal // 推进锚点
 ```
 
-压缩触发时设置 `postCompressionSkip = true`（与 §5.1 的 flag 一致）。
+> 实现注（2026-08-16）：重新锚定放在**跳过轮**（压缩后第二轮）而非
+> postCompression 轮本身——后者读到的 provider usage 可能还是压缩前的体积。
+> 若不重锚，压缩前的锚点会阻断重采样直到 est 涨回压缩前水平（长死区），
+> 跨界首个样本还可能被 clamp 成离群值（见 tests/density.test.ts 回归用例）。
 
 然后 `createCore({ countTokens: (text) => defaultCountTokens(text) × density })`。
 
@@ -143,11 +148,20 @@ tokens: countTokens(msg.text ?? "")
 直接除会污染系数；相邻两轮差值自动消掉固定开销，得到纯"消息真实 token / 估算 token"密度。
 本会话实测密度 ≈ 1.6-1.8（中文为主）。
 
-### 3.3 第三层 — compress 工具返回值与 acp_status 对齐
+### 3.3 第三层 — 决策与显示层对齐（含 usage 校准）
 
 `compress-tool.ts` 的 `beforeTokens` 与 status breakdown 已用 `defaultCountTokens`
 （CJK-aware），统一改走注入的校准 countTokens，让**模型看到的数字、footer、nudge
 判断全部同口径**。
+
+**usage/emergency 仲裁同乘 density（实现注 2026-08-16，新增）**：四个 processTurn
+调用点（context transform / compress / acp_status / /acp panel）的 `tokenCount` 一律
+`rawSentTokens × density`（`calibrateTokens`）。原因：`decideNudge` 的
+`usage = tokenCount / limit` 直接驱动 75% 强制 nudge 与 95% emergency truncate，
+若用未校准的 CJK-aware 估算，CJK 会话（real/est ≈ 1.2-1.6）会在真实占用
+已超窗后安全阀才动作。注意**估计器样本仍喂 RAW sentTokens**——样本若也乘
+density，density 会追逐自己的校准值发散。回归测试：
+tests/density-usage-fixes.test.ts。
 
 ## 4. 系数收敛（无预热期）
 
@@ -168,19 +182,30 @@ tokens: countTokens(msg.text ?? "")
 ## 5. 边界与风险
 
 1. **压缩瞬间 Δest 为负** → `Δest >= 50` 门槛自然跳过；压缩后第一轮正增长可能含残余
-   realUsage（provider 在压缩前返回），建议压缩后设置 flag 再跳过一轮（评审 D7）
+   realUsage（provider 在压缩前返回），压缩后设置 flag 再跳过一轮（评审 D7）。
+   **检测方式（实现注 2026-08-16）**：block 由 compress 工具在两次 context 事件**之间**
+   创建（`processTurn` 从不创建 block），因此不能靠单次 processTurn 的输入/输出 state
+   比较检测——实现为 runtime 按 session 记录上一轮 active block id 集
+   （`noteActiveBlocks`），本轮加载 state 出现新 active block 即置 flag。
 2. **会话开始无 realUsage** → density 初始 1，第二轮起自然收敛
-3. **模型/窗口切换** → `session_start` 重置 density（runtime 已有 `clearNudgeTracking`）；
-   **mid-session 模型切换**（如 A 模型 → B 模型）也要重置——不同 tokenizer 的 CJK 密度
-   差异巨大（DeepSeek 1.2 vs GPT-4 0.7 vs Claude 0.5），且不同 provider 的 usage 统计
-   口径不同（thinking/cache tokens 是否单列），切换后 density 应重新收敛（评审 D6）
+3. **模型/窗口切换** → `session_start` 重置 density（runtime 已有 `clearNudgeTracking`）。
+   **mid-session 模型切换**（如 A 模型 → B 模型）：不同 tokenizer 的 CJK 密度差异巨大
+   （DeepSeek 1.2 vs GPT-4 0.7 vs Claude 0.5），且不同 provider 的 usage 统计口径不同
+   （thinking/cache tokens 是否单列），切换后 density 应重新收敛（评审 D6）。
+   **实现注（2026-08-16）**：实现为 per-model 隔离（切换模型即使用目标模型自己的
+   条目，新模型从 1 开始收敛，不会跨模型污染）+ 仅 `session_start` 重置当前模型；
+   未监听 mid-session 切换事件——A→B→A 回切会复用 A 的旧条目，约 2 个采样轮后
+   被 C1 双轮确认机制重新校准，代价可接受，不做额外监听。
 4. **per-model 存储** → density 不能是 runtime 全局单值，应为 `Map<modelId, number>`
    （同一个 provider 下有多个模型时各算各的）；并行 session 也要隔离，key 到
    `sessionId × modelId` 粒度（评审 D5）
 5. **density clamp [0.5, 2.5]** → 上界从 4 收紧：没有自然语言能达到 4 token/char，
    即使 CJK+emoji 混合也不超过 2.5；下界 0.5 给纯英文留余量（评审 D3）
 6. **最小 Δest 阈值 = 50** → 微消息（1-2 字符）的比值极不稳定（评审 D4）
-7. **T2/T3 不受影响** → summary 本身短，CJK-aware 已足够
+7. **T2/T3 同乘 density（实现注 2026-08-16，替代原"不受影响"结论）** → 注入的
+   countTokens 是 kernel 内部唯一计数器，T2/T3 的 summary pending 也随 density 放大。
+   影响小（summary 短；CJK 摘要被放大更接近真实占用），且方向正确，**保持实现现状**；
+   如需严格按原规格隔离 T2/T3，需 kernel 侧拆分计数器（未做）。
 8. **密度不持久化（已知行为）** → density 存内存 Map，Pi 重启后回 1；冷启动
    第 1 轮低估 ~40%，2-3 轮后自动收敛（评审 B1）。不做持久化：收敛快、
    `*.acp.json` 格式改动需向后兼容、冷启动不差于现状（chars/4 本就是当前行为）
@@ -246,7 +271,9 @@ tokens: countTokens(msg.text ?? "")
 - [x] **已决定**：累积锚点法采用"连续 2 轮 ±20% 才采纳"加固（C1 推荐实现，§3.2）
 - [x] **已决定**：`acp_status` breakdown **不乘** density——status 显示 kernel 口径（调试视角），
       footer 已显示 provider 真实值，用户有对照
-- [x] **已决定**：T2/T3 pending **不乘** density——summary 短，CJK-aware 足够（§5.7）
+- [x] **已决定（2026-08-16 修订）**：T2/T3 pending **随** density 放大（注入计数器
+  是 kernel 内部唯一计数器，未拆分）——原"不乘"结论与实现不符，现以实现为准，
+  见 §5.7
 - [x] **已验证**：`computeProtectedRefs` 的 preserveRecentTokens 改用 countTokens 后，保护区大小变化**影响存在但可控，且是正确方向**——中文消息的保护区物理大小变小（1 字符 ≈ 1 token 而非 0.25），`preserveRecentTokens` 现在保护"最近 N 真实 token"而非"最近 N 字符/4 估算"；`preserveRecentMessages` 作为消息数兜底仍有效（至少保护最近 N 条消息）；nudge 因可压缩范围变大而略微提前，正是校准目的。测试见 `tests/recommend.test.ts` 第 3 例（computeProtectedRefs 注入 countTokens 撑大保护区）。结论：校准后的正确语义，非回归。
 - [x] **已确认**：runtime 拿 modelId 用 `ctx.model.id`（`src/delegate-tool.ts:562`，完整标识符）
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@ import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
-import { collectCoveredMessageIds, estimateTokens } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, calibrateTokens } from "./tokens.js";
 import { buildStatusPanel } from "billion-context-kit";
 import { getDelegateUsage } from "./delegate-tool.js";
 
@@ -93,8 +93,9 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
   const sessionTokens = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n"));
   const coveredIds = collectCoveredMessageIds(state);
+  const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
-  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount: sentTokens });
+  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount: calibrateTokens(sentTokens, runtime.density.densityFor(modelId)) });
 
   // Shared kit surface renders the panel (dual accounting, viability
   // filtering, bars, block list with topic fallback). Host-specific inputs:

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -6,7 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow } from "./log.js";
-import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
 import { defaultCountTokens } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 
@@ -63,6 +63,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   const config = runtime.configFor(ctx);
   // Sent-view arbitration — the same scale as the context transform and
   // acp_status (see src/index.ts): never the session-tree tokenCount.
+  const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
   const sentTokens = estimateTokens(coreMessages, collectCoveredMessageIds(initialState)) + systemPromptTokens;
@@ -70,16 +71,16 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     messages: coreMessages,
     state: initialState,
     config,
-    tokenCount: sentTokens,
+    tokenCount: calibrateTokens(sentTokens, runtime.density.densityFor(modelId)),
   });
   const state = turn.state;
   const messages = turn.messages;
   // Display-layer density alignment (doc §3.3): beforeTokens is calibrated to
   // the same scale as the kernel's injected countTokens (which already carries
   // density), so the numbers the model sees match real usage.
-  const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const density = runtime.density.densityFor(modelId);
-  const beforeTokens = Math.round(estimateTokens(messages, collectCoveredMessageIds(state)) * density);  const summaryMaxChars = args.summaryMaxChars;
+  const beforeTokens = calibrateTokens(estimateTokens(messages, collectCoveredMessageIds(state)), density);
+  const summaryMaxChars = args.summaryMaxChars;
   const topLevelTopic = args.topic;
 
   debug.event("compress-in", {

--- a/src/density.ts
+++ b/src/density.ts
@@ -70,6 +70,16 @@ export class DensityEstimator {
     }
     if (est.postCompressionSkip) {
       est.postCompressionSkip = false;
+      // Re-anchor on the clean post-compression basis. The postCompression
+      // round's own usage may still reflect the pre-compression size, so the
+      // re-anchor happens here (one round later), not on that round. Without
+      // it the pre-compression anchor blocks resampling until the estimate
+      // regrows past it (long dead zone) and the first crossing sample can
+      // be a clamped outlier.
+      est.anchorReal = realTotal;
+      est.anchorEst = estTotal;
+      est.pendingDensity = null;
+      est.confirmCount = 0;
       return;
     }
     if (est.anchorReal === null || est.anchorEst === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, setDebugEnabled, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
-import { collectCoveredMessageIds, estimateTokens, lastUserMessageId } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
@@ -71,6 +71,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     resetDelegateUsage();
     setDelegateDisplayUsage("separate");
     const sid = ctx.sessionManager.getSessionId();
+    runtime.clearSessionTracking(sid);
     logInfo("session", { event: "start", sid, cwd: ctx.cwd, debug: runtime.adapter.debug ?? null, version: typeof CURRENT_VERSION !== "undefined" ? CURRENT_VERSION : null });
     try {
       const user = await loadUserConfig(ctx.cwd);
@@ -139,7 +140,22 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const systemPromptText = getSystemPromptText(ctx);
       const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
       const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
-      const tokenCount = sentTokens;
+      // Usage/emergency arbitration on the CALIBRATED sent view: density is
+      // the provider-anchored real/estimate ratio learned by the estimator
+      // (docs/token-calibration-plan.md §3.2). Raw CJK-aware estimates
+      // under-report CJK context by ~20-40%, which would delay the forced
+      // nudge and emergency truncate past the real window. The estimator
+      // below is fed the RAW sentTokens — its samples must stay on the
+      // raw basis or density would chase its own calibration.
+      const tokenCount = calibrateTokens(sentTokens, runtime.density.densityFor(modelId));
+      // A compress happened since the previous context round: blocks are
+      // created out-of-band by the compress tool, so detect new active
+      // blocks on the LOADED state vs. the previous round (comparing a
+      // single processTurn's input/output can never see them).
+      const postCompression = runtime.noteActiveBlocks(
+        sid,
+        state.blocks.filter((b) => b.active).map((b) => b.blockId),
+      );
 
       debug.event("context-in", {
         sid,
@@ -160,10 +176,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // 密度校准（Phase 2）：processTurn 后调用，countTokens 用上一轮 density（1 轮延迟可忽略）。
       // real 侧 = provider 锚定 usage（缺失时锚点冻结，§5.9）；est 侧 = 发送视图估算
       // （estimateTokens 内部走 CJK 感知 defaultCountTokens，与注入 kernel 的计数器同源）。
-      // postCompression = 本次新增了 active block（模型刚压缩过）。
-      const postCompression = turn.state.blocks.some(
-        (b) => b.active && !state.blocks.some((o) => o.blockId === b.blockId)
-      );
+      // postCompression = 自上一轮 context 事件以来新增了 active block（模型刚压缩过）。
       runtime.density.update(modelId, realUsage?.tokens ?? null, sentTokens, postCompression);
 
       logInfo("turn", {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -42,6 +42,14 @@ export interface AcpRuntime {
   density: DensityEstimator;
   /** 设置 countTokens 闭包使用的 modelId（每轮 context 事件调用）。 */
   setCountModel(modelId: string): void;
+  /** Record this session's active block ids for the current context round;
+   *  returns true when a new active block appeared since the previous round
+   *  (i.e. a compress happened out-of-band — blocks are created by the
+   *  compress tool between context events, so they can never be detected by
+   *  comparing a single processTurn's input/output state). */
+  noteActiveBlocks(sid: string, activeBlockIds: string[]): boolean;
+  /** Drop per-session tracking state (session_start). */
+  clearSessionTracking(sid: string): void;
   adapter: AdapterConfig;
   setAdapter(adapter: AdapterConfig): void;
   prompts: Prompts;
@@ -199,6 +207,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     countTokens: (text) => density.estimateWithDensity(countModelId, text),
   });
   const store = new SessionStateStore();
+  const lastActiveBlockIds = new Map<string, Set<string>>();
   const locks = new Map<string, Promise<void>>();
   let adapterRef = adapter;
   let promptsRef: Prompts = defaultPrompts;
@@ -256,4 +265,15 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };}
+  function noteActiveBlocks(sid: string, activeBlockIds: string[]): boolean {
+    const current = new Set(activeBlockIds);
+    const prev = lastActiveBlockIds.get(sid);
+    const isNew = prev !== undefined && activeBlockIds.some((id) => !prev.has(id));
+    lastActiveBlockIds.set(sid, current);
+    return isNew;
+  }
+  function clearSessionTracking(sid: string): void {
+    lastActiveBlockIds.delete(sid);
+  }
+
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };}

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel";
-import { estimateTokens, collectCoveredMessageIds } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
 import { getSystemPromptText } from "./compat.js";
 import { viableRanges } from "billion-context-kit";
 import { logThrow } from "./log.js";
@@ -57,6 +57,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   // Sent-view arbitration (same scale as the context transform): never the
   // session-tree number from getContextUsage, which includes compressed
   // originals and never shrinks (false emergencies; see src/index.ts).
+  const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
   const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
@@ -64,7 +65,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
     messages: coreMessages,
     state,
     config,
-    tokenCount: sentTokens,
+    tokenCount: calibrateTokens(sentTokens, runtime.density.densityFor(modelId)),
   });
   const processed = turn.messages;
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -19,6 +19,15 @@ export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>
   return tokens;
 }
 
+/** Scale a raw (uncalibrated) sent-view estimate by the per-model density
+ *  learned from provider usage (density = real/estimate). Used for nudge /
+ *  usage / emergency arbitration at every processTurn site so the decision
+ *  runs on the provider-anchored scale; the estimator itself is always fed
+ *  the RAW estimate — see density.ts. */
+export function calibrateTokens(estimate: number, density: number): number {
+  return density === 1 ? estimate : Math.round(estimate * density);
+}
+
 /** Id of the last user-role entry — used as a per-turn key so a nudge prints at
  *  most once per turn. Returns undefined if there is no user message yet. */
 export function lastUserMessageId(entries: { id: string; message?: { role?: string } }[]): string | undefined {

--- a/tests/commands-kit-panel.test.ts
+++ b/tests/commands-kit-panel.test.ts
@@ -11,6 +11,7 @@ const { makeCommands } = await import("../src/commands.js");
 function fakeRuntime(): AcpRuntime {
   return {
     configFor: () => ({ modelContextLimit: 1_000_000 }),
+    density: { densityFor: () => 1, update: () => {}, resetModel: () => {} },
     stateFor: async () => ({
       state: { blocks: [], stats: { tokensCompressed: 0 }, messageRefs: { byRaw: {}, byRef: {} } },
       coreMessages: [],

--- a/tests/density-usage-fixes.test.ts
+++ b/tests/density-usage-fixes.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+import { createRuntime } from "../src/runtime.js";
+
+// Regression guards for the density-usage fixes:
+//  1. post-compression detection must see blocks created OUT-OF-BAND by the
+//     compress tool between context events (the within-processTurn comparison
+//     in #155 could never see them — blocks are only created by
+//     applyCompression, never by processTurn).
+//  2. nudge usage/emergency arbitration must run on the CALIBRATED sent view
+//     (raw estimate × density), not the raw estimate — otherwise CJK sessions
+//     (real/estimate ≈ 1.2-1.6) trip the 75% forced nudge and the 95%
+//     emergency truncate well past the real window.
+
+// ─── 1. runtime-level detection (unit) ────────────────────────────────────
+
+test("noteActiveBlocks detects out-of-band block creation per session", () => {
+  const r = createRuntime({});
+  assert.equal(r.noteActiveBlocks("s1", []), false, "first observation: no baseline yet");
+  assert.equal(r.noteActiveBlocks("s1", []), false, "steady state: nothing new");
+  assert.equal(r.noteActiveBlocks("s1", ["b1"]), true, "new active block since last round");
+  assert.equal(r.noteActiveBlocks("s1", ["b1"]), false, "same block next round: not new");
+  assert.equal(r.noteActiveBlocks("s1", ["b1", "b2"]), true, "second compress");
+  assert.equal(r.noteActiveBlocks("s2", ["b1"]), false, "other session has its own baseline");
+  r.clearSessionTracking("s1");
+  assert.equal(r.noteActiveBlocks("s1", ["b1", "b2"]), false, "cleared session re-baselines");
+});
+
+// ─── 2. calibrated nudge arbitration (integration) ────────────────────────
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function msg(id: string, role: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role, content: text, timestamp: Date.now() } };
+}
+
+// 400K ASCII chars = 100K tokens (chars/4, no CJK)
+const BIG = "x".repeat(400_000);
+// 4K chars = 1K tokens
+const SMALL = "y".repeat(4_000);
+
+const nudgeCount = (r: any) =>
+  (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached|compress/i.test(JSON.stringify(m.content))).length;
+
+async function runCalibratedScenario(realScale: number) {
+  // realScale: provider usage per 1K estimated tokens (1.0 = uncalibrated control)
+  const stateFile = `/tmp/pai-acp-calibrated-${realScale}.session.json`;
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+
+  let usage = 0;
+  const ctx: any = {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000, id: "cal-test" },
+    sessionManager: {
+      getBranch: () => entries as any[],
+      getSessionId: () => `cal-${realScale}`,
+      getSessionFile: () => stateFile,
+    },
+    getContextUsage: () => ({ tokens: usage, percent: usage / 200_000, contextWindow: 200_000 }),
+  };
+
+  // 7 messages: 100K + 6×1K = 106K est. With preserveRecentMessages=5 the
+  // first two (101K) sit OUTSIDE the protected zone from r7 onward, so a
+  // forced nudge has a viable compressible range. Each round adds one message
+  // (alternating roles, final round ends on a fresh user message → fresh
+  // per-turn nudge key).
+  const roles = ["user", "assistant", "user", "assistant", "user", "assistant", "user"] as const;
+  const all = roles.map((role, i) => msg(`e${i}`, role, i === 0 ? BIG : SMALL));
+  let entries: any[] = [];
+  const fire = () => handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+
+  let r: any;
+  // r1: anchor (no sample yet)
+  entries = [all[0]!];
+  usage = 100_000 * realScale;
+  r = await fire();
+  assert.equal(nudgeCount(r), 0, "r1: anchored, no nudge");
+
+  for (let i = 1; i <= 6; i++) {
+    // r2..r7: +1K est per round → Δreal/Δest = realScale each round.
+    // r2: sample 1 (pending); r3: sample 2 → ADOPT density = realScale.
+    entries = all.slice(0, i + 1);
+    usage += 1_000 * realScale;
+    r = await fire();
+  }
+
+  // r7: raw sent view = 106K (53% of 200K — would stay idle); calibrated =
+  // 106K × realScale. At 1.6 that is 169.6K (84.8%) → crosses the 75% forced
+  // nudge threshold and must fire; at 1.0 it stays idle.
+  await rm(`${stateFile}.acp.json`, { force: true });
+  return nudgeCount(r);
+}
+
+test("forced nudge fires on the calibrated scale (density 1.6) but not on the raw scale", async () => {
+  // Control: provider usage matches the raw estimate → density 1.0 →
+  // 103K / 200K = 51.5% → no forced nudge.
+  const control = await runCalibratedScenario(1.0);
+  assert.equal(control, 0, "raw-scale session at 51.5% must not trip the forced nudge");
+
+  // Calibrated: same message bytes, provider usage runs 1.6× the estimate
+  // (a CJK-heavy session). Raw view reads 51.5%, real view reads ~82%.
+  const calibrated = await runCalibratedScenario(1.6);
+  assert.ok(calibrated >= 1, "calibrated 82.4% must cross the 75% forced-nudge threshold");
+});

--- a/tests/density.test.ts
+++ b/tests/density.test.ts
@@ -68,9 +68,10 @@ test("negative Δest (compression round) is skipped and does not corrupt anchor"
   d.update(MODEL, 100_000, 20_000); // Δest = -31_000 → skip
   // 压缩后第一轮 postCompression=true → 跳过
   d.update(MODEL, 100_000, 20_000, true);
-  // 之后正常轮继续，锚点仍是压缩前的（Δest 累积窗口拉长）
-  d.update(MODEL, 101_600, 51_000); // 与 anchor 的 Δ 相同 → instant 1.6, pending
-  d.update(MODEL, 103_200, 52_000); // confirm → adopt
+  // 下一轮：在干净的压缩后基准上重新锚定（锚点不再跨越压缩事件）
+  d.update(MODEL, 101_600, 51_000); // re-anchor，不采样
+  d.update(MODEL, 103_200, 52_000); // Δ=(1600,1000) → 1.6 pending
+  d.update(MODEL, 104_800, 53_000); // 1.6 confirm → adopt
   assert.equal(d.densityFor(MODEL), 1.6);
 });
 
@@ -150,5 +151,52 @@ test("null realTotal freezes anchors without corrupting", () => {
   d.update(MODEL, 101_600, 51_000); // 1.6 pending
   d.update(MODEL, null, 52_000); // 无 usage → 跳过
   d.update(MODEL, 103_200, 52_000); // 与 anchor 差 3200/2000 = 1.6 → confirm → adopt
+  assert.equal(d.densityFor(MODEL), 1.6);
+});
+
+// ─── post-compression re-anchoring (fixes the pre-compression-anchor dead zone) ───
+
+test("re-anchors on the round AFTER postCompression — no dead zone", () => {
+  const d = est();
+  d.update(MODEL, 300_000, 200_000); // anchor
+  d.update(MODEL, 301_600, 201_000); // 1.6 pending
+  d.update(MODEL, 303_200, 202_000); // 1.6 adopt
+  assert.equal(d.densityFor(MODEL), 1.6);
+  // compression frees 100K est / 150K real; next context round reports the
+  // (still stale, pre-compression-sized) usage
+  d.update(MODEL, 303_000, 100_000, true); // postCompression → set skip
+  // one round later: usage caught up to the compressed context → re-anchor here
+  d.update(MODEL, 151_500, 101_000);
+  // resampling starts from the NEW anchor immediately (no 100K regrowth wait)
+  d.update(MODEL, 153_100, 102_000); // Δ=(1600,1000) → 1.6 pending
+  d.update(MODEL, 154_700, 103_000); // 1.6 confirm → adopt
+  assert.equal(d.densityFor(MODEL), 1.6);
+});
+
+test("re-anchoring discards the pre-compression pending confirmation", () => {
+  const d = est();
+  d.update(MODEL, 300_000, 200_000); // anchor
+  d.update(MODEL, 301_600, 201_000); // 1.6 pending (count=1) — not yet adopted
+  // compress before confirmation completes
+  d.update(MODEL, 301_600, 100_000, true); // postCompression → skip
+  d.update(MODEL, 151_600, 101_000); // re-anchor; stale pending(1.6) must be dropped
+  // if the stale pending survived, this sample would be the 2nd confirmation
+  // and adopt immediately — it must instead start a FRESH count=1
+  d.update(MODEL, 153_200, 102_000); // 1.6 → pending only
+  assert.equal(d.densityFor(MODEL), 1, "fresh confirmation cycle must not adopt on its first sample");
+  d.update(MODEL, 154_800, 103_000); // 2nd consistent sample → adopt
+  assert.equal(d.densityFor(MODEL), 1.6);
+});
+
+test("null usage on the re-anchor round defers the re-anchor without losing the flag", () => {
+  const d = est();
+  d.update(MODEL, 300_000, 200_000);
+  d.update(MODEL, 301_600, 201_000);
+  d.update(MODEL, 303_200, 202_000); // adopt 1.6
+  d.update(MODEL, 303_200, 100_000, true); // postCompression
+  d.update(MODEL, null, 100_500); // usage missing → flag must persist
+  d.update(MODEL, 151_500, 101_000); // re-anchor now
+  d.update(MODEL, 153_100, 102_000); // pending
+  d.update(MODEL, 154_700, 103_000); // adopt
   assert.equal(d.densityFor(MODEL), 1.6);
 });


### PR DESCRIPTION
Fixes three gaps left by #155 / #150, found in post-merge review (评估最近 48h 合并 PR 的 bug 回归审查).

## 1. `postCompression` flag was dead code (medium-low)
`src/index.ts` compared a single `processTurn` input/output state for new active blocks. But blocks are only created by `applyCompression` (compress tool) **between** context events — kernel 0.0.27's only `blocks.push` is inside `applyCompression`. The comparison was always `false`; the D7/F1 post-compression skip never engaged in production (unit tests called `update()` directly, masking it).
**Fix:** runtime tracks per-session active block ids across context rounds (`noteActiveBlocks` / `clearSessionTracking`); a new active block on the *loaded* state sets the flag.

## 2. Density anchor never reset after compression (medium)
Probe with the real estimator: a 100K-est compression left the pre-compression anchor in place, blocking resampling until the estimate regrew past it (~100 rounds of 1K/round growth) — density stayed stale exactly when the content mix changed, and the first crossing sample could be a clamped 0.5 outlier.
**Fix:** the post-compression skip round now re-anchors on the clean post-compression basis and drops the stale pending confirmation (re-anchor happens one round *after* the compression round, because that round's provider usage may still reflect the pre-compression size).

## 3. Usage/emergency arbitration uncalibrated (medium)
`decideNudge`: `usage = tokenCount/limit` → drives the 75% forced nudge and 95% emergency truncate. All 4 `processTurn` sites passed the **raw** CJK-aware estimate, which under-reports CJK context ~20-40% (real/est ≈ 1.2-1.6) → safety valves fire well past the real window (possible "prompt too long" on small windows). The density estimator — which computes exactly that ratio — was next door but only fed the kernel's internal `countTokens`.
**Fix:** all 4 sites now pass `calibrateTokens(sentTokens, density)` (new helper in `src/tokens.ts`); the estimator is still fed the **raw** sentTokens (samples must not chase their own calibration). One-time scale flip when density is adopted moves decisions *toward* the true usage, so no stamp re-baselining is needed.

## Also
- `docs/token-calibration-plan.md`: frozen spec aligned with implementation — T2/T3 pending **does** scale with the shared injected countTokens (original "不乘" decision not implementable without a kernel split; documented as as-is), mid-session model switches handled by per-model isolation + session_start reset (D6), re-anchor timing, postCompression detection method
- `CHANGELOG.md`: backfilled missing v0.1.37 / v0.1.38 entries + unreleased #140 / #145 / #155
- `src/compress-tool.ts`: fixed merge artifact (two statements on one line at old :78)

## Tests
- 3 new `density.test.ts` cases (re-anchor no dead zone; stale pending dropped; null-usage defers re-anchor without losing the flag) + 1 pre-existing case updated to the new semantics
- `tests/density-usage-fixes.test.ts`: runtime `noteActiveBlocks` unit + integration proving the forced nudge fires at calibrated 84.8% while the identical raw-scale session (53%) stays idle
- **315/315 unit, 5/5 e2e (real `pi -p`), typecheck + build clean**