### PR TITLE
build: align acp-kernel to 0.0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.27",
+				"acp-kernel": "0.0.28",
 				"billion-context-kit": "0.2.0",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
@@ -3186,9 +3186,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.27",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.27.tgz",
-			"integrity": "sha512-y3AtAanYWZRQHkTeP9z9i82XbMHTjFp/mq4Q5aK/gLVl+C/eUlKwjlCf/ht5RvjYFgbkjiYcmjJba7706pSm1Q==",
+			"version": "0.0.28",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.28.tgz",
+			"integrity": "sha512-1pdpu8xmIlVFxfO3oHzaigX8DhlYVyMr9o5sSYHRzcOfijCwhnnz3yJMeqT8Gb1WBnIyl5UyV9muhTa5A4D/Sg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.27",
+		"acp-kernel": "0.0.28",
 		"billion-context-kit": "0.2.0",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",


### PR DESCRIPTION
Ecosystem alignment (third consumer, after omp #84/#85 and billion-context proxy #165): acp-kernel 0.0.27 → 0.0.28.

0.0.28 adds wire format detection (`WIRE_FORMATS`/`detectWireFormat`) and the transform-channel policy on top of 0.0.27's subagent-namespace anchor store; the pi adapter is in-process (context transform always honored) so no behavior change is expected — this closes the version gap so all consumers ship one kernel.

Verification: `npm test` 315/315 pass with zero adaptation; `npm run typecheck` clean.