### PR TITLE
fix: re-apply #109's omp long-session fixes on the current architecture

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -5,7 +5,7 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { debug, logError, logInfo, logThrow } from "./log.js";
+import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
 import { defaultCountTokens } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
@@ -103,7 +103,18 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   await runtime.save(applied.state, ctx);
   const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
 
-  const afterTokens = Math.max(0, beforeTokens - tokensCompressed);
+  // Re-measure the post-compression sent view on the SAME scale as beforeTokens
+  // (post-processTurn view: visible text + every active block's summary anchor
+  // + ref-tag overhead), so "X → Y (~Z reclaimed)" compares like-for-like —
+  // including the new block's own summary, which the model will pay for next.
+  const afterTurn = runtime.core.processTurn({
+    messages: coreMessages,
+    state: applied.state,
+    config,
+    tokenCount: calibrateTokens(sentTokens, density),
+  });
+  const afterTokens = calibrateTokens(estimateTokens(afterTurn.messages, collectCoveredMessageIds(applied.state)), density);
+  const reclaimed = Math.max(0, beforeTokens - afterTokens);
 
   const newBlocks = applied.state.blocks.slice(-blocksCreated);
   debug.event("compress-out", {
@@ -136,10 +147,10 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "errors", count: errors.length, errors: errors.slice(0, 5) });
   }
   if (warnings.length > 0) {
-    logError("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
+    logWarn("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
   }
 
-  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(tokensCompressed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
+  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(reclaimed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
   if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
   if (errors.length > 0) lines.push("Errors: " + errors.join("; "));
   return lines.join("\n");

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -314,6 +314,16 @@ export function makeEventApplier(
 const WAIT_TIMEOUT_MS_DEFAULT = 10_000;
 const WAIT_TIMEOUT_MS_MAX = 300_000;
 
+/** Resolve a wait timeout to ms. Agents frequently pass seconds (e.g. 180)
+ *  instead of milliseconds; values below the 1s floor make no sense as a wait
+ *  duration, so rescale them to seconds before clamping — otherwise 180 clamps
+ *  to 1000ms and the wait times out in 1s. */
+export function resolveWaitTimeoutMs(raw: number | undefined): number {
+  if (raw === undefined) return WAIT_TIMEOUT_MS_DEFAULT;
+  const ms = raw < 1_000 ? raw * 1_000 : raw;
+  return Math.min(Math.max(ms, 1_000), WAIT_TIMEOUT_MS_MAX);
+}
+
 const DelegateParams = Type.Object({
   agent: Type.String({
     description: `Role of the delegate. One of: ${AGENT_NAMES.join(", ")}. See tool description for what each does.`,
@@ -349,7 +359,7 @@ const WaitParams = Type.Object({
   runId: Type.String({ description: "The runId returned by acp_delegate to wait for." }),
   timeout: Type.Optional(
     Type.Integer({
-      description: `Maximum milliseconds to block waiting for the result. Default ${WAIT_TIMEOUT_MS_DEFAULT} (10s); max ${WAIT_TIMEOUT_MS_MAX} (300s). If the delegate does not finish in time, returns "failed (not ready)" — do NOT keep waiting or retry; go do other work, and a completion notification will still be injected when it completes.`,
+      description: `Maximum time to block waiting for the result, in milliseconds. Default ${WAIT_TIMEOUT_MS_DEFAULT} (10s); max ${WAIT_TIMEOUT_MS_MAX} (300s). Values below 1000 are treated as seconds (so 180 means 180s, not 180ms). If the delegate does not finish in time, returns "failed (not ready)" — do NOT keep waiting or retry; go do other work, and a completion notification will still be injected when it completes.`,
     }),
   ),
 });
@@ -557,10 +567,7 @@ export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof W
         }
         return buildWaitResult(run, formatRunResult(run), displayMode);
       }
-      const timeoutMs = Math.min(
-        Math.max(args.timeout ?? WAIT_TIMEOUT_MS_DEFAULT, 1_000),
-        WAIT_TIMEOUT_MS_MAX,
-      );
+      const timeoutMs = resolveWaitTimeoutMs(args.timeout);
       // Refuse to park a second waiter on the same run: a second wait would
       // overwrite run.waiter and orphan the first wait's listener/timer.
       if (run.waiter) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,10 @@ import { viableRanges } from "billion-context-kit";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
-import { debug, setDebugEnabled, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
+import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
-import { loadUserConfig, applyUserConfig } from "./user-config.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
 
@@ -79,10 +78,8 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const modelInfo = ctx.model as { id?: string; contextWindow?: number; api?: string } | undefined;
     logInfo("session", { event: "start", sid, cwd: ctx.cwd, debug: runtime.adapter.debug ?? null, version: typeof CURRENT_VERSION !== "undefined" ? CURRENT_VERSION : null, model: modelInfo?.id ?? null, modelApi: modelInfo?.api ?? null, contextWindow: modelInfo?.contextWindow ?? null });
     try {
-      const user = await loadUserConfig(ctx.cwd);
-      runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+      await runtime.reloadConfig(ctx.cwd);
       setDelegateDisplayUsage(resolveDelegate(runtime.adapter).displayUsage);
-      if (runtime.adapter.debug !== undefined) setDebugEnabled(runtime.adapter.debug);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
     }
@@ -124,6 +121,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const sid = ctx.sessionManager.getSessionId();
     const release = await runtime.acquireLock(sid);
     try {
+      await runtime.reloadConfig(ctx.cwd);
       // 每轮绑定 countTokens 使用的模型（密度校准按 model 隔离）
       const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
       runtime.setCountModel(modelId);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -12,7 +12,8 @@ import { resolveConfig, type AdapterConfig } from "./config.js";
 import { DensityEstimator } from "./density.js";
 import { entriesToCoreMessages, extractText, matchesStoredText, messageIdentity, messageRef } from "./messages.js";
 import { SessionStateStore, type LiveRefOrigin } from "./state.js";
-import { logInfo, logWarn } from "./log.js";
+import { loadUserConfig, applyUserConfig } from "./user-config.js";
+import { logInfo, logWarn, setDebugEnabled } from "./log.js";
 import { findUniqueLongestRun, type MatchRange } from "./sequence-match.js";
 // pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
 // `getBranch()`. Both return chronological SessionEntry[]; feature-detect so
@@ -51,7 +52,6 @@ export interface AcpRuntime {
   /** Drop per-session tracking state (session_start). */
   clearSessionTracking(sid: string): void;
   adapter: AdapterConfig;
-  setAdapter(adapter: AdapterConfig): void;
   prompts: Prompts;
   setPrompts(prompts: Prompts): void;
   markNudgeShown(turnKey: string): void;
@@ -59,6 +59,10 @@ export interface AcpRuntime {
   clearNudgeTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
   configFor(ctx: ExtensionContext): Config;
+  /** Re-read ~/.<dir>/acp.json + <cwd>/<dir>/acp.json and re-derive the adapter
+   *  config when the contents change. Cheap no-op when unchanged. Called at
+   *  session_start and on every context event so config edits apply live. */
+  reloadConfig(cwd: string): Promise<void>;
   stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
   save(state: CompressionState, ctx: ExtensionContext): Promise<void>;
   acquireLock(sid: string): Promise<() => void>;
@@ -209,7 +213,9 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const store = new SessionStateStore();
   const lastActiveBlockIds = new Map<string, Set<string>>();
   const locks = new Map<string, Promise<void>>();
+  const factoryAdapter = adapter;
   let adapterRef = adapter;
+  let lastUserConfigKey: string | undefined;
   let promptsRef: Prompts = defaultPrompts;
   const nudgeShownTurns = new Set<string>();
 
@@ -232,6 +238,28 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   function configFor(ctx: ExtensionContext): Config {
     const m = ctx.model as { provider?: string; id?: string } | undefined;
     return resolveConfig(adapterRef, liveContextLimit(ctx), m?.provider, m?.id);
+  }
+
+  async function reloadConfig(cwd: string): Promise<void> {
+    let user;
+    try {
+      user = await loadUserConfig(cwd);
+    } catch (e) {
+      logWarn("runtime", { event: "config-reload-failed", error: e instanceof Error ? e.message : String(e) });
+      return;
+    }
+    try {
+      const key = JSON.stringify(user);
+      if (key === lastUserConfigKey) return;
+      lastUserConfigKey = key;
+      // Re-derive from the factory config (not adapterRef) so a key REMOVED from
+      // acp.json actually reverts, instead of lingering from a prior apply.
+      adapterRef = applyUserConfig(factoryAdapter, user);
+      if (adapterRef.debug !== undefined) setDebugEnabled(adapterRef.debug);
+      logInfo("runtime", { event: "config-reloaded", limit: adapterRef.modelContextLimit ?? null });
+    } catch (e) {
+      logWarn("runtime", { event: "config-reload-failed", error: e instanceof Error ? e.message : String(e) });
+    }
   }
 
   async function stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]) {
@@ -276,4 +304,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, stateFor, save, acquireLock };}
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}

--- a/tests/compress-tool.test.ts
+++ b/tests/compress-tool.test.ts
@@ -110,3 +110,44 @@ test("compress beforeTokens scales with calibrated density (Phase 2)", async () 
   // est 603 + tag overhead (4 msgs × ~21 chars / 4) ≈ 645 × 1.6 ≈ 1032 → 1.0K
   assert.match(text, /▣ ACP \| 1\.0K →/);
 });
+
+// afterTokens (and hence "reclaimed") must be measured on the SAME scale as
+// beforeTokens — the post-processTurn sent view, which carries every active
+// block's summary anchor plus ref-tag overhead. Regressing to the raw
+// projection (no summaries, no tags) would over-claim reclaimed by the
+// cumulative summary mass of all blocks, exactly in long sessions.
+test("compress afterTokens is measured on the same sent-view scale as beforeTokens (multi-block)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-compress-scales.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const entries = [userMsg("e1", "hello world"), userMsg("e2", ZH), userMsg("e3", ZH2), userMsg("e4", ZH2)];
+  const ctx = fakeCtx(entries, stateFile);
+  ctx.__setUsage(100_000);
+  await runContextRound(handlers, ctx); // density anchor at 1
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  async function doCompress(callId: string, range: { startId: string; endId: string; summary: string }) {
+    const out = await compressTool.execute(callId, { content: [range] }, undefined, undefined, ctx);
+    return typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  }
+
+  await doCompress("tc1", { startId: "m00001", endId: "m00001", summary: "first block" });
+  const text = await doCompress("tc2", { startId: "m00003", endId: "m00003", summary: "second block" });
+
+  const m = /▣ ACP \| (\d+(?:\.\d+)?)(K?) → (\d+(?:\.\d+)?)(K?) tokens \(~(\d+(?:\.\d+)?)(K?) reclaimed/.exec(text);
+  assert.ok(m, `no ACP line in output: ${text}`);
+  const toTok = (n: string, k?: string) => (k === "K" ? Number(n) * 1000 : Number(n));
+  const before = toTok(m![1]!, m![2]);
+  const after = toTok(m![3]!, m![4]);
+  const reclaimed = toTok(m![5]!, m![6]);
+
+  // Visible-only (e2+e4) = 450. The true post-compression sent view adds the
+  // two summary anchors + tag overhead (~60) → afterTokens ≥ 480; a raw
+  // projection regression would report ~450.
+  assert.ok(after >= 480, `afterTokens ${after} missing the summary-anchor scale (raw projection would be ~450): ${text}`);
+  // True freed ≈ removed e3 (150) + tag delta − new summary (~170); a raw
+  // afterTokens would over-claim by block-1 summary + tags (~220).
+  assert.ok(reclaimed <= 180, `reclaimed ${reclaimed} over-claimed (raw afterTokens would be ~220): ${text}`);
+  assert.equal(before - after, reclaimed, "reclaimed consistent with the arrow");
+});

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -331,4 +331,31 @@ test("buildWaitResult merged mode does not accumulate delegateUsageTotal", () =>
   const result = buildWaitResult(run as any, "content", "merged");
   assert.ok(result.usage, "usage present in merged mode");
   assert.equal(getDelegateUsage(), undefined, "merged mode never accumulates");
+});
+
+// ─── resolveWaitTimeoutMs: small values treated as seconds (ISSUE-1) ──────
+
+test("resolveWaitTimeoutMs returns the default when undefined", () => {
+  assert.equal(resolveWaitTimeoutMs(undefined), 10_000);
+});
+
+test("resolveWaitTimeoutMs rescales sub-1000 values as seconds", () => {
+  assert.equal(resolveWaitTimeoutMs(180), 180_000);
+  assert.equal(resolveWaitTimeoutMs(60), 60_000);
+  assert.equal(resolveWaitTimeoutMs(1), 1_000);
+});
+
+test("resolveWaitTimeoutMs passes through values >= 1000 as ms, clamped to [1000, 300000]", () => {
+  assert.equal(resolveWaitTimeoutMs(1_000), 1_000);
+  assert.equal(resolveWaitTimeoutMs(45_000), 45_000);
+  assert.equal(resolveWaitTimeoutMs(300_000), 300_000);
+  assert.equal(resolveWaitTimeoutMs(500_000), 300_000);
+});
+
+test("resolveWaitTimeoutMs boundary: 999 → 300000 (seconds→clamp), 0/negative → 1000 floor", () => {
+  // The <1000 → seconds rescale means 999 becomes 999000 then clamps to the
+  // 300000 max — a sharp edge at the 999/1000 boundary, documented here.
+  assert.equal(resolveWaitTimeoutMs(999), 300_000);
+  assert.equal(resolveWaitTimeoutMs(0), 1_000);
+  assert.equal(resolveWaitTimeoutMs(-5), 1_000);
 });

--- a/tests/e2e-compress-config.test.ts
+++ b/tests/e2e-compress-config.test.ts
@@ -6,11 +6,11 @@ import { join } from "node:path";
 import { CONFIG_DIR_NAME, type ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { createInitialState, type CoreMessage } from "acp-kernel";
 import { createRuntime } from "../src/runtime.js";
-import { loadUserConfig, applyUserConfig } from "../src/user-config.js";
+import { loadUserConfig } from "../src/user-config.js";
 
 // E2E for the three-level compress cascade: writes a REAL acp.json and drives
-// the REAL production pipeline (loadUserConfig → applyUserConfig → setAdapter →
-// configFor, the exact functions wired at src/index.ts:71-72,117), as opposed
+// the REAL production pipeline (loadUserConfig → applyUserConfig → reloadConfig →
+// configFor, the exact functions wired at session_start / context events), as opposed
 // to the resolveCompress unit tests in config.test.ts.
 
 function ctxFor(provider: string | undefined, id: string | undefined, contextWindow: number): ExtensionContext {
@@ -52,7 +52,7 @@ test("e2e compress config: acp.json provider/model overrides take effect through
         assert.ok(user.compress, "acp.json compress block loaded from disk");
 
         const runtime = createRuntime({});
-        runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+        await runtime.reloadConfig(cwd);
 
         const sonnet = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
         assert.equal(sonnet.nudge.maxContextLimitPct, 0.7, "model-level maxContextLimit 70% reaches the kernel");
@@ -75,7 +75,7 @@ test("e2e compress config: acp.json provider/model overrides take effect through
 test("e2e compress config: a single runtime resolves differently per model (proves per-turn, not static)", async () => {
     await withConfigDir(ACP_JSON, async (cwd) => {
         const runtime = createRuntime({});
-        runtime.setAdapter(applyUserConfig(runtime.adapter, await loadUserConfig(cwd)));
+        await runtime.reloadConfig(cwd);
         const sonnet = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
         const haiku = runtime.configFor(ctxFor("anthropic", "claude-haiku", 200_000));
         const openai = runtime.configFor(ctxFor("openai", "gpt-4o", 200_000));
@@ -91,7 +91,7 @@ test("e2e compress config: without a config file the kernel defaults apply", asy
         const user = await loadUserConfig(cwd);
         assert.deepEqual(user, {}, "no acp.json anywhere (HOME + cwd) → empty user config");
         const runtime = createRuntime({});
-        runtime.setAdapter(applyUserConfig(runtime.adapter, user));
+        await runtime.reloadConfig(cwd);
         const cfg = runtime.configFor(ctxFor("anthropic", "claude-sonnet-4-5", 200_000));
         assert.equal(cfg.nudge.maxContextLimitPct, 0.75, "kernel default maxContextLimitPct");
         assert.equal(cfg.nudge.emergencyThresholdPct, 0.95, "kernel default emergencyThresholdPct");
@@ -121,7 +121,7 @@ test("e2e compress config: a 2w limit fires the compress nudge at 2w tokens; a 1
     await withConfigDir(ACP_JSON, async (cwd) => {
         process.env.HOME = cwd;
         const runtime = createRuntime({});
-        runtime.setAdapter(applyUserConfig(runtime.adapter, await loadUserConfig(cwd)));
+        await runtime.reloadConfig(cwd);
         const tokenCount = 20_000;
 
         const small = runtime.configFor(ctxFor("openai", "gpt-4o", 20_000));

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -714,3 +714,47 @@ test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the syste
   // Core ACP prompt is still present — only the delegate section is dropped.
   assert.ok(result.systemPrompt.includes("ACP TAGS"), "core ACP prompt still present when delegate disabled");
 });
+
+// ─── ISSUE-9: modelContextLimit changes in <cwd>/.pi/acp.json hot-reload ──
+
+test("modelContextLimit changes in .pi/acp.json are picked up on the next context event", async () => {
+  (globalThis as Record<string, unknown>).CURRENT_VERSION ??= "0.0.0-test";
+  const { mkdtempSync, writeFileSync, rmSync, mkdirSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { formatCompactTokens } = await import("billion-context-kit");
+
+  const tmp = mkdtempSync(join(tmpdir(), "acp-hotreload-"));
+  const piDir = join(tmp, ".pi");
+  mkdirSync(piDir, { recursive: true });
+  const acpJson = join(piDir, "acp.json");
+  writeFileSync(acpJson, JSON.stringify({ modelContextLimit: 100_000 }));
+
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+
+    function ctxWithCwd() {
+      return { ...fakeCtx([], join(tmp, "state.json")), cwd: tmp };
+    }
+    async function acpStatus(): Promise<string> {
+      let captured = "";
+      const ctx = {
+        ...fakeCtx([], join(tmp, "state.json")),
+        cwd: tmp,
+        ui: { notify: (s: string) => { captured = s; }, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+      };
+      await api.commands.get("acp").handler([], ctx);
+      return captured;
+    }
+
+    await handlers.get("context")![0]!({ type: "context", messages: [] }, ctxWithCwd());
+    assert.ok((await acpStatus()).includes(formatCompactTokens(100_000)), "initial limit reflects acp.json modelContextLimit=100000");
+
+    writeFileSync(acpJson, JSON.stringify({ modelContextLimit: 250_000 }));
+    await handlers.get("context")![0]!({ type: "context", messages: [] }, ctxWithCwd());
+    assert.ok((await acpStatus()).includes(formatCompactTokens(250_000)), "rewritten modelContextLimit=250000 hot-reloaded on next context event");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Re-implementation of #109 (its branch is 119 commits behind and the areas it touched were rewritten by #150/#155/#158 — a direct merge would conflict). The four fixes have **zero overlap** with current master and each still reproduces on it.

## Fixes (all from the #109 findings)

- **ISSUE-1 (P0) — `acp_delegate_wait` timeout unit**: `timeout: 180` (seconds, matching the tool's own example "wait 180s") hit the raw-millisecond path and was clamped to 1s. Now `resolveWaitTimeoutMs`: values below 1000 are seconds (180 → 180s), ≥ 1000 stay ms, clamped to [1000, 300000]. Param description documents the rule.
- **ISSUE-2 (P0) — compress "X → Y (~Z reclaimed)" line**: both ends are now measured on the same scale — the post-processTurn sent view (visible text + every active block's summary anchor + ref-tag overhead), re-run on the post-compression state. The old subtraction mixed a calibrated `beforeTokens` with the kernel's raw `tokensCompressed`; and a raw-projection `afterTokens` would under-report Y and **inflate Z by the cumulative block-summary mass** in multi-block sessions (exactly the long-session scenario). New regression test pins the multi-block scale (afterTokens carries both summary anchors; reclaimed ≈ removed range only).
- **ISSUE-5 (P1) — log level**: warnings emitted as `logWarn`, not `logError`.
- **ISSUE-9 (P1) — user-config hot-reload**: configFor-path keys (`modelContextLimit`, guardrails, `autoUpdate`, delegate prompt toggle) in `~/.pi/acp.json` / `<cwd>/.pi/acp.json` re-read on every context event via `runtime.reloadConfig(cwd)` — memoized on the config's JSON key, re-derives from the factory adapter so key **removals** revert to defaults. Session-start keys (prompts, delegate tool registration, `displayUsage`) still apply at session_start (unchanged). `setAdapter` is gone from the runtime interface.

## Verification

- `npm run typecheck` clean
- `npm test`: **321/321** (315 before + 4 `resolveWaitTimeoutMs` unit tests incl. 999→300000/0/−5 boundary, +1 multi-block afterTokens-scale regression test, +1 integration hot-reload test asserting the /acp panel limit goes 100K→250K across a file rewrite)
- Existing e2e-compress-config tests switched from the removed `setAdapter` to `reloadConfig` (same observable behavior, 4 call sites)

Replaces #109 (left open for the author to close after review).