### PR TITLE
feat: auto-retry provider token rate-limit errors (Bedrock throttle) with progressive backoff

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -35,6 +35,11 @@ Create `~/.pi/acp.json` (or `<project>/.pi/acp.json`) and drop in whichever keys
   "toolBashDefaultTimeout": 60,
   "toolOutputMaxBytes": 200000,
 
+  "throttleRetry": {
+    "enabled": true,
+    "maxRetries": 10
+  },
+
   "delegate": {
     "enabled": true,
     "displayUsage": "separate"
@@ -93,6 +98,7 @@ All keys below are currently **ACTIVE**.
 | `modelContextLimit` | number | *(auto)* | 🟢 ACTIVE | Override the context limit (in tokens). |
 | `toolBashDefaultTimeout` | number | `60` | 🟢 ACTIVE | Default `bash` tool timeout in seconds when the model omits it. |
 | `toolOutputMaxBytes` | number | `200000` | 🟢 ACTIVE | Hard byte cap on tool result text. |
+| `throttleRetry` | boolean \| object | `true` | 🟢 ACTIVE | Auto-retry provider token rate-limit errors with progressive backoff. |
 
 **Delegate keys**
 
@@ -100,6 +106,16 @@ All keys below are currently **ACTIVE**.
 |-----|------|---------|--------|-------------|
 | `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | Enable the `acp_delegate` tools and their system-prompt section. |
 | `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | Controls how delegate sub-agent token usage is reported. |
+
+**Provider throttle retry keys**
+
+| Key | Type | Default | Status | Description |
+|-----|------|---------|--------|-------------|
+| `throttleRetry.enabled` | boolean | `true` | 🟢 ACTIVE | Enable auto-retry of provider token rate-limit errors. |
+| `throttleRetry.maxRetries` | number | `10` | 🟢 ACTIVE | Total budget of ACP-driven retries per error episode. |
+| `throttleRetry.baseDelayMs` | number | `60000` | 🟢 ACTIVE | Delay before the first paced kick. |
+| `throttleRetry.maxDelayMs` | number | `300000` | 🟢 ACTIVE | Cap for paced kick delays. |
+| `throttleRetry.backoffMode` | string | `"exponential"` | 🟢 ACTIVE | Delay progression: `"exponential"` (×2 per kick) or `"fixed"`. |
 
 **Compression keys**
 
@@ -189,6 +205,76 @@ The `delegate` sub-object controls the `acp_delegate` sub-agent tool family (`ac
 - **Default:** `"separate"`
 - **Status:** 🟢 ACTIVE
 - **Description:** Controls how delegate sub-agent token usage is reported back to the main session. `"separate"` (default) tracks delegate tokens in a separate accumulator — the main session totals stay clean and delegate usage shows as its own block in `acp_status` (excluded from main totals). `"merged"` folds delegate token usage into the tool-result `usage` field so it is counted as part of the main session totals. Only meaningful when `delegate.enabled` is `true`.
+
+---
+
+## Provider Throttle Retry
+
+The `throttleRetry` key controls auto-retry of **provider-side token rate-limit errors** — e.g. AWS Bedrock's per-minute token-throughput quota, whose standard error text is `"Too many tokens, please wait before trying again."` When the relay streams that error as content with a non-standard `finish_reason`, it surfaces to Pi as `Provider finish_reason: error_finish` and fails the turn immediately: Pi's built-in retry does not recognize the signature, and it must not be treated as context overflow.
+
+How it works:
+
+1. When a turn ends in a recognized throttle error, ACP rewrites the error so Pi's **native retry** re-runs the same turn (no duplicate user message, the error is kept out of the LLM context, native TUI retry indicator). Pi's native budget is small and fast (3 attempts, 2s base).
+2. When a run still ends in a throttle error and ACP's budget allows, ACP waits a **progressive delay** (default: 60s, 120s, 240s, … capped at 5 minutes), then sends one auto-marked user message (starts with `[ACP:provider-throttle]`) that resumes the interrupted step.
+3. The model is instructed to resume where it left off (system-prompt note). Sending new input during a wait **cancels** the pending retry. When the budget is exhausted, the error is surfaced to you unchanged.
+
+> **Not retried** (deliberately left to Pi's own behavior or to fail-fast): real context-overflow errors (`prompt is too long`, …), quota/billing exhaustion (`quota exceeded`, `billing`, …), and generic 429s.
+
+> **Strict pacing (optional):** By default ACP lets Pi's native fast retries run first and then paces on its own. If you want *only* ACP's paced kicks (e.g. a very tight tokens/minute quota), additionally set Pi's own retry off via `"retry": { "enabled": false }` in `~/.pi/settings.json`.
+
+### `throttleRetry`
+
+- **Type:** `boolean | object`
+- **Default:** `true` (object form with all defaults)
+- **Status:** 🟢 ACTIVE
+- **Description:** Enable/disable auto-retry of provider token rate-limit errors and tune its budget. `throttleRetry: false` disables the feature entirely. Object form (any subset):
+
+```json
+{
+  "throttleRetry": {
+    "enabled": true,
+    "maxRetries": 10,
+    "baseDelayMs": 60000,
+    "maxDelayMs": 300000,
+    "backoffMode": "exponential"
+  }
+}
+```
+
+### `throttleRetry.enabled`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** 🟢 ACTIVE
+- **Description:** Turn the feature on/off. `false` (or top-level `throttleRetry: false`) restores the original fail-fast behavior.
+
+### `throttleRetry.maxRetries`
+
+- **Type:** `number` (integer ≥ 1)
+- **Default:** `10`
+- **Status:** 🟢 ACTIVE
+- **Description:** Total budget of ACP-driven retries for one error episode (a run ending in the same throttle error, plus the paced kicks it triggers). Any successful non-error response — or a new user message — starts a fresh episode. Exhausted → the error is surfaced to you as-is.
+
+### `throttleRetry.baseDelayMs`
+
+- **Type:** `number` (milliseconds)
+- **Default:** `60000`
+- **Status:** 🟢 ACTIVE
+- **Description:** Delay before the first paced kick — sized for Bedrock's per-minute rolling quota window. `maxDelayMs` is forced to at least this value.
+
+### `throttleRetry.maxDelayMs`
+
+- **Type:** `number` (milliseconds)
+- **Default:** `300000`
+- **Status:** 🟢 ACTIVE
+- **Description:** Cap for paced kick delays in `"exponential"` mode (60s → 120s → 240s → 300s → 300s … with defaults). Ignored in `"fixed"` mode, which always uses `baseDelayMs`.
+
+### `throttleRetry.backoffMode`
+
+- **Type:** string enum `"exponential" | "fixed"`
+- **Default:** `"exponential"`
+- **Status:** 🟢 ACTIVE
+- **Description:** Delay progression between paced kicks: `"exponential"` doubles the delay per kick (capped at `maxDelayMs`); `"fixed"` repeats `baseDelayMs` every kick.
 
 ---
 

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -35,6 +35,11 @@
   "toolBashDefaultTimeout": 60,
   "toolOutputMaxBytes": 200000,
 
+  "throttleRetry": {
+    "enabled": true,
+    "maxRetries": 10
+  },
+
   "delegate": {
     "enabled": true,
     "displayUsage": "separate"
@@ -93,6 +98,7 @@
 | `modelContextLimit` | number | *(自动)* | 🟢 ACTIVE | 覆盖上下文窗口大小（token 数）。 |
 | `toolBashDefaultTimeout` | number | `60` | 🟢 ACTIVE | 模型省略 `timeout` 时注入 bash 工具的默认超时秒数。 |
 | `toolOutputMaxBytes` | number | `200000` | 🟢 ACTIVE | 工具返回文本的硬性字节上限。 |
+| `throttleRetry` | boolean \| object | `true` | 🟢 ACTIVE | 自动重试 provider 侧 token 限流错误（递进退避）。 |
 
 **delegate 键**
 
@@ -100,6 +106,16 @@
 |----|------|--------|------|------|
 | `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | 启用 `acp_delegate` 工具及其系统提示部分。 |
 | `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | 控制 delegate 子代理的 token 用量如何报回主会话。 |
+
+**provider 限流重试键**
+
+| 键 | 类型 | 默认值 | 状态 | 说明 |
+|----|------|--------|------|------|
+| `throttleRetry.enabled` | boolean | `true` | 🟢 ACTIVE | 启用 provider token 限流错误的自动重试。 |
+| `throttleRetry.maxRetries` | number | `10` | 🟢 ACTIVE | 单个错误 episode 内 ACP 驱动重试的总预算。 |
+| `throttleRetry.baseDelayMs` | number | `60000` | 🟢 ACTIVE | 首次递进 kick 前的等待毫秒数。 |
+| `throttleRetry.maxDelayMs` | number | `300000` | 🟢 ACTIVE | 递进 kick 延迟上限。 |
+| `throttleRetry.backoffMode` | string | `"exponential"` | 🟢 ACTIVE | 延迟递进方式：`"exponential"`（每次 kick ×2）或 `"fixed"`。 |
 
 **compress 键**
 
@@ -189,6 +205,76 @@
 - **默认值：** `"separate"`
 - **状态：** 🟢 ACTIVE
 - **说明：** 控制 delegate 子代理的 token 用量如何报回主会话。`"separate"`（默认）将 delegate token 记入独立累加器——主会话总量保持干净，delegate 用量在 `acp_status` 中单独显示一块（不计入主总量）。`"merged"` 将 delegate token 用量并入工具返回的 `usage` 字段，算作主会话总量的一部分。仅在 `delegate.enabled` 为 `true` 时有意义。
+
+---
+
+## Provider 限流重试
+
+`throttleRetry` 键控制对 **provider 侧 token 限流错误** 的自动重试——例如 AWS Bedrock 的每分钟 token 吞吐量配额，其标准报错文案是 `"Too many tokens, please wait before trying again."`。当 relay 把这个错误 JSON 塞进流式 content 并带上非标准 `finish_reason` 时，Pi 侧表现为 `Provider finish_reason: error_finish` 并立即失败：Pi 内置重试不认识这个特征，而且它绝不能被当成上下文超长处理。
+
+工作方式：
+
+1. turn 以被识别的限流错误结束时，ACP 改写错误信息，让 Pi 的 **原生重试** 重跑同一个 turn（不重复用户消息、错误不进 LLM 上下文、原生 TUI 重试指示器）。Pi 原生预算小且快（3 次、2s 起步）。
+2. 如果一次 run 仍然以限流错误结束且 ACP 预算允许，ACP 等待 **递进延迟**（默认：60s、120s、240s……上限 5 分钟），然后发送一条带标记的用户消息（以 `[ACP:provider-throttle]` 开头）恢复被中断的步骤。
+3. 模型会被提示从中断处继续（系统提示说明）。等待期间用户发送新输入会 **取消** 挂起的重试。预算用尽后，错误原样呈现给你。
+
+> **不重试**（刻意留给 Pi 自身行为或直接失败）：真正的上下文超长错误（`prompt is too long` 等）、配额/计费耗尽（`quota exceeded`、`billing` 等）、以及通用 429。
+
+> **严格节奏（可选）：** 默认 ACP 先让 Pi 原生快速重试跑，再自行递进等待。如果你只想用 ACP 的递进 kick（例如 tokens/分钟配额很紧），另外在 `~/.pi/settings.json` 里设 `"retry": { "enabled": false }` 关掉 Pi 自身重试。
+
+### `throttleRetry`
+
+- **类型：** `boolean | object`
+- **默认值：** `true`（等价于全默认的 object 形式）
+- **状态：** 🟢 ACTIVE
+- **说明：** 启用/禁用 provider token 限流错误的自动重试，并调整其预算。`throttleRetry: false` 完全关闭该功能（恢复原始 fail-fast 行为）。object 形式（任意子集）：
+
+```json
+{
+  "throttleRetry": {
+    "enabled": true,
+    "maxRetries": 10,
+    "baseDelayMs": 60000,
+    "maxDelayMs": 300000,
+    "backoffMode": "exponential"
+  }
+}
+```
+
+### `throttleRetry.enabled`
+
+- **类型：** `boolean`
+- **默认值：** `true`
+- **状态：** 🟢 ACTIVE
+- **说明：** 开关。`false`（或顶层 `throttleRetry: false`）恢复原始 fail-fast 行为。
+
+### `throttleRetry.maxRetries`
+
+- **类型：** `number`（整数 ≥ 1）
+- **默认值：** `10`
+- **状态：** 🟢 ACTIVE
+- **说明：** 单个错误 episode（一次以同一限流错误结束的 run + 它触发的递进 kick）内 ACP 驱动重试的总预算。任何一次成功的非错误响应——或新的用户消息——都会开启新 episode。用尽后错误原样呈现。
+
+### `throttleRetry.baseDelayMs`
+
+- **类型：** `number`（毫秒）
+- **默认值：** `60000`
+- **状态：** 🟢 ACTIVE
+- **说明：** 首次递进 kick 前的等待毫秒数——按 Bedrock 分钟级滚动配额窗口设计。`maxDelayMs` 会被强制至少等于该值。
+
+### `throttleRetry.maxDelayMs`
+
+- **类型：** `number`（毫秒）
+- **默认值：** `300000`
+- **状态：** 🟢 ACTIVE
+- **说明：** `"exponential"` 模式下递进 kick 的延迟上限（默认参数下为 60s → 120s → 240s → 300s → 300s……）。`"fixed"` 模式下忽略，始终使用 `baseDelayMs`。
+
+### `throttleRetry.backoffMode`
+
+- **类型：** 字符串枚举 `"exponential" | "fixed"`
+- **默认值：** `"exponential"`
+- **状态：** 🟢 ACTIVE
+- **说明：** 递进 kick 之间的延迟递进方式：`"exponential"` 每次 kick 延迟翻倍（上限 `maxDelayMs`）；`"fixed"` 每次 kick 固定 `baseDelayMs`。
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { defaultConfig, type Config, type Prompts } from "acp-kernel";
+import type { ThrottleRetryConfig } from "./throttle-retry.js";
 
 /** Delegate sub-agent configuration. */
 export interface DelegateConfig {
@@ -93,6 +94,11 @@ export interface AdapterConfig {
   delegate?: boolean | DelegateConfig;
   /** Compression tuning. */
   compress?: CompressConfig;
+  /** Provider token-throttle (Bedrock "Too many tokens, please wait before
+   *  trying again.") auto-retry. Accepts a boolean shorthand (`false`
+   *  disables) or a ThrottleRetryConfig object. Default: enabled, 10 retries,
+   *  60s exponential base capped at 300s per kick. */
+  throttleRetry?: boolean | ThrottleRetryConfig;
   /** Legacy flat alias for `delegate.displayUsage`. Kept for backward
    *  compatibility with existing acp.json files. Prefer `delegate.displayUsage`. */
   displayUsage?: "merged" | "separate";

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,15 @@ import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./l
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
+import {
+  THROTTLE_RETRY_ERROR_MESSAGE,
+  THROTTLE_KICK_TEXT,
+  abortableSleep,
+  isKickMessage,
+  isThrottleError,
+  resolveThrottleRetry,
+  throttleDelayMs,
+} from "./throttle-retry.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
 
@@ -38,6 +47,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
     wireToolGuardrails(pi, runtime);
+    wireThrottleRetry(pi, runtime);
     pi.registerTool(makeCompressTool(runtime));
     pi.registerTool(makeDecompressTool(runtime));
     pi.registerTool(makeSearchTool(runtime));
@@ -64,6 +74,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("session_start", async (_event, ctx) => {
     runtime.store.invalidate();
     runtime.clearNudgeTracking();
+    runtime.throttle.reset();
     // 新会话重置该模型的密度校准（文档 §5.3：模型/窗口切换时重新收敛）
     const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
     runtime.density.resetModel(modelId);
@@ -282,6 +293,81 @@ function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const acp = buildAcpSystemPrompt(runtime.prompts);
     const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;
     return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, prompt) };
+  });
+}
+
+// Bedrock per-minute token-throttle auto-retry (hybrid design):
+//  1. message_end (sync, no sleep): when a finalized assistant message is a
+//     provider throttle error, rewrite its errorMessage to a pi-retryable
+//     form. Pi's native post-run classifier then re-runs the same turn via
+//     agent.continue() (error message removed from LLM state, native TUI
+//     indicator) within its own in-memory budget (default 3).
+//  2. agent_settled: if the run still ended on a rewritten throttle error and
+//     the ACP episode budget remains, ACP sleeps its own progressive delay
+//     (60s exponential base, capped) then pi.sendUserMessage(kick) to resume
+//     the task — covering attempts Pi's in-memory budget refuses.
+//     agent_settled fires in _runAgentPrompt's finally (after all of pi's
+//     retry/compaction/continue decisions) with the agent idle, so the sleep
+//     blocks nothing; ctx.signal is undefined there, so ACP keeps its own
+//     AbortController. Any non-kick user input cancels the pending kick
+//     (input event, source !== "extension"); the throttled error stays in
+//     context and the system-prompt line guides the model to resume.
+function wireThrottleRetry(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  pi.on("message_end", (event, ctx) => {
+    const msg = event.message;
+    if (msg.role === "user") {
+      runtime.throttle.onUserMessage(isKickMessage(msg));
+      return;
+    }
+    if (msg.role !== "assistant") return;
+    if (msg.stopReason !== "error") {
+      runtime.throttle.onProgress();
+      return;
+    }
+    if (!isThrottleError(msg)) {
+      runtime.throttle.onNonThrottleError();
+      return;
+    }
+    const cfg = resolveThrottleRetry(runtime.adapter.throttleRetry);
+    if (!cfg.enabled) {
+      runtime.throttle.onNonThrottleError();
+      return;
+    }
+    const decision = runtime.throttle.onThrottleError(cfg.maxRetries);
+    if (decision === "exhausted") {
+      logWarn("throttle-retry", { sid: ctx.sessionManager.getSessionId(), event: "budget-exhausted", max: cfg.maxRetries });
+      if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — retry budget exhausted (${cfg.maxRetries}); surfacing error`);
+      return;
+    }
+    logInfo("throttle-retry", { sid: ctx.sessionManager.getSessionId(), event: "rewrite", attempt: runtime.throttle.state.attempts, max: cfg.maxRetries, path: "native" });
+    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — retry ${runtime.throttle.state.attempts}/${cfg.maxRetries} (fast probe)`);
+    return { message: { ...msg, errorMessage: THROTTLE_RETRY_ERROR_MESSAGE } };
+  });
+  pi.on("agent_settled", async (_event, ctx) => {
+    const cfg = resolveThrottleRetry(runtime.adapter.throttleRetry);
+    if (!cfg.enabled || !runtime.throttle.readyToKick(cfg.maxRetries)) return;
+    const kickNumber = runtime.throttle.state.kicks + 1;
+    const delayMs = throttleDelayMs(kickNumber, cfg);
+    runtime.throttle.onKickStarted();
+    const sid = ctx.sessionManager.getSessionId();
+    logInfo("throttle-retry", { sid, event: "kick-sleep", kickNumber, delayMs });
+    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — waiting ${Math.round(delayMs / 1000)}s before retry ${runtime.throttle.state.attempts + 1}/${cfg.maxRetries}`);
+    const result = await abortableSleep(delayMs, runtime.throttle.sleepController().signal);
+    if (result === "aborted") {
+      runtime.throttle.onKickCancelled();
+      logInfo("throttle-retry", { sid, event: "kick-cancelled", kickNumber });
+      if (ctx.hasUI) ctx.ui.notify("[ACP] throttle retry cancelled (user input received)");
+      return;
+    }
+    if (!runtime.throttle.readyToKick(cfg.maxRetries)) return;
+    pi.sendUserMessage(THROTTLE_KICK_TEXT);
+    logInfo("throttle-retry", { sid, event: "kick-sent", kickNumber, attempt: runtime.throttle.state.attempts + 1, max: cfg.maxRetries });
+  });
+  pi.on("input", (event) => {
+    if (event.source !== "extension") runtime.throttle.cancelSleep();
+  });
+  pi.on("session_shutdown", () => {
+    runtime.throttle.reset();
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("session_start", async (_event, ctx) => {
     runtime.store.invalidate();
     runtime.clearNudgeTracking();
-    runtime.throttle.reset();
+    runtime.throttleFor(ctx.sessionManager.getSessionId()).reset();
     // 新会话重置该模型的密度校准（文档 §5.3：模型/窗口切换时重新收敛）
     const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
     runtime.density.resetModel(modelId);
@@ -314,60 +314,62 @@ function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
 //     context and the system-prompt line guides the model to resume.
 function wireThrottleRetry(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("message_end", (event, ctx) => {
+    const th = runtime.throttleFor(ctx.sessionManager.getSessionId());
     const msg = event.message;
     if (msg.role === "user") {
-      runtime.throttle.onUserMessage(isKickMessage(msg));
+      th.onUserMessage(isKickMessage(msg));
       return;
     }
     if (msg.role !== "assistant") return;
     if (msg.stopReason !== "error") {
-      runtime.throttle.onProgress();
+      th.onProgress();
       return;
     }
     if (!isThrottleError(msg)) {
-      runtime.throttle.onNonThrottleError();
+      th.onNonThrottleError();
       return;
     }
     const cfg = resolveThrottleRetry(runtime.adapter.throttleRetry);
     if (!cfg.enabled) {
-      runtime.throttle.onNonThrottleError();
+      th.onNonThrottleError();
       return;
     }
-    const decision = runtime.throttle.onThrottleError(cfg.maxRetries);
+    const decision = th.onThrottleError(cfg.maxRetries);
     if (decision === "exhausted") {
       logWarn("throttle-retry", { sid: ctx.sessionManager.getSessionId(), event: "budget-exhausted", max: cfg.maxRetries });
       if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — retry budget exhausted (${cfg.maxRetries}); surfacing error`);
       return;
     }
-    logInfo("throttle-retry", { sid: ctx.sessionManager.getSessionId(), event: "rewrite", attempt: runtime.throttle.state.attempts, max: cfg.maxRetries, path: "native" });
-    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — retry ${runtime.throttle.state.attempts}/${cfg.maxRetries} (fast probe)`);
+    logInfo("throttle-retry", { sid: ctx.sessionManager.getSessionId(), event: "rewrite", attempt: th.state.attempts, max: cfg.maxRetries, path: "native" });
+    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — retry ${th.state.attempts}/${cfg.maxRetries} (fast probe)`);
     return { message: { ...msg, errorMessage: THROTTLE_RETRY_ERROR_MESSAGE } };
   });
   pi.on("agent_settled", async (_event, ctx) => {
+    const th = runtime.throttleFor(ctx.sessionManager.getSessionId());
     const cfg = resolveThrottleRetry(runtime.adapter.throttleRetry);
-    if (!cfg.enabled || !runtime.throttle.readyToKick(cfg.maxRetries)) return;
-    const kickNumber = runtime.throttle.state.kicks + 1;
+    if (!cfg.enabled || !th.readyToKick(cfg.maxRetries)) return;
+    const kickNumber = th.state.kicks + 1;
     const delayMs = throttleDelayMs(kickNumber, cfg);
-    runtime.throttle.onKickStarted();
+    th.onKickStarted();
     const sid = ctx.sessionManager.getSessionId();
     logInfo("throttle-retry", { sid, event: "kick-sleep", kickNumber, delayMs });
-    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — waiting ${Math.round(delayMs / 1000)}s before retry ${runtime.throttle.state.attempts + 1}/${cfg.maxRetries}`);
-    const result = await abortableSleep(delayMs, runtime.throttle.sleepController().signal);
+    if (ctx.hasUI) ctx.ui.notify(`[ACP] provider throttled — waiting ${Math.round(delayMs / 1000)}s before retry ${th.state.attempts + 1}/${cfg.maxRetries}`);
+    const result = await abortableSleep(delayMs, th.sleepController().signal);
     if (result === "aborted") {
-      runtime.throttle.onKickCancelled();
+      th.onKickCancelled();
       logInfo("throttle-retry", { sid, event: "kick-cancelled", kickNumber });
       if (ctx.hasUI) ctx.ui.notify("[ACP] throttle retry cancelled (user input received)");
       return;
     }
-    if (!runtime.throttle.readyToKick(cfg.maxRetries)) return;
+    if (!th.readyToKick(cfg.maxRetries)) return;
     pi.sendUserMessage(THROTTLE_KICK_TEXT);
-    logInfo("throttle-retry", { sid, event: "kick-sent", kickNumber, attempt: runtime.throttle.state.attempts + 1, max: cfg.maxRetries });
+    logInfo("throttle-retry", { sid, event: "kick-sent", kickNumber, attempt: th.state.attempts + 1, max: cfg.maxRetries });
   });
-  pi.on("input", (event) => {
-    if (event.source !== "extension") runtime.throttle.cancelSleep();
+  pi.on("input", (event, ctx) => {
+    if (event.source !== "extension") runtime.throttleFor(ctx.sessionManager.getSessionId()).cancelSleep();
   });
-  pi.on("session_shutdown", () => {
-    runtime.throttle.reset();
+  pi.on("session_shutdown", (_event, ctx) => {
+    runtime.throttleFor(ctx.sessionManager.getSessionId()).reset();
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,7 @@ function wireThrottleRetry(pi: ExtensionAPI, runtime: AcpRuntime): void {
     if (event.source !== "extension") runtime.throttleFor(ctx.sessionManager.getSessionId()).cancelSleep();
   });
   pi.on("session_shutdown", (_event, ctx) => {
-    runtime.throttleFor(ctx.sessionManager.getSessionId()).reset();
+    runtime.throttleDrop(ctx.sessionManager.getSessionId());
   });
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -41,8 +41,10 @@ export function isPiHost(sm: ExtensionContext["sessionManager"]): boolean {
 export interface AcpRuntime {
   core: CompressionCore;
   /** Per-session provider-throttle retry episode (attempt budget + kick
-   *  pacing). Reset on session_start and on any real progress / user input. */
-  throttle: ThrottleEpisode;
+   *  pacing), keyed by session id so concurrent sessions in one extension
+   *  instance cannot share an episode. Reset on session_start and on any
+   *  real progress / user input. */
+  throttleFor: (sid: string) => ThrottleEpisode;
   store: SessionStateStore;
   density: DensityEstimator;
   /** 设置 countTokens 闭包使用的 modelId（每轮 context 事件调用）。 */
@@ -222,7 +224,12 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   let lastUserConfigKey: string | undefined;
   let promptsRef: Prompts = defaultPrompts;
   const nudgeShownTurns = new Set<string>();
-  const throttle = new ThrottleEpisode();
+  const throttleEpisodes = new Map<string, ThrottleEpisode>();
+  function throttleFor(sid: string): ThrottleEpisode {
+    let ep = throttleEpisodes.get(sid);
+    if (!ep) { ep = new ThrottleEpisode(); throttleEpisodes.set(sid, ep); }
+    return ep;
+  }
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -309,4 +316,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, throttle, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}
+  return { core, store, density, throttleFor, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -45,6 +45,10 @@ export interface AcpRuntime {
    *  instance cannot share an episode. Reset on session_start and on any
    *  real progress / user input. */
   throttleFor: (sid: string) => ThrottleEpisode;
+  /** Drop a session's throttle episode entirely (session_shutdown): aborts a
+   *  pending kick sleep and releases the map entry so a long-lived process
+   *  that cycles through many sessions doesn't accumulate them. */
+  throttleDrop: (sid: string) => void;
   store: SessionStateStore;
   density: DensityEstimator;
   /** 设置 countTokens 闭包使用的 modelId（每轮 context 事件调用）。 */
@@ -230,6 +234,11 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     if (!ep) { ep = new ThrottleEpisode(); throttleEpisodes.set(sid, ep); }
     return ep;
   }
+  function throttleDrop(sid: string): void {
+    const ep = throttleEpisodes.get(sid);
+    if (ep) ep.reset(); // abort a pending kick sleep before releasing the entry
+    throttleEpisodes.delete(sid);
+  }
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -316,4 +325,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, throttleFor, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}
+  return { core, store, density, throttleFor, throttleDrop, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,6 +13,7 @@ import { DensityEstimator } from "./density.js";
 import { entriesToCoreMessages, extractText, matchesStoredText, messageIdentity, messageRef } from "./messages.js";
 import { SessionStateStore, type LiveRefOrigin } from "./state.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
+import { ThrottleEpisode } from "./throttle-retry.js";
 import { logInfo, logWarn, setDebugEnabled } from "./log.js";
 import { findUniqueLongestRun, type MatchRange } from "./sequence-match.js";
 // pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
@@ -39,6 +40,9 @@ export function isPiHost(sm: ExtensionContext["sessionManager"]): boolean {
 
 export interface AcpRuntime {
   core: CompressionCore;
+  /** Per-session provider-throttle retry episode (attempt budget + kick
+   *  pacing). Reset on session_start and on any real progress / user input. */
+  throttle: ThrottleEpisode;
   store: SessionStateStore;
   density: DensityEstimator;
   /** 设置 countTokens 闭包使用的 modelId（每轮 context 事件调用）。 */
@@ -218,6 +222,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   let lastUserConfigKey: string | undefined;
   let promptsRef: Prompts = defaultPrompts;
   const nudgeShownTurns = new Set<string>();
+  const throttle = new ThrottleEpisode();
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -304,4 +309,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}
+  return { core, store, density, throttle, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -62,6 +62,11 @@ decompress restores previously compressed content and writes it to a file by def
 CONTEXT BREAKDOWN
 
 When context usage passes a threshold, the system appends a breakdown showing where tokens are spent. Compress the largest ranges first when the current step no longer needs them.
+
+PROVIDER THROTTLE RETRY
+
+A provider rate-limit error (e.g. "Too many tokens, please wait before trying again.") may appear as a failed assistant response followed by a [ACP:provider-throttle] note. The interruption was transient and the system is retrying automatically. After such an interruption, resume the interrupted step exactly where it left off: do not re-run completed steps, do not re-read content already in context, and do not discuss the interruption unless asked.
+Retries are capped; when the cap is reached the error is surfaced to the user unchanged. If the user sends new input during a retry wait, the retry is cancelled.
 `;
 }
 

--- a/src/throttle-retry.ts
+++ b/src/throttle-retry.ts
@@ -1,0 +1,154 @@
+import { extractText } from "./messages.js";
+
+// Load-bearing string: must contain "429" + "rate limit" so pi's post-run
+// classifier (isRetryableAssistantError) treats the rewritten message as
+// retryable, while the "rate limit" hit on pi-ai's NON_OVERFLOW exclusion
+// patterns keeps it off the context-overflow/compaction path. It must match
+// no NON_RETRYABLE quota/billing pattern. Pinned by tests/throttle-retry.test.ts.
+export const THROTTLE_RETRY_ERROR_MESSAGE = "429 rate limit: Too many tokens, please wait before trying again.";
+
+export const THROTTLE_KICK_SENTINEL = "[ACP:provider-throttle]";
+export const THROTTLE_KICK_TEXT = `${THROTTLE_KICK_SENTINEL} The previous assistant response was interrupted by a provider rate limit (transient, not a real failure). Resume the task exactly where it left off — do not re-run completed steps and do not discuss the interruption unless asked.`;
+
+const BEDROCK_THROTTLE_PHRASE = /too many tokens, please wait before trying again/i;
+const THROTTLE_NAME = /throttl/i;
+const OVERFLOW_GUARD = /prompt is too long|request_too_large|exceeds the context window|maximum context length|input token count.*exceeds|reduce the length of the messages|exceeded model token limit|context[_ ]length[_ ]exceeded/i;
+const QUOTA_GUARD = /quota exceeded|insufficient_quota|out of budget|available balance|monthly usage limit|free usage limit|billing/i;
+
+export interface ThrottleErrorProbe {
+  role: string;
+  stopReason?: string;
+  errorMessage?: string;
+  content: unknown;
+}
+
+export function isThrottleError(msg: ThrottleErrorProbe): boolean {
+  if (msg.role !== "assistant" || msg.stopReason !== "error") return false;
+  const haystack = `${msg.errorMessage ?? ""}\n${extractText(msg.content)}`;
+  if (OVERFLOW_GUARD.test(haystack)) return false;
+  if (QUOTA_GUARD.test(haystack)) return false;
+  if (THROTTLE_NAME.test(msg.errorMessage ?? "")) return true;
+  return BEDROCK_THROTTLE_PHRASE.test(haystack);
+}
+
+export function isKickMessage(msg: { role: string; content: unknown }): boolean {
+  if (msg.role !== "user") return false;
+  return extractText(msg.content).trimStart().startsWith(THROTTLE_KICK_SENTINEL);
+}
+
+export interface ThrottleRetryConfig {
+  enabled?: boolean;
+  maxRetries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMode?: "exponential" | "fixed";
+}
+
+export interface ResolvedThrottleRetry {
+  enabled: boolean;
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  backoffMode: "exponential" | "fixed";
+}
+
+export const DEFAULT_THROTTLE_RETRY: ResolvedThrottleRetry = {
+  enabled: true,
+  maxRetries: 10,
+  baseDelayMs: 60_000,
+  maxDelayMs: 300_000,
+  backoffMode: "exponential",
+};
+
+export function resolveThrottleRetry(cfg: boolean | ThrottleRetryConfig | undefined): ResolvedThrottleRetry {
+  if (cfg === false) return { ...DEFAULT_THROTTLE_RETRY, enabled: false };
+  const c = typeof cfg === "object" ? cfg : {};
+  const base = Math.max(1, Math.floor(c.baseDelayMs ?? DEFAULT_THROTTLE_RETRY.baseDelayMs));
+  const explicitMax = typeof c.maxDelayMs === "number" ? Math.floor(c.maxDelayMs) : undefined;
+  const maxDelay = Math.max(base, explicitMax ?? DEFAULT_THROTTLE_RETRY.maxDelayMs);
+  return {
+    enabled: c.enabled !== false,
+    maxRetries: Math.max(1, Math.floor(c.maxRetries ?? DEFAULT_THROTTLE_RETRY.maxRetries)),
+    baseDelayMs: base,
+    maxDelayMs: maxDelay,
+    backoffMode: c.backoffMode ?? "exponential",
+  };
+}
+
+export function throttleDelayMs(kickNumber: number, r: ResolvedThrottleRetry): number {
+  const delay = r.backoffMode === "exponential" ? r.baseDelayMs * 2 ** (Math.max(1, kickNumber) - 1) : r.baseDelayMs;
+  return Math.min(delay, r.maxDelayMs);
+}
+
+export interface ThrottleEpisodeState {
+  attempts: number;
+  kicks: number;
+  candidate: boolean;
+}
+
+export const INITIAL_THROTTLE_STATE: ThrottleEpisodeState = { attempts: 0, kicks: 0, candidate: false };
+
+export class ThrottleEpisode {
+  state: ThrottleEpisodeState = { ...INITIAL_THROTTLE_STATE };
+  private cancel: AbortController | null = null;
+
+  reset(): void {
+    this.state = { ...INITIAL_THROTTLE_STATE };
+    if (this.cancel) {
+      this.cancel.abort();
+      this.cancel = null;
+    }
+  }
+
+  onProgress(): void {
+    this.reset();
+  }
+
+  onUserMessage(kick: boolean): void {
+    if (!kick) this.reset();
+  }
+
+  onThrottleError(maxRetries: number): "rewrite" | "exhausted" {
+    if (this.state.attempts >= maxRetries) {
+      this.state = { ...this.state, candidate: false };
+      return "exhausted";
+    }
+    this.state = { attempts: this.state.attempts + 1, kicks: this.state.kicks, candidate: true };
+    return "rewrite";
+  }
+
+  onNonThrottleError(): void {
+    this.state = { ...this.state, candidate: false };
+  }
+
+  readyToKick(maxRetries: number): boolean {
+    return this.state.candidate && this.state.attempts < maxRetries;
+  }
+
+  onKickStarted(): void {
+    this.state = { ...this.state, kicks: this.state.kicks + 1 };
+  }
+
+  onKickCancelled(): void {
+    this.reset();
+  }
+
+  sleepController(): AbortController {
+    if (!this.cancel) this.cancel = new AbortController();
+    return this.cancel;
+  }
+
+  cancelSleep(): void {
+    this.cancel?.abort();
+  }
+}
+
+export async function abortableSleep(ms: number, signal: AbortSignal): Promise<"ok" | "aborted"> {
+  const end = Date.now() + ms;
+  for (;;) {
+    if (signal.aborted) return "aborted";
+    const remaining = end - Date.now();
+    if (remaining <= 0) return "ok";
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(250, remaining)));
+  }
+}

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import type { Prompts } from "acp-kernel";
 import type { AdapterConfig, CompressConfig, DelegateConfig } from "./config.js";
+import type { ThrottleRetryConfig } from "./throttle-retry.js";
 import { debug, logWarn } from "./log.js";
 
 /** User-facing config keys (subset of AdapterConfig). Loaded from
@@ -17,6 +18,7 @@ export interface UserAcpConfig {
   toolOutputMaxBytes?: number;
   delegate?: boolean | DelegateConfig;
   compress?: CompressConfig;
+  throttleRetry?: boolean | ThrottleRetryConfig;
   displayUsage?: "merged" | "separate";
   prompts?: Partial<Prompts>;
   acknowledgePromptsRisk?: boolean;
@@ -53,7 +55,7 @@ function join(... parts: string[]): string {
 const KNOWN = new Set([
   "debug", "autoUpdate", "modelContextLimit",
   "toolBashDefaultTimeout", "toolOutputMaxBytes",
-  "delegate", "compress", "displayUsage",
+  "delegate", "compress", "displayUsage", "throttleRetry",
   "prompts", "acknowledgePromptsRisk",
 ]);
 

--- a/tests/prompts-config.test.ts
+++ b/tests/prompts-config.test.ts
@@ -73,7 +73,7 @@ test("applyUserConfig flows prompts through to the adapter", () => {
 test("buildAcpSystemPrompt default output is byte-stable (no trailing whitespace, full rules embedded)", () => {
   const prompt = buildAcpSystemPrompt(defaultPrompts);
   assert.ok(
-    prompt.endsWith("the current step no longer needs them.\n"),
+    prompt.endsWith("If the user sends new input during a retry wait, the retry is cancelled.\n"),
     "ends exactly like the master const — const->function refactor must not add trailing whitespace",
   );
   assert.equal(

--- a/tests/throttle-retry.test.ts
+++ b/tests/throttle-retry.test.ts
@@ -1,0 +1,246 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  THROTTLE_RETRY_ERROR_MESSAGE,
+  THROTTLE_KICK_TEXT,
+  THROTTLE_KICK_SENTINEL,
+  INITIAL_THROTTLE_STATE,
+  ThrottleEpisode,
+  isThrottleError,
+  isKickMessage,
+  resolveThrottleRetry,
+  throttleDelayMs,
+  abortableSleep,
+  type ThrottleErrorProbe,
+} from "../src/throttle-retry.js";
+
+const RELAY_ERROR = "Provider finish_reason: error_finish";
+const BEDROCK_JSON = '{"message":"Too many tokens, please wait before trying again."}';
+
+function assistant(errorMessage: string | undefined, content: unknown, stopReason = "error"): ThrottleErrorProbe {
+  return { role: "assistant", stopReason, errorMessage, content };
+}
+
+function text(...blocks: string[]) {
+  return blocks.map((text) => ({ type: "text", text }));
+}
+
+test("isThrottleError: relay shape (error_finish + Bedrock JSON streamed as content)", () => {
+  assert.equal(isThrottleError(assistant(RELAY_ERROR, text(BEDROCK_JSON))), true);
+  assert.equal(isThrottleError(assistant(RELAY_ERROR, BEDROCK_JSON)), true);
+});
+
+test("isThrottleError: direct Bedrock provider path (throttling name in errorMessage)", () => {
+  assert.equal(isThrottleError(assistant("ThrottlingException: Too many tokens, please wait before trying again.", [])), true);
+  assert.equal(isThrottleError(assistant("Throttling error: Too many tokens, please wait before trying again.", [])), true);
+  assert.equal(isThrottleError(assistant("Throttling: request rate increased too quickly.", [])), true);
+});
+
+test("isThrottleError: Bedrock phrase in errorMessage (relay variants)", () => {
+  assert.equal(isThrottleError(assistant("Error: Too many tokens, please wait before trying again.", [])), true);
+});
+
+test("isThrottleError: real context-overflow signatures are rejected", () => {
+  assert.equal(isThrottleError(assistant("prompt is too long: 213462 tokens > 200000 maximum", [])), false);
+  assert.equal(isThrottleError(assistant("Your input exceeds the context window of this model.", [])), false);
+  assert.equal(isThrottleError(assistant("Input length (265330) exceeds the model's maximum context length (200000).", [])), false);
+  assert.equal(isThrottleError(assistant("request_too_large", [])), false);
+});
+
+test("isThrottleError: quota/billing exhaustion is rejected", () => {
+  assert.equal(isThrottleError(assistant("You exceeded your current quota, please check your plan and billing details", [])), false);
+  assert.equal(isThrottleError(assistant("Model quota exceeded for the current billing plan", [])), false);
+  assert.equal(isThrottleError(assistant("insufficient_quota", [])), false);
+});
+
+test("isThrottleError: Bedrock daily-quota message (no 'please wait' phrase) is rejected", () => {
+  assert.equal(isThrottleError(assistant("Too many tokens per day is exceeded", [])), false);
+});
+
+test("isThrottleError: generic 429 (already handled by pi native retry) is not ours", () => {
+  assert.equal(isThrottleError(assistant("429 too many requests from upstream", [])), false);
+});
+
+test("isThrottleError: non-error stop reasons and non-assistant roles are rejected", () => {
+  assert.equal(isThrottleError(assistant("ThrottlingException: x", [], "aborted")), false);
+  assert.equal(isThrottleError(assistant("ThrottlingException: x", [], "stop")), false);
+  assert.equal(isThrottleError({ role: "user", stopReason: "error", errorMessage: "ThrottlingException: x", content: [] }), false);
+});
+
+test("isThrottleError: bare error_finish without the Bedrock phrase is rejected", () => {
+  assert.equal(isThrottleError(assistant(RELAY_ERROR, [])), false);
+  assert.equal(isThrottleError(assistant(RELAY_ERROR, text("Something else went wrong"))), false);
+  assert.equal(isThrottleError(assistant(undefined, [])), false);
+});
+
+test("isKickMessage: recognizes the ACP kick and rejects everything else", () => {
+  assert.equal(isKickMessage({ role: "user", content: [{ type: "text", text: THROTTLE_KICK_TEXT }] }), true);
+  assert.equal(isKickMessage({ role: "user", content: THROTTLE_KICK_TEXT }), true);
+  assert.equal(isKickMessage({ role: "user", content: `  ${THROTTLE_KICK_SENTINEL} resumed` }), true);
+  assert.equal(isKickMessage({ role: "user", content: [{ type: "text", text: "please continue" }] }), false);
+  assert.equal(isKickMessage({ role: "assistant", content: THROTTLE_KICK_TEXT }), false);
+});
+
+test("resolveThrottleRetry: defaults", () => {
+  assert.deepEqual(resolveThrottleRetry(undefined), { enabled: true, maxRetries: 10, baseDelayMs: 60_000, maxDelayMs: 300_000, backoffMode: "exponential" });
+  assert.deepEqual(resolveThrottleRetry(true), { enabled: true, maxRetries: 10, baseDelayMs: 60_000, maxDelayMs: 300_000, backoffMode: "exponential" });
+});
+
+test("resolveThrottleRetry: boolean false shorthand disables", () => {
+  const r = resolveThrottleRetry(false);
+  assert.equal(r.enabled, false);
+  assert.equal(r.maxRetries, 10);
+});
+
+test("resolveThrottleRetry: partial object overrides", () => {
+  assert.deepEqual(resolveThrottleRetry({ maxRetries: 3 }), { enabled: true, maxRetries: 3, baseDelayMs: 60_000, maxDelayMs: 300_000, backoffMode: "exponential" });
+  assert.equal(resolveThrottleRetry({ enabled: false }).enabled, false);
+  assert.equal(resolveThrottleRetry({ backoffMode: "fixed" }).backoffMode, "fixed");
+});
+
+test("resolveThrottleRetry: clamps", () => {
+  assert.equal(resolveThrottleRetry({ maxRetries: 0 }).maxRetries, 1);
+  assert.equal(resolveThrottleRetry({ maxRetries: 2.9 }).maxRetries, 2);
+  assert.equal(resolveThrottleRetry({ baseDelayMs: 0.4 }).baseDelayMs, 1);
+  const r = resolveThrottleRetry({ baseDelayMs: 600_000 });
+  assert.equal(r.maxDelayMs, 600_000, "cap must not go below base");
+  assert.equal(resolveThrottleRetry({ baseDelayMs: 60_000, maxDelayMs: 120_000 }).maxDelayMs, 120_000, "explicit maxDelayMs is honored");
+});
+
+test("throttleDelayMs: exponential with cap", () => {
+  const r = resolveThrottleRetry(undefined);
+  assert.equal(throttleDelayMs(1, r), 60_000);
+  assert.equal(throttleDelayMs(2, r), 120_000);
+  assert.equal(throttleDelayMs(3, r), 240_000);
+  assert.equal(throttleDelayMs(4, r), 300_000);
+  assert.equal(throttleDelayMs(10, r), 300_000);
+});
+
+test("throttleDelayMs: fixed mode and custom base", () => {
+  const r = resolveThrottleRetry({ backoffMode: "fixed", baseDelayMs: 30_000, maxDelayMs: 30_000 });
+  assert.equal(throttleDelayMs(1, r), 30_000);
+  assert.equal(throttleDelayMs(9, r), 30_000);
+});
+
+test("episode: full 10-retry timeline (3 native + kick + 3 native + kick + exhaustion)", () => {
+  const ep = new ThrottleEpisode();
+  const max = 10;
+  assert.deepEqual(ep.state, INITIAL_THROTTLE_STATE);
+  assert.equal(ep.onThrottleError(max), "rewrite");
+  for (let i = 1; i <= 3; i++) assert.equal(ep.onThrottleError(max), "rewrite");
+  assert.equal(ep.state.attempts, 4);
+  assert.equal(ep.readyToKick(max), true);
+  ep.onKickStarted();
+  assert.equal(ep.state.kicks, 1);
+  ep.onUserMessage(true);
+  assert.equal(ep.state.attempts, 4, "kick user message must not reset the episode");
+  for (let i = 4; i <= 7; i++) assert.equal(ep.onThrottleError(max), "rewrite");
+  assert.equal(ep.state.attempts, 8);
+  assert.equal(ep.readyToKick(max), true);
+  ep.onKickStarted();
+  assert.equal(ep.state.kicks, 2);
+  ep.onUserMessage(true);
+  assert.equal(ep.onThrottleError(max), "rewrite");
+  assert.equal(ep.onThrottleError(max), "rewrite");
+  assert.equal(ep.state.attempts, 10);
+  assert.equal(ep.onThrottleError(max), "exhausted", "11th error exceeds the 10-retry budget");
+  assert.equal(ep.state.candidate, false);
+  assert.equal(ep.readyToKick(max), false, "no kick after exhaustion");
+  assert.equal(ep.onThrottleError(max), "exhausted", "stays exhausted");
+});
+
+test("episode: resets", () => {
+  const ep = new ThrottleEpisode();
+  ep.onThrottleError(10);
+  ep.onThrottleError(10);
+  ep.onUserMessage(false);
+  assert.deepEqual(ep.state, INITIAL_THROTTLE_STATE, "new user message starts a new episode");
+  ep.onThrottleError(10);
+  ep.onProgress();
+  assert.deepEqual(ep.state, INITIAL_THROTTLE_STATE, "any non-error assistant response resets");
+  ep.onThrottleError(10);
+  ep.onKickStarted();
+  ep.onKickCancelled();
+  assert.deepEqual(ep.state, INITIAL_THROTTLE_STATE, "cancelled kick resets");
+});
+
+test("episode: non-throttle error clears candidate but keeps the budget", () => {
+  const ep = new ThrottleEpisode();
+  ep.onThrottleError(10);
+  assert.equal(ep.state.candidate, true);
+  ep.onNonThrottleError();
+  assert.equal(ep.state.candidate, false);
+  assert.equal(ep.state.attempts, 1);
+  assert.equal(ep.readyToKick(10), false);
+});
+
+test("episode: exhaustion does not consume the budget", () => {
+  const ep = new ThrottleEpisode();
+  for (let i = 0; i < 10; i++) ep.onThrottleError(10);
+  ep.onThrottleError(10);
+  assert.equal(ep.state.attempts, 10);
+});
+
+test("episode: reset aborts a pending sleep controller", async () => {
+  const ep = new ThrottleEpisode();
+  const controller = ep.sleepController();
+  assert.equal(controller.signal.aborted, false);
+  ep.reset();
+  assert.equal(controller.signal.aborted, true);
+  assert.notEqual(ep.sleepController(), controller);
+});
+
+test("abortableSleep: resolves ok after the delay", async () => {
+  const start = Date.now();
+  const result = await abortableSleep(30, new AbortController().signal);
+  assert.equal(result, "ok");
+  assert.ok(Date.now() - start >= 25, "should sleep close to the requested duration");
+});
+
+test("abortableSleep: pre-aborted signal returns immediately", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const start = Date.now();
+  const result = await abortableSleep(5_000, controller.signal);
+  assert.equal(result, "aborted");
+  assert.ok(Date.now() - start < 100);
+});
+
+test("abortableSleep: abort mid-sleep returns aborted promptly", async () => {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 20);
+  const start = Date.now();
+  const result = await abortableSleep(10_000, controller.signal);
+  assert.equal(result, "aborted");
+  assert.ok(Date.now() - start < 1_000);
+});
+
+// Mirrors of the pi-ai patterns that the rewritten errorMessage must satisfy
+// (pi-ai is not importable here: zero-runtime-deps constraint).
+const NON_RETRYABLE = new RegExp(["GoUsageLimitError", "FreeUsageLimitError", "Monthly usage limit reached", "available balance", "insufficient_quota", "out of budget", "quota exceeded", "billing"].join("|"), "i");
+const RETRYABLE = new RegExp(["overloaded", "rate.?limit", "too many requests", "429", "500", "502", "503", "504", "524", "service.?unavailable", "server.?error", "internal.?error", "provider.?returned.?error"].join("|"), "i");
+const OVERFLOW = [/prompt is too long/i, /request_too_large/i, /exceeds the context window/i, /exceeded model token limit/i, /context[_ ]length[_ ]exceeded/i, /too many tokens/i, /token limit exceeded/i];
+const NON_OVERFLOW = [/^(Throttling error|Service unavailable):/i, /rate limit/i, /too many requests/i];
+
+function mirrorIsContextOverflow(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+  return !NON_OVERFLOW.some((p) => p.test(errorMessage)) && OVERFLOW.some((p) => p.test(errorMessage));
+}
+function mirrorIsRetryable(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+  if (NON_RETRYABLE.test(errorMessage)) return false;
+  return RETRYABLE.test(errorMessage);
+}
+
+test("rewrite contract: THROTTLE_RETRY_ERROR_MESSAGE is retryable and NOT overflow to pi", () => {
+  assert.ok(RETRYABLE.test(THROTTLE_RETRY_ERROR_MESSAGE), "must match a pi retryable pattern");
+  assert.ok(!NON_RETRYABLE.test(THROTTLE_RETRY_ERROR_MESSAGE), "must not match any pi non-retryable (quota/billing) pattern");
+  assert.ok(!mirrorIsContextOverflow(THROTTLE_RETRY_ERROR_MESSAGE), "must not be routed to pi compaction");
+  assert.ok(mirrorIsRetryable(THROTTLE_RETRY_ERROR_MESSAGE), "must be accepted by pi's retry classifier");
+  assert.ok(/429/.test(THROTTLE_RETRY_ERROR_MESSAGE) && /rate limit/i.test(THROTTLE_RETRY_ERROR_MESSAGE), "load-bearing tokens: 429 + rate limit");
+});
+
+test("rewrite contract: the original error is NOT retryable (the bug this feature fixes)", () => {
+  assert.ok(!mirrorIsRetryable(RELAY_ERROR), "original 'Provider finish_reason: error_finish' matches no retryable pattern");
+  assert.ok(!mirrorIsContextOverflow(RELAY_ERROR), "and no overflow pattern");
+});

--- a/tests/throttle-retry.test.ts
+++ b/tests/throttle-retry.test.ts
@@ -217,6 +217,11 @@ test("abortableSleep: abort mid-sleep returns aborted promptly", async () => {
 
 // Mirrors of the pi-ai patterns that the rewritten errorMessage must satisfy
 // (pi-ai is not importable here: zero-runtime-deps constraint).
+// These are COPIES of pi-ai's retry/overflow classifier (isRetryableAssistantError
+// + context-overflow detection) as shipped in pi-stable 0.83.5 (2026-08-18). If
+// pi-ai changes any of these patterns, update BOTH the mirrors below AND the
+// THROTTLE_RETRY_ERROR_MESSAGE string so the rewrite keeps the native-retryable
+// classification — the asserts at the bottom of this file pin that contract.
 const NON_RETRYABLE = new RegExp(["GoUsageLimitError", "FreeUsageLimitError", "Monthly usage limit reached", "available balance", "insufficient_quota", "out of budget", "quota exceeded", "billing"].join("|"), "i");
 const RETRYABLE = new RegExp(["overloaded", "rate.?limit", "too many requests", "429", "500", "502", "503", "504", "524", "service.?unavailable", "server.?error", "internal.?error", "provider.?returned.?error"].join("|"), "i");
 const OVERFLOW = [/prompt is too long/i, /request_too_large/i, /exceeds the context window/i, /exceeded model token limit/i, /context[_ ]length[_ ]exceeded/i, /too many tokens/i, /token limit exceeded/i];


### PR DESCRIPTION
## 背景 / Closes #169

provider 侧分钟级 token 限流（如 AWS Bedrock 的 `"Too many tokens, please wait before trying again."`，relay 以 content + `finish_reason: "error_finish"` 流回）在 Pi 侧表现为 `Provider finish_reason: error_finish`——既不匹配 pi 的 overflow 模式（不压缩）也不匹配 retry 模式（不重试），turn 直接失败。

## 方案（hybrid，经设计评审）

1. **`message_end` 改写**：识别到限流错误且 ACP 预算内时，把 errorMessage 改写为 pi 可识别的 429 形式（`429 rate limit: Too many tokens, ...`），由 **pi 原生重试**重跑同一 turn——不重复用户消息、错误不进 LLM 上下文、原生 TUI 重试指示器。pi 原生预算小而快（3 次、2s 起步），先跑。
2. **`agent_settled` 递进 kick（ACP 自己的节奏）**：run 仍以限流错误结束且预算允许时，等待递进延迟（默认 60s → 120s → 240s → 300s 封顶），然后发一条带标记的用户消息（`[ACP:provider-throttle] ...`）恢复被中断的步骤。
3. **`input` 取消**：等待期间用户发新输入 → 取消挂起的重试。
4. **episode 预算**：同一错误 episode 共 `maxRetries`（默认 10）次 ACP 驱动重试；任何一次非错误响应或新用户消息重置 episode；用尽后错误原样呈现。

**刻意不重试**（保留 fail-fast）：真正的上下文超长（`prompt is too long` 等）、配额/计费耗尽（`quota exceeded`/`billing` 等）、通用 429（pi 原生重试已覆盖）。

## 配置（`acp.json`）

```json
{
  "throttleRetry": {
    "enabled": true,
    "maxRetries": 10,
    "baseDelayMs": 60000,
    "maxDelayMs": 300000,
    "backoffMode": "exponential"
  }
}
```

`throttleRetry: false` 恢复原始 fail-fast。默认开启。若想要严格节奏（只用 ACP 的 60s 级 kick），另在 `~/.pi/settings.json` 设 `"retry": { "enabled": false }` 关闭 pi 自身重试（文档已注明）。

## 改动

- 新增 `src/throttle-retry.ts`：检测谓词（overflow/quota 守卫 + Bedrock 特征词）、episode 状态机、配置解析、可中断 sleep、kick 消息常量
- `src/index.ts`：`wireThrottleRetry`（message_end / agent_settled / input / session_shutdown 四个钩子）
- `src/config.ts` / `src/user-config.ts` / `src/runtime.ts`：配置类型与传递
- `src/system-prompt.ts`：PROVIDER THROTTLE RETRY 段落（指导模型从中断处恢复）
- `CONFIGURATION.md` / `CONFIGURATION.zh-CN.md`：完整参数文档
- `tests/throttle-retry.test.ts`：+26 测试，含与 pi-ai 模式表的契约测试（改写串必须命中 retryable 且不命中 overflow）；全量 **336/336 通过**，typecheck + build 通过

## 关键验证点（设计评审确认）

- pi 在 `message_end` 扩展 handler 之后才捕获 `_lastAssistantMessage`，改写对重试分类器可见
- `_replaceMessageInPlace` 会清空目标对象所有键 → 替换消息 spread 原消息全部字段（usage 等不丢）
- `agent_settled` 在 pi 所有 retry/compaction 决策之后才发（finally 路径），ACP 的 kick 不会与 pi 自身动作竞争