### PR TITLE
release v0.1.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.39",
+	"version": "0.1.40",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.39",
+			"version": "0.1.40",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.39",
+	"version": "0.1.40",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release 0.1.39 → 0.1.40. Release commit touches only `package.json` + lock; CI `release.yml` publishes on merge.

## Changes since v0.1.39 (2 commits)

- `bde906b` fix: apply #109's omp long-session fixes on the current architecture (re-based onto the post-kernel-wire codebase)
- `4eb7c6f` merge #163

No dependency changes: `acp-kernel` stays at 0.0.28 and `billion-context-kit` at 0.2.0 — both already at npm latest.

## Preflight
- `npm ci` + typecheck + build + test: **321/321 pass**