### PR TITLE
release v0.1.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (master, since v0.1.38)
 
+- **fix(cache)**: 标签 `tokens=` 与密度校准解耦 — 发给模型的 `<acp>` 标签恒用 raw `defaultCountTokens`（正文纯函数），density 只保留 nudge/emergency 仲裁；消除快照缺失/会话恢复/密度漂移引起的标签字节漂移与前缀缓存全量失效（61k re-bill 根因，closes #171）(#173)
 - Density calibration (Phase 2 of token calibration) + token-count snapshot: kernel 0.0.24→0.0.27 (`acp-kernel`), `src/density.ts` 累积锚点密度估计器（clamp [0.5,2.5]、Δest≥50、±20% 双轮确认、per-model 隔离、压缩后重锚），`countTokens` 注入 kernel；`tokenSnapshot` 跨重启稳定 `<acp>` 标签数字，修复校准期前缀缓存反复重建（closes #146）(#155)
 - Three-level compress cascade (global > provider > model, per-field deepest-wins): `compress.providers` in acp.json (#145)
 - `decompress` `toFile` 加固：拒绝经符号链接逃出 `tmpdir()`/`~/.cache/opencode`/`~/.cache/pi` 的路径（含悬空链接）(#140)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.40",
+	"version": "0.1.41",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.40",
+			"version": "0.1.41",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.40",
+	"version": "0.1.41",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,5 +1,6 @@
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 import type { CoreMessage } from "acp-kernel";
+import { rewriteTagTokens } from "./tag-tokens.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -274,15 +275,23 @@ function reconstructToolCallMessage(
   });
 
   const peeled = peelRefTagBlocks(filtered);
+  const stableTag = rewriteTagTokens(tag, coreBodyOf(firstCore.text ?? "", tag));
   const lastTextIdx = [...peeled].reverse().findIndex((b) => (b as { type?: string }).type === "text");
   if (lastTextIdx >= 0) {
     const idx = peeled.length - 1 - lastTextIdx;
     const lastBlock = peeled[idx] as { type: string; text: string };
     const baseText = lastBlock.text ?? "";
-    peeled[idx] = { ...lastBlock, text: baseText.length > 0 ? `${baseText}\n\n${tag}` : tag };
+    peeled[idx] = { ...lastBlock, text: baseText.length > 0 ? `${baseText}\n\n${stableTag}` : stableTag };
     return { ...(original as object), content: peeled } as AgentMessage;
   }
-  return { ...(original as object), content: [{ type: "text", text: tag }, ...peeled] } as AgentMessage;
+  return { ...(original as object), content: [{ type: "text", text: stableTag }, ...peeled] } as AgentMessage;
+}
+
+function coreBodyOf(coreText: string, tag: string): string {
+  const tagCore = tag.replace(/\s+$/, "");
+  let bodyStart = tagCore.length;
+  if (coreText.charAt(bodyStart) === "\n") bodyStart += 1;
+  return coreText.slice(bodyStart);
 }
 
 function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
@@ -297,15 +306,13 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
   // Honor kernel body mutations (emergency truncation of large tool-results,
   // future rewrites): if core.text's body differs from the original text,
   // rebuild from the kernel body — otherwise truncation never reaches the model.
-  const tagCore = tag.replace(/\s+$/, "");
-  let bodyStart = tagCore.length;
-  if (core.text && core.text.charAt(bodyStart) === "\n") bodyStart += 1;
-  const coreBody = core.text ? core.text.slice(bodyStart) : "";
+  const coreBody = coreBodyOf(core.text ?? "", tag);
   const originalBody = extractText(base.content);
   const trimEnd = (s: string): string => s.replace(/\s+$/, "");
   if (coreBody && trimEnd(coreBody) !== trimEnd(originalBody)) {
-    return rebuildBodyFromCore(original, coreBody, tag);
+    return rebuildBodyFromCore(original, coreBody, rewriteTagTokens(tag, coreBody));
   }
+  const stableTag = rewriteTagTokens(tag, originalBody);
   const rawBlocks = Array.isArray(base.content)
     ? base.content
     : typeof base.content === "string"
@@ -319,7 +326,7 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
     const b = newBlocks[i] as { type?: string; text?: string };
     if (b?.type === "text" && typeof b.text === "string" && b.text.length > 0) {
       const baseText = b.text.replace(/\n*$/, "");
-      newBlocks[i] = { ...b, text: `${baseText}\n\n${tag}` };
+      newBlocks[i] = { ...b, text: `${baseText}\n\n${stableTag}` };
       injected = true;
       break;
     }
@@ -330,7 +337,7 @@ function patchRefTag(original: AgentMessage, core: CoreMessage): AgentMessage {
 
   return {
     ...(original as object),
-    content: [...peeled, { type: "text" as const, text: tag }],
+    content: [...peeled, { type: "text" as const, text: stableTag }],
   } as AgentMessage;
 }
 

--- a/src/tag-tokens.ts
+++ b/src/tag-tokens.ts
@@ -1,0 +1,15 @@
+import { defaultCountTokens } from "acp-kernel";
+
+export function formatTokens(tokens: number): string {
+  if (tokens < 1000) return String(tokens);
+  if (tokens < 10000) return `${(tokens / 1000).toFixed(1)}K`;
+  return `${Math.round(tokens / 1000)}K`;
+}
+
+export function stableTagTokens(text: string): string {
+  return formatTokens(defaultCountTokens(text));
+}
+
+export function rewriteTagTokens(tag: string, body: string): string {
+  return tag.replace(/tokens="[^"]*"/, `tokens="${stableTagTokens(body)}"`);
+}

--- a/tests/tag-tokens.test.ts
+++ b/tests/tag-tokens.test.ts
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatTokens,
+  stableTagTokens,
+  rewriteTagTokens,
+} from "../src/tag-tokens.js";
+import { coreOutToAgentMessages } from "../src/messages.js";
+import type { CoreMessage } from "acp-kernel";
+import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
+
+const LT = "\x3c";
+const GT = "\x3e";
+function acpRef(ref: string, tokens = "2", type = "text"): string {
+  return LT + 'acp tokens="' + tokens + '" type="' + type + '"' + GT + ref + LT + "/acp" + GT;
+}
+
+function msgEntry(id: string, message: object): SessionMessageEntry {
+  return {
+    type: "message",
+    id,
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: message as SessionMessageEntry["message"],
+  };
+}
+
+function user(text: string): object {
+  return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function collectOriginals(entries: SessionEntry[]): Map<string, SessionMessageEntry["message"]> {
+  const originalById = new Map<string, SessionMessageEntry["message"]>();
+  for (const entry of entries) {
+    if (entry.type === "message") originalById.set(entry.id, entry.message);
+  }
+  return originalById;
+}
+
+function simulateTurn(entries: SessionEntry[], coreOut: CoreMessage[]): SessionMessageEntry["message"][] {
+  return coreOutToAgentMessages(coreOut, collectOriginals(entries));
+}
+
+function textOf(msg: SessionMessageEntry["message"]): string {
+  const m = msg as { content?: unknown };
+  const content = m.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .flatMap((b) => {
+        const block = b as { type?: string; text?: string };
+        return block.type === "text" && typeof block.text === "string" ? [block.text] : [];
+      })
+      .join("\n");
+  }
+  return "";
+}
+
+test("formatTokens mirrors kernel formatting rules", () => {
+  assert.equal(formatTokens(0), "0");
+  assert.equal(formatTokens(999), "999");
+  assert.equal(formatTokens(1000), "1.0K");
+  assert.equal(formatTokens(2500), "2.5K");
+  assert.equal(formatTokens(9999), "10.0K");
+  assert.equal(formatTokens(10000), "10K");
+  assert.equal(formatTokens(12345), "12K");
+});
+
+test("stableTagTokens equals raw defaultCountTokens formatting", () => {
+  assert.equal(stableTagTokens(""), "0");
+  assert.equal(stableTagTokens("hello world foo bar baz"), "6");
+  assert.equal(stableTagTokens("这是一个中文测试"), "8");
+  assert.equal(stableTagTokens("hello世界"), "4");
+});
+
+test("rewriteTagTokens replaces tokens= but preserves ref and type", () => {
+  const tag = acpRef("m00042", "5.0K", "bash");
+  const body = "hello world foo bar baz";
+  const out = rewriteTagTokens(tag, body);
+  assert.equal(out, acpRef("m00042", "6", "bash"));
+});
+
+test("tag tokens in output are raw-counted, not density-inflated", () => {
+  const body = "a".repeat(1000);
+  const entries: SessionEntry[] = [msgEntry("mid", user(body))];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", "2.5K")}\n${body}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const text = textOf(out[0]);
+  assert.ok(text.includes(acpRef("m00001", "250")), `expected raw 250 tag, got: ${text.slice(-60)}`);
+  assert.ok(!text.includes('tokens="2.5K"'), "density-inflated tag value must not reach the model");
+});
+
+test("tag token value is deterministic across re-renders at different densities", () => {
+  const body = "这是一个测试。a".repeat(8);
+  const entries: SessionEntry[] = [msgEntry("mid", user(body))];
+  const render = (densityTag: string): string => {
+    const coreOut: CoreMessage[] = [
+      { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", densityTag)}\n${body}` },
+    ];
+    const out = simulateTurn(entries, coreOut);
+    return textOf(out[0]);
+  };
+  const atDensity1 = render("1.0K");
+  const atDensity25 = render("2.5K");
+  assert.equal(atDensity1, atDensity25, "rendered bytes must not depend on calibration density");
+});
+
+test("rebuild path (truncated core body) tags the kernel body with raw tokens", () => {
+  const originalBody = "original body that will be replaced";
+  const coreBody = "x".repeat(800);
+  const entries: SessionEntry[] = [msgEntry("mid", user(originalBody))];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "user", contentType: "text", text: `${acpRef("m00001", "2.5K")}\n${coreBody}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const text = textOf(out[0]);
+  assert.ok(text.startsWith(coreBody), "kernel body must win over the original");
+  assert.ok(text.trimEnd().endsWith(acpRef("m00001", "200")), `expected raw 200 tag at end, got: ${text.slice(-60)}`);
+});
+
+test("tool-result tags keep their type while tokens become raw", () => {
+  const body = "a".repeat(400);
+  const toolMsg = {
+    role: "toolResult",
+    toolName: "bash",
+    toolCallId: "call1",
+    content: body,
+    timestamp: Date.now(),
+  };
+  const entries: SessionEntry[] = [msgEntry("mid", toolMsg)];
+  const coreOut: CoreMessage[] = [
+    { id: "mid", role: "tool", contentType: "tool-result", toolName: "bash", toolCallId: "call1", text: `${acpRef("m00001", "2.0K", "bash")}\n${body}` },
+  ];
+  const out = simulateTurn(entries, coreOut);
+  const content = (out[0] as { content: Array<{ type: string; text: string }> }).content;
+  const texts = content.filter((b) => b.type === "text").map((b) => b.text);
+  assert.ok(texts.some((t) => t.includes(acpRef("m00001", "100", "bash"))), "tool tag type preserved, tokens raw");
+});


### PR DESCRIPTION
Release 0.1.40 → 0.1.41. Release commit touches only `package.json` + lock + CHANGELOG entry; CI `release.yml` publishes on merge.

## Changes since v0.1.40

- `830d771` fix: decouple tag tokens from density calibration (cache-miss root cause #171) — 标签 `tokens=` 恒用 raw `defaultCountTokens`（正文纯函数），密度只保留 nudge/emergency 仲裁；消除快照缺失/会话恢复/密度漂移引起的前缀缓存全量失效
- `82df2d6` release v0.1.41 (version bump + CHANGELOG)

⚠️ 建议先合并 #173（同一 commit 830d771），本 PR 的 diff 会自动收敛为仅版本 bump；若先合并本 PR，修复会随本 PR 一并进入 master，#173 届时显示 already-merged 直接关闭即可。

No dependency changes: `acp-kernel` stays at 0.0.28.

## Preflight
- `npm run typecheck`: 0 errors; `npm test`: **328/328 pass**
