### PR TITLE
fix: decouple tag tokens from density calibration (cache-miss root cause #171)

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,5 +1,6 @@
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 import type { CoreMessage } from "acp-kernel";
+import { rewriteTagTokens } from "./tag-tokens.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -274,15 +275,23 @@ function reconstructToolCallMessage(
   });
 
   const peeled = peelRefTagBlocks(filtered);
+  const stableTag = rewriteTagTokens(tag, coreBodyOf(firstCore.text ?? "", tag));
   const lastTextIdx = [...peeled].reverse().findIndex((b) => (b as { type?: string }).type === "text");
   if (lastTextIdx >= 0) {
     const idx = peeled.length - 1 - lastTextIdx;
     const lastBlock = peeled[idx] as { type: string; text: string };
     const baseText = lastBlock.text ?? "";
-    peeled[idx] = { ...lastBlock, text: baseText.length > 0 ? `${baseText}\n\n${tag}` : tag };
+    peeled[idx] = { ...lastBlock, text: baseText.length > 0 ? `${baseText}\n\n${stableTag}` : stableTag };
     return { ...(original as object), content: peeled } as AgentMessage;
   }
-  return { ...(original as object), content: [{ type: "text", text: tag }, ...peeled] } as AgentMessage;
+  return { ...(original as object), content: [{ type: "text", text: stableTag }, ...peeled] } as AgentMessage;
+}
+
+function coreBodyOf(coreText: string, tag: string): string {
+  const tagCore = tag.replace(/\s+$/, "");
+  let bodyStart = tagCore.length;
+  if (coreText.charAt(bodyStart) === "\n") bodyStart += 1;
+  return coreText.slice(bodyStart);
 }
 
 function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
@@ -297,15 +306,13 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
   // Honor kernel body mutations (emergency truncation of large tool-results,
   // future rewrites): if core.text's body differs from the original text,
   // rebuild from the kernel body — otherwise truncation never reaches the model.
-  const tagCore = tag.replace(/\s+$/, "");
-  let bodyStart = tagCore.length;
-  if (core.text && core.text.charAt(bodyStart) === "\n") bodyStart += 1;
-  const coreBody = core.text ? core.text.slice(bodyStart) : "";
+  const coreBody = coreBodyOf(core.text ?? "", tag);
   const originalBody = extractText(base.content);
   const trimEnd = (s: string): string => s.replace(/\s+$/, "");
   if (coreBody && trimEnd(coreBody) !== trimEnd(originalBody)) {
-    return rebuildBodyFromCore(original, coreBody, tag);
+    return rebuildBodyFromCore(original, coreBody, rewriteTagTokens(tag, coreBody));
   }
+  const stableTag = rewriteTagTokens(tag, originalBody);
   const rawBlocks = Array.isArray(base.content)
     ? base.content
     : typeof base.content === "string"
@@ -319,7 +326,7 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
     const b = newBlocks[i] as { type?: string; text?: string };
     if (b?.type === "text" && typeof b.text === "string" && b.text.length > 0) {
       const baseText = b.text.replace(/\n*$/, "");
-      newBlocks[i] = { ...b, text: `${baseText}\n\n${tag}` };
+      newBlocks[i] = { ...b, text: `${baseText}\n\n${stableTag}` };
       injected = true;
       break;
     }
@@ -330,7 +337,7 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
 
   return {
     ...(original as object),
-    content: [...peeled, { type: "text" as const, text: tag }],
+    content: [...peeled, { type: "text" as const, text: stableTag }],
   } as AgentMessage;
 }
 

--- a/src/tag-tokens.ts
+++ b/src/tag-tokens.ts
@@ -1,0 +1,15 @@
+import { defaultCountTokens } from "acp-kernel";
+
+export function formatTokens(tokens: number): string {
+  if (tokens < 1000) return String(tokens);
+  if (tokens < 10000) return `${(tokens / 1000).toFixed(1)}K`;
+  return `${Math.round(tokens / 1000)}K`;
+}
+
+export function stableTagTokens(text: string): string {
+  return formatTokens(defaultCountTokens(text));
+}
+
+export function rewriteTagTokens(tag: string, body: string): string {
+  return tag.replace(/tokens="[^"]*"/, `tokens="${stableTagTokens(body)}"`);
+}

--- a/tests/tag-tokens.test.ts
+++ b/tests/tag-tokens.test.ts
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatTokens,
+  stableTagTokens,
+  rewriteTagTokens,
+} from "../src/tag-tokens.js";
+import { coreOutToAgentMessages } from "../src/messages.js";
+import type { CoreMessage } from "acp-kernel";
+import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
+
+const LT = "\x3c";
+const GT = "\x3e";
+function acpRef(ref: string, tokens = "2", type = "text"): string {
+  return LT + 'acp tokens="' + tokens + '" type="' + type + '"' + GT + ref + LT + "/acp" + GT;
+}
+
+function msgEntry(id: string, message: object): SessionMessageEntry {
+  return {
+    type: "message",
+    id,
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: message as SessionMessageEntry["message"],
+  };
+}
+
+function user(text: string): object {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function collectOriginals(entries: SessionEntry[]): Map<string, SessionMessageEntry["message"]> {
+  const originalById = new Map<string, SessionMessageEntry["message"]>();
+  for (const entry of entries) {
+    if (entry.type === "message") originalById.set(entry.id, entry.message);
+  }
+  return originalById;
+}
+
+function simulateTurn(entries: SessionEntry[], coreOut: CoreMessage[]): SessionMessageEntry["message"][] {
+  return coreOutToAgentMessages(coreOut, collectOriginals(entries));
+}
+
+function textOf(msg: SessionMessageEntry["message"]): string {
+  const m = msg as { content?: unknown };
+  const content = m.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .flatMap((b) => {
+        const block = b as { type?: string; text?: string };
+        return block.type === "text" && typeof block.text === "string" ? [block.text] : [];
+      })
+      .join("\n");
+  }
+  return "";
+}
+
+test("formatTokens mirrors kernel formatting rules", () => {
+  assert.equal(formatTokens(0), "0");
+  assert.equal(formatTokens(999), "999");
+  assert.equal(formatTokens(1000), "1.0K");
+  assert.equal(formatTokens(2500), "2.5K");
+  assert.equal(formatTokens(9999), "10.0K");
+  assert.equal(formatTokens(10000), "10K");
+  assert.equal(formatTokens(12345), "12K");
+});
+
+test("stableTagTokens equals raw defaultCountTokens formatting", () => {
+  assert.equal(stableTagTokens(""), "0");
+  assert.equal(stableTagTokens("hello world foo bar baz"), "6");
+  assert.equal(stableTagTokens("这是一个中文测试"), "8");
+  assert.equal(stableTagTokens("hello世界"), "4");
+});
+
+test("rewriteTagTokens replaces tokens= but preserves ref and type", () => {
+  const tag = acpRef("m00042", "5.0K", "bash");
+  const body = "hello world foo bar baz";
+  const out = rewriteTagTokens(tag, body);
+  assert.equal(out, acpRef("m00042", "6", "bash"));
+});
+
+test("tag tokens in output are raw-counted, not density-inflated", () => {
+  const body = "a".repeat(1000);
+  const entries: SessionEntry[] = [msgEntry("mid", user(body))];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", "2.5K")}\n${body}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const text = textOf(out[0]);
+  assert.ok(text.includes(acpRef("m00001", "250")), `expected raw 250 tag, got: ${text.slice(-60)}`);
+  assert.ok(!text.includes('tokens="2.5K"'), "density-inflated tag value must not reach the model");
+});
+
+test("tag token value is deterministic across re-renders at different densities", () => {
+  const body = "这是一个测试。a".repeat(8);
+  const entries: SessionEntry[] = [msgEntry("mid", user(body))];
+  const render = (densityTag: string): string => {
+    const coreOut: CoreMessage[] = [
+      { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", densityTag)}\n${body}` },
+    ];
+    const out = simulateTurn(entries, coreOut);
+    return textOf(out[0]);
+  };
+  const atDensity1 = render("1.0K");
+  const atDensity25 = render("2.5K");
+  assert.equal(atDensity1, atDensity25, "rendered bytes must not depend on calibration density");
+});
+
+test("rebuild path (truncated core body) tags the kernel body with raw tokens", () => {
+  const originalBody = "original body that will be replaced";
+  const coreBody = "x".repeat(800);
+  const entries: SessionEntry[] = [msgEntry("mid", user(originalBody))];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", "2.5K")}\n${coreBody}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const text = textOf(out[0]);
+  assert.ok(text.startsWith(coreBody), "kernel body must win over the original");
+  assert.ok(text.trimEnd().endsWith(acpRef("m00001", "200")), `expected raw 200 tag at end, got: ${text.slice(-60)}`);
+});
+
+test("tool-result tags keep their type while tokens become raw", () => {
+  const body = "a".repeat(400);
+  const toolMsg = {
+    role: "toolResult",
+    toolName: "bash",
+    toolCallId: "call1",
+    content: body,
+    timestamp: Date.now(),
+  };
+  const entries: SessionEntry[] = [msgEntry("mid", toolMsg)];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "call1", text: `${acpRef("m00001", "2.0K", "bash")}\n${body}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const content = (out[0] as { content: Array<{ type: string; text: string }> }).content;
+  const texts = content.filter((b) => b.type === "text").map((b) => b.text);
+  assert.ok(texts.some((t) => t.includes(acpRef("m00001", "100", "bash"))), "tool tag type preserved, tokens raw");
+});


### PR DESCRIPTION
Replaces #172 (same commit 830d771) — head branch renamed to `2026-08-17_stable-tag-tokens` to satisfy pr-validation (scripts/ci/check-pr.sh requires `YYYY-MM-DD_short-title` branch names).

---

Fixes #171

## 背景

用户报告升级到 v0.1.36+（引入密度校准 DensityEstimator）后频繁缓存 miss、一次 61k tokens 整段 re-bill。根因在标签渲染链路：`<acp tokens=...>` 的值由 `countTokens = defaultCountTokens × density`（runtime.ts createRuntime 注入内核的闭包）现场计算，密度校准从 1.0 收敛到 2.5 期间重算值漂移。内核的 tokenSnapshot 快照（`dist/index.js:740-781`）只在快照命中时冻结旧值；旧会话状态文件（139/147 无 tokenSnapshot）恢复、压缩后 syncBlocks 剪枝、密度标尺重置（per-model 全局 + 每次 session_start reset）等路径一旦触发重算，标签字节变化 → 从该消息起整段前缀缓存失效。

## 修复方案（issue 建议 A）

将标签 token 值的渲染与密度校准解耦：标签恒用原始 `defaultCountTokens`（确定性、版本稳定），density 只保留用于 nudge/emergency 仲裁。

- `src/tag-tokens.ts`（新增）：`formatTokens`（与内核格式规则逐字一致）、`stableTagTokens`、`rewriteTagTokens`
- `src/messages.ts`：三个标签注入点（normal 注入 / 回退插入 / rebuild 路径）全部改用 raw 稳定值；新增 `coreBodyOf` 精确还原内核渲染契约（tag 后恰一个 `\n`，与 acp-kernel renderMessage 一致）

效果：快照缺失重算也得到相同字节 → 该类全量缓存失效永久消除；旧会话恢复不再触发全量 re-bill。

## 验证

- 新增 `tests/tag-tokens.test.ts` 7 例：formatTokens 边界、raw 计数（CJK/混合）、密度 1.0 vs 2.5 渲染字节逐字一致、rebuild 截断路径、tool 标签类型保留
- `npm run typecheck` 0 错误；`npm test` 328/328 通过（含 rebuild 假阳性回归 #219）
- `npm run build` 成功；bundle 已装运行环境待实测缓存命中稳定性
