### PR TITLE
build: dedupe acp-kernel in bundle (overrides for kit's pinned kernel)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3215,16 +3215,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/billion-context-kit/node_modules/acp-kernel": {
-			"version": "0.0.23",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
-			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/bundle-require": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"
+	},
+	"overrides": {
+		"billion-context-kit": {
+			"acp-kernel": "$acp-kernel"
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to the 48h-merge review: the kit-adoption PRs (#149/#150) left a **second acp-kernel in the shipped bundle**.

## Problem
`billion-context-kit` pins `acp-kernel: "0.0.23"` exactly (its AGENTS.md hard rule 3 — kept intentionally). npm therefore installs a nested `node_modules/billion-context-kit/node_modules/acp-kernel@0.0.23` next to the adapter's 0.0.27. tsup inlines both:

- `grep -c "function defaultCountTokens" dist/index.js` → **2** (was: one 0.0.27 + one 0.0.23)
- the panel code (kit's `buildStatusPanel`) ran 0.0.23's `formatRanges`/`defaultCountTokens` while the rest of the adapter ran 0.0.27's
- harmless today (both helpers verified byte-identical 0.0.23→0.0.27), but any future kernel change to counting/formatting/state shape silently drifts the shared panel, and the duplicate costs ~22KB

## Fix
npm `overrides` with the `$` self-reference — the kit's kernel resolves to whatever the top-level declares, tracking future bumps automatically:

```json
"overrides": { "billion-context-kit": { "acp-kernel": "$acp-kernel" } }
```

No kit change, kit's exact-pin spec preserved for its own tree.

## Verified
- dist contains exactly one kernel copy (`defaultCountTokens` / `formatRanges` each ×1)
- bundle 492KB → 470KB
- 310/310 unit, 5/5 e2e (real `pi -p`), typecheck + build clean

Note: the sibling adapters (omp/opencode) that also inline the kit have the same latent duplication and would want the same one-line override.