### PR TITLE
release v0.1.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.38",
+	"version": "0.1.39",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.38",
+			"version": "0.1.39",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.38",
+	"version": "0.1.39",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## v0.1.39

**fix(density)：Qwen/CJK 会话下 nudge/emergency 不触发的 bug 修复** — 本地估算对 Qwen3.8（中文+代码+JSON）系统性低估 ~2×，仲裁跑在低估刻度上，实际 95% 时估算才 ~47%，emergency 永远到不了（现场：实际 237,573/262,144 = 90.6% 时显示 29%）。本版带密度校准：provider 真实 usage 锚点学 real/est 密度（clamp [0.0.5,2.5] 区间 [0.5,2.5]、±20% 双轮确认、压缩后重锚），`calibrateTokens` 让 75% nudge / 95% emergency 在真实刻度上仲裁。实测（Qwen3.8-27B FP8, 262K）：3 轮收敛到 2.5，校准后首次 nudge 正常注入。

### 包含（since v0.1.38）
- **density 校准全套**（#155 + #158 + #159 + afce492）：累积锚点估计器、post-compression 重锚、out-of-band block 检测、calibrated usage 仲裁、tokenSnapshot 稳定标签数字（#146）
- **acp-kernel 0.0.28**（#160：wire formats + transform-channel policy）
- 三层 compress 配置（#145）、decompress toFile 加固（#140）、日志 model identity（#156）、kernel bundle 去重（#159）

### 版本
- `package.json` version 0.1.38 → 0.1.39（+ lock）

### 验证
- typecheck clean
- 315/315 tests pass
- build OK
- 真机验证：本地 pi（pi-stable 0.83.5 + Qwen3.8-27B via vllm）热装后密度 3 轮收敛 2.5，校准后 nudge 正常注入