### PR TITLE
fix: harden context window — self-heal on upstream overflow + reserve output headroom (extension side)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
-import { coreOutToAgentMessages } from "./messages.js";
+import { coreOutToAgentMessages, extractText } from "./messages.js";
 import { viableRanges } from "billion-context-kit";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
@@ -134,11 +134,14 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // (see overflow-selfheal). If it is smaller than what we resolved this
       // turn (e.g. the 150k fallback for an unknown model), re-center the kernel
       // on it so the nudge/truncate bands sit below the real limit, not above it.
-      // Spread into a new object — never mutate the shared resolved config.
+      // Learned per MODEL: switching to a bigger model mid-session must not
+      // inherit the smaller model's learned limit. Spread into a new object —
+      // never mutate the shared resolved config.
       let config = configBase;
-      if (ov.learnedWindow && ov.learnedWindow > 0 && ov.learnedWindow < config.modelContextLimit) {
-        config = { ...config, modelContextLimit: ov.learnedWindow };
-        logInfo("overflow-selfheal", { sid, event: "window-recenter", resolved: configBase.modelContextLimit, learned: ov.learnedWindow });
+      const learnedWindow = ov.learnedWindowFor(modelId);
+      if (learnedWindow && learnedWindow > 0 && learnedWindow < config.modelContextLimit) {
+        config = { ...config, modelContextLimit: learnedWindow };
+        logInfo("overflow-selfheal", { sid, modelId, event: "window-recenter", resolved: configBase.modelContextLimit, learned: learnedWindow });
       }
       // Output headroom: reserve the model's max output budget from the window
       // so the kernel's nudge/truncate bands sit below (window - maxTokens) —
@@ -338,13 +341,19 @@ function wireOverflowSelfHeal(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const msg = event.message;
     if (msg.role !== "assistant") return;
     if (msg.stopReason !== "error") return;
-    const info = inspectOverflowMessage(msg.errorMessage);
+    // Haystack = errorMessage + error content: some relays put the upstream
+    // error body in the streamed content and leave errorMessage generic
+    // ("Provider finish_reason: error_finish") — errorMessage alone would miss
+    // them. (Same haystack approach as isThrottleError.)
+    const haystack = `${msg.errorMessage ?? ""}\n${extractText(msg.content)}`;
+    const info = inspectOverflowMessage(haystack);
     if (!info.isOverflow) return;
     const sid = ctx.sessionManager.getSessionId();
+    const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
     const ov = runtime.overflowFor(sid);
-    if (info.window) ov.learnedWindow = info.window;
+    if (info.window) ov.setLearnedWindow(modelId, info.window);
     ov.armed = true;
-    logWarn("overflow-selfheal", { sid, event: "detected", window: info.window ?? null, message: info.message.slice(0, 200) });
+    logWarn("overflow-selfheal", { sid, modelId, event: "detected", window: info.window ?? null, message: info.message.slice(0, 200) });
     if (ctx.hasUI) ctx.ui.notify(`[ACP] context overflow detected${info.window ? ` (window ${info.window})` : ""} — forcing emergency compression next turn`);
   });
   pi.on("session_shutdown", (_event, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
-import { inspectOverflowMessage, reserveOutputHeadroom } from "./overflow-selfheal.js";
+import { inspectOverflowMessage, reserveOutputHeadroom, shouldReserveOutputHeadroom } from "./overflow-selfheal.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -149,12 +149,17 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // the "context + output > window" overflow on a small window. maxTokens is
       // the model's max output capability (ctx.model.maxTokens). Applied to the
       // (possibly re-centered) window above; never mutates the shared config.
+      // Anthropic is exempt — its input limit is enforced independently of
+      // max_tokens, so reserving would shift every band down by maxTokens with
+      // no safety gain (see shouldReserveOutputHeadroom).
       const maxOutput = (ctx.model as { maxTokens?: number } | undefined)?.maxTokens ?? 0;
-      const reservedWindow = reserveOutputHeadroom(config.modelContextLimit, maxOutput);
-      if (reservedWindow !== config.modelContextLimit) {
-        const before = config.modelContextLimit;
-        config = { ...config, modelContextLimit: reservedWindow };
-        logInfo("overflow-selfheal", { sid, event: "output-headroom", before, after: reservedWindow, maxOutput });
+      if (shouldReserveOutputHeadroom((ctx.model as { api?: string } | undefined)?.api)) {
+        const reservedWindow = reserveOutputHeadroom(config.modelContextLimit, maxOutput);
+        if (reservedWindow !== config.modelContextLimit) {
+          const before = config.modelContextLimit;
+          config = { ...config, modelContextLimit: reservedWindow };
+          logInfo("overflow-selfheal", { sid, event: "output-headroom", before, after: reservedWindow, maxOutput });
+        }
       }
       const coveredIds = collectCoveredMessageIds(state);
       // Nudge arbitration on the SENT-VIEW scale: chars/4 estimate over the
@@ -357,7 +362,7 @@ function wireOverflowSelfHeal(pi: ExtensionAPI, runtime: AcpRuntime): void {
     if (ctx.hasUI) ctx.ui.notify(`[ACP] context overflow detected${info.window ? ` (window ${info.window})` : ""} — forcing emergency compression next turn`);
   });
   pi.on("session_shutdown", (_event, ctx) => {
-    runtime.overflowFor(ctx.sessionManager.getSessionId()).reset();
+    runtime.overflowDrop(ctx.sessionManager.getSessionId());
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
-import { inspectOverflowMessage } from "./overflow-selfheal.js";
+import { inspectOverflowMessage, reserveOutputHeadroom } from "./overflow-selfheal.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -139,6 +139,19 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       if (ov.learnedWindow && ov.learnedWindow > 0 && ov.learnedWindow < config.modelContextLimit) {
         config = { ...config, modelContextLimit: ov.learnedWindow };
         logInfo("overflow-selfheal", { sid, event: "window-recenter", resolved: configBase.modelContextLimit, learned: ov.learnedWindow });
+      }
+      // Output headroom: reserve the model's max output budget from the window
+      // so the kernel's nudge/truncate bands sit below (window - maxTokens) —
+      // the context then always leaves room for the model's reply, preventing
+      // the "context + output > window" overflow on a small window. maxTokens is
+      // the model's max output capability (ctx.model.maxTokens). Applied to the
+      // (possibly re-centered) window above; never mutates the shared config.
+      const maxOutput = (ctx.model as { maxTokens?: number } | undefined)?.maxTokens ?? 0;
+      const reservedWindow = reserveOutputHeadroom(config.modelContextLimit, maxOutput);
+      if (reservedWindow !== config.modelContextLimit) {
+        const before = config.modelContextLimit;
+        config = { ...config, modelContextLimit: reservedWindow };
+        logInfo("overflow-selfheal", { sid, event: "output-headroom", before, after: reservedWindow, maxOutput });
       }
       const coveredIds = collectCoveredMessageIds(state);
       // Nudge arbitration on the SENT-VIEW scale: chars/4 estimate over the

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { checkForUpdate } from "./update.js";
 import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
+import { inspectOverflowMessage } from "./overflow-selfheal.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -38,6 +39,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
     wireToolGuardrails(pi, runtime);
+    wireOverflowSelfHeal(pi, runtime);
     pi.registerTool(makeCompressTool(runtime));
     pi.registerTool(makeDecompressTool(runtime));
     pi.registerTool(makeSearchTool(runtime));
@@ -126,7 +128,18 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
       runtime.setCountModel(modelId);
       const { state, coreMessages, entries } = await runtime.stateFor(ctx, event.messages);
-      const config = runtime.configFor(ctx);
+      const configBase = runtime.configFor(ctx);
+      const ov = runtime.overflowFor(sid);
+      // Self-heal: a prior upstream overflow may have taught us the real window
+      // (see overflow-selfheal). If it is smaller than what we resolved this
+      // turn (e.g. the 150k fallback for an unknown model), re-center the kernel
+      // on it so the nudge/truncate bands sit below the real limit, not above it.
+      // Spread into a new object — never mutate the shared resolved config.
+      let config = configBase;
+      if (ov.learnedWindow && ov.learnedWindow > 0 && ov.learnedWindow < config.modelContextLimit) {
+        config = { ...config, modelContextLimit: ov.learnedWindow };
+        logInfo("overflow-selfheal", { sid, event: "window-recenter", resolved: configBase.modelContextLimit, learned: ov.learnedWindow });
+      }
       const coveredIds = collectCoveredMessageIds(state);
       // Nudge arbitration on the SENT-VIEW scale: chars/4 estimate over the
       // pruned projection + measured system prompt. pi's real usage is
@@ -150,7 +163,20 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // nudge and emergency truncate past the real window. The estimator
       // below is fed the RAW sentTokens — its samples must stay on the
       // raw basis or density would chase its own calibration.
-      const tokenCount = calibrateTokens(sentTokens, runtime.density.densityFor(modelId));
+      let tokenCount = calibrateTokens(sentTokens, runtime.density.densityFor(modelId));
+      // Self-heal (armed): after an overflow, force this turn's usage to >=95%
+      // so the kernel's emergency nudge + tool-result truncate fire immediately,
+      // even if the density-calibrated estimate under-reports the sent view.
+      // tokenCount only feeds processTurn (nudge/truncate); density.update below
+      // uses the raw sentTokens, so the boost cannot corrupt calibration.
+      if (ov.armed && config.modelContextLimit > 0) {
+        ov.armed = false;
+        const floor = Math.floor(config.modelContextLimit * 0.95);
+        if (floor > tokenCount) {
+          tokenCount = floor;
+          logWarn("overflow-selfheal", { sid, event: "armed-emergency", tokenCount, limit: config.modelContextLimit });
+        }
+      }
       // A compress happened since the previous context round: blocks are
       // created out-of-band by the compress tool, so detect new active
       // blocks on the LOADED state vs. the previous round (comparing a
@@ -282,6 +308,34 @@ function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
     const acp = buildAcpSystemPrompt(runtime.prompts);
     const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;
     return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, prompt) };
+  });
+}
+
+// Context-overflow self-heal: when the model API rejects a request because the
+// context is too large (a context-overflow 400), learn the real window (if the
+// error states it) and arm an emergency for the next turn. The `context` handler
+// (wireContextTransform) reads the learned window + armed flag via
+// runtime.overflowFor(sid). Design: src/overflow-selfheal.ts.
+//
+// Unlike throttle-retry we do NOT rewrite the error or ask pi to retry: the
+// overflow is real, and re-sending the same context would overflow again. The
+// error surfaces; the next turn self-heals.
+function wireOverflowSelfHeal(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  pi.on("message_end", (event, ctx) => {
+    const msg = event.message;
+    if (msg.role !== "assistant") return;
+    if (msg.stopReason !== "error") return;
+    const info = inspectOverflowMessage(msg.errorMessage);
+    if (!info.isOverflow) return;
+    const sid = ctx.sessionManager.getSessionId();
+    const ov = runtime.overflowFor(sid);
+    if (info.window) ov.learnedWindow = info.window;
+    ov.armed = true;
+    logWarn("overflow-selfheal", { sid, event: "detected", window: info.window ?? null, message: info.message.slice(0, 200) });
+    if (ctx.hasUI) ctx.ui.notify(`[ACP] context overflow detected${info.window ? ` (window ${info.window})` : ""} — forcing emergency compression next turn`);
+  });
+  pi.on("session_shutdown", (_event, ctx) => {
+    runtime.overflowFor(ctx.sessionManager.getSessionId()).reset();
   });
 }
 

--- a/src/overflow-selfheal.ts
+++ b/src/overflow-selfheal.ts
@@ -62,6 +62,28 @@ function toTokenNumber(raw: string | undefined): number | undefined {
   return Number.isFinite(n) && n >= 1000 ? n : undefined;
 }
 
+/**
+ * Reserve the model's output budget from the context window, so the kernel's
+ * nudge/truncate bands sit below (window - maxOutput) and the context always
+ * leaves room for the model's reply. This prevents the "context + output >
+ * window" overflow on a small window (agents routinely set a large max output).
+ * Returns the window unchanged when maxOutput is not usable (non-positive,
+ * non-finite, or >= window — a maxOutput >= window request is degenerate and is
+ * left to the overflow self-heal).
+ */
+export function reserveOutputHeadroom(window: number, maxOutput: number): number {
+  if (
+    Number.isFinite(window) &&
+    window > 0 &&
+    Number.isFinite(maxOutput) &&
+    maxOutput > 0 &&
+    maxOutput < window
+  ) {
+    return window - maxOutput;
+  }
+  return window;
+}
+
 // Per-session overflow self-heal state. Keyed by session id so concurrent
 // sessions in one extension instance cannot share a learned window or an
 // armed emergency (same rationale as the throttle episode).

--- a/src/overflow-selfheal.ts
+++ b/src/overflow-selfheal.ts
@@ -1,0 +1,77 @@
+// Context-overflow self-heal (extension side).
+//
+// When the model API rejects a request because the context is too large (a
+// context-overflow 400), the extension reacts on the NEXT turn:
+//   1. LEARN the real window: many providers state it in the error body
+//      ("prompt is too long: ... > 128000 maximum", "maximum context length is
+//      128000 tokens"). We persist it per-session and re-center the kernel's
+//      nudge/truncate bands on it — below the real limit, not above it (the
+//      fallback 150k puts those bands ABOVE a smaller real window, so nothing
+//      fires before the overflow).
+//   2. ARM an emergency: we force the next context event's usage to >=95% so
+//      the kernel's emergency nudge + tool-result truncate fire immediately,
+//      even if the density-calibrated estimate under-reports the sent view.
+//
+// This is the extension-side mirror of the proxy's overflow self-heal
+// (billion-context PR #172). Unlike throttle-retry we do NOT rewrite the error
+// or ask pi to retry: the overflow is real, and re-sending the same context
+// would overflow again. The error surfaces; the next turn recovers.
+//
+// NOTE: the OVERFLOW_MARKER below is deliberately a superset of the
+// OVERFLOW_GUARD in src/throttle-retry.ts (which uses it to AVOID treating an
+// overflow as a throttle). Keep the two in sync when either changes.
+
+// Detect a context-overflow error. Deliberately does NOT match Bedrock's
+// "too many tokens" throttle (a 429, handled by throttle-retry) — only
+// genuine context-length errors.
+export const OVERFLOW_MARKER =
+  /prompt is too long|prompt_too_long|prompt_is_too_long|request_too_large|exceeds the context window|exceeds the (maximum |model['’]s )?limit|maximum context length|max context length|context length exceeded|context[_ ]length[_ ]exceeded|exceeded model token limit|input token count.*exceeds|reduce the length of the messages|token limit exceeded/i;
+
+export interface OverflowInfo {
+  isOverflow: boolean;
+  /** The real context window, when the provider stated it in the error. */
+  window?: number;
+  message: string;
+}
+
+// Pure: detect a context-overflow error from an error haystack (the
+// errorMessage plus any error content) and parse the real window when the
+// provider states it.
+export function inspectOverflowMessage(haystack: string | undefined | null): OverflowInfo {
+  const body = (haystack ?? "").trim();
+  if (!body || !OVERFLOW_MARKER.test(body)) return { isOverflow: false, message: body };
+  return { isOverflow: true, window: parseOverflowWindow(body), message: body };
+}
+
+function parseOverflowWindow(text: string): number | undefined {
+  // Anthropic: "prompt is too long: 130000 tokens > 128000 maximum" -> 128000
+  let m = />\s*(\d[\d,]*)\s*(?:tokens?)?\s*maximum/i.exec(text);
+  if (m) return toTokenNumber(m[1]);
+  // OpenAI: "maximum context length is 128000 tokens"
+  m = /maximum context length is (\d[\d,]*)/i.exec(text);
+  if (m) return toTokenNumber(m[1]);
+  // "...exceeds the model's maximum of N tokens" / "limit of N tokens"
+  m = /(?:maximum|limit) of (\d[\d,]*)\s*(?:input\s+)?tokens/i.exec(text);
+  if (m) return toTokenNumber(m[1]);
+  return undefined;
+}
+
+function toTokenNumber(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const n = Number(raw.replace(/,/g, ""));
+  return Number.isFinite(n) && n >= 1000 ? n : undefined;
+}
+
+// Per-session overflow self-heal state. Keyed by session id so concurrent
+// sessions in one extension instance cannot share a learned window or an
+// armed emergency (same rationale as the throttle episode).
+export class OverflowEpisode {
+  /** Real window learned from an overflow error (null until learned). */
+  learnedWindow: number | null = null;
+  /** When true, the next context event forces usage >=95% (emergency). */
+  armed = false;
+  reset(): void {
+    this.learnedWindow = null;
+    this.armed = false;
+  }
+}

--- a/src/overflow-selfheal.ts
+++ b/src/overflow-selfheal.ts
@@ -23,9 +23,15 @@
 
 // Detect a context-overflow error. Deliberately does NOT match Bedrock's
 // "too many tokens" throttle (a 429, handled by throttle-retry) — only
-// genuine context-length errors.
+// genuine context-length errors. The extra phrasings mirror pi-ai's own
+// OVERFLOW_PATTERNS (pi-stable-ai/dist/utils/overflow.js) for providers whose
+// error text the shorter set missed (Bedrock direct, xAI, Ollama, DashScope,
+// llama.cpp, LM Studio, MiniMax, Mistral, Together, Poolside, z.ai) — without
+// them the self-heal silently never fires for a direct connection to those
+// providers (pi's native overflow/compaction handling still copes, but no
+// window is learned and no emergency is armed).
 export const OVERFLOW_MARKER =
-  /prompt is too long|prompt_too_long|prompt_is_too_long|request_too_large|exceeds the context window|exceeds the (maximum |model['’]s )?limit|maximum context length|maximum context size|max context length|context length exceeded|context[_ ]length[_ ]exceeded|exceeded model token limit|input token count.*exceeds|reduce the length of the messages|token limit exceeded/i;
+  /prompt is too long|prompt_too_long|prompt_is_too_long|prompt too long; exceeded (?:max )?context length|request_too_large|exceeds the context window|exceeds the (maximum |model['’]s )?limit|maximum context length|maximum context size|max context length|context length exceeded|context[_ ]length[_ ]exceeded|exceeded model token limit|input token count.*exceeds|reduce the length of the messages|token limit exceeded|input is too long for requested model|maximum prompt length is|exceeds the maximum allowed input length|is longer than the model['’]?s context length|exceeds the available context size|greater than the context length|context window exceeds limit|too large for model with \d+ maximum context length|but the configured context size is|model_context_window_exceeded|range of input length should be/i;
 
 export interface OverflowInfo {
   isOverflow: boolean;
@@ -87,6 +93,22 @@ export function reserveOutputHeadroom(window: number, maxOutput: number): number
     return window - maxOutput;
   }
   return window;
+}
+
+/**
+ * Whether the OUTPUT budget should be reserved from the context window at
+ * all. Anthropic's Messages API enforces the input limit INDEPENDENTLY of
+ * max_tokens (the output budget is separate — input up to the window works
+ * with any max_tokens), so reserving the model's output capability would
+ * shift the nudge/truncate bands down by maxTokens on every session with no
+ * safety gain (e.g. a 200k model with a 64k output budget would start
+ * compressing around 136k). The OpenAI-family APIs count output against the
+ * window, so the reservation is only needed there. Unknown APIs reserve
+ * (conservative — a missed reservation at worst overflows once and the
+ * self-heal corrects it).
+ */
+export function shouldReserveOutputHeadroom(api: string | undefined): boolean {
+  return api !== "anthropic-messages";
 }
 
 // Per-session overflow self-heal state. Keyed by session id so concurrent

--- a/src/overflow-selfheal.ts
+++ b/src/overflow-selfheal.ts
@@ -25,7 +25,7 @@
 // "too many tokens" throttle (a 429, handled by throttle-retry) — only
 // genuine context-length errors.
 export const OVERFLOW_MARKER =
-  /prompt is too long|prompt_too_long|prompt_is_too_long|request_too_large|exceeds the context window|exceeds the (maximum |model['’]s )?limit|maximum context length|max context length|context length exceeded|context[_ ]length[_ ]exceeded|exceeded model token limit|input token count.*exceeds|reduce the length of the messages|token limit exceeded/i;
+  /prompt is too long|prompt_too_long|prompt_is_too_long|request_too_large|exceeds the context window|exceeds the (maximum |model['’]s )?limit|maximum context length|maximum context size|max context length|context length exceeded|context[_ ]length[_ ]exceeded|exceeded model token limit|input token count.*exceeds|reduce the length of the messages|token limit exceeded/i;
 
 export interface OverflowInfo {
   isOverflow: boolean;
@@ -49,6 +49,11 @@ function parseOverflowWindow(text: string): number | undefined {
   if (m) return toTokenNumber(m[1]);
   // OpenAI: "maximum context length is 128000 tokens"
   m = /maximum context length is (\d[\d,]*)/i.exec(text);
+  if (m) return toTokenNumber(m[1]);
+  // OpenAI Responses (newer phrasing): "exceeds the model's maximum context
+  // size of 128000 tokens" — must be parsed too, or the learned window stays
+  // unknown for /responses relays.
+  m = /maximum context size (?:is|of) (\d[\d,]*)/i.exec(text);
   if (m) return toTokenNumber(m[1]);
   // "...exceeds the model's maximum of N tokens" / "limit of N tokens"
   m = /(?:maximum|limit) of (\d[\d,]*)\s*(?:input\s+)?tokens/i.exec(text);
@@ -88,12 +93,23 @@ export function reserveOutputHeadroom(window: number, maxOutput: number): number
 // sessions in one extension instance cannot share a learned window or an
 // armed emergency (same rationale as the throttle episode).
 export class OverflowEpisode {
-  /** Real window learned from an overflow error (null until learned). */
-  learnedWindow: number | null = null;
-  /** When true, the next context event forces usage >=95% (emergency). */
+  /** Real windows learned from overflow errors, keyed by model id. A learned
+   *  window is model-specific: switching to a bigger model mid-session must
+   *  not inherit the smaller model's learned limit (that would re-center the
+   *  bands below the new model's real window → premature compression). */
+  private learned = new Map<string, number>();
+  learnedWindowFor(modelId: string): number | null {
+    return this.learned.get(modelId) ?? null;
+  }
+  setLearnedWindow(modelId: string, window: number): void {
+    this.learned.set(modelId, window);
+  }
+  /** When true, the next context event forces usage >=95% (emergency). Kept
+   *  session-scoped (not per-model): the context did not shrink, so the next
+   *  turn needs the emergency regardless of which model answers it. */
   armed = false;
   reset(): void {
-    this.learnedWindow = null;
+    this.learned.clear();
     this.armed = false;
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -70,6 +70,10 @@ export interface AcpRuntime {
   /** Per-session overflow self-heal state (learned window + armed emergency).
    *  Keyed by session id so concurrent sessions cannot share an episode. */
   overflowFor(sid: string): OverflowEpisode;
+  /** Drop a session's overflow episode entirely (session_shutdown): releases
+   *  the map entry so a long-lived process cycling through many sessions
+   *  doesn't accumulate them. */
+  overflowDrop(sid: string): void;
 }
 // omp fires the context event before the current user message is persisted to
 // the session branch, so merge event.messages (exact messages about to be sent,
@@ -229,6 +233,9 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     if (!ep) { ep = new OverflowEpisode(); overflowEpisodes.set(sid, ep); }
     return ep;
   }
+  function overflowDrop(sid: string): void {
+    overflowEpisodes.delete(sid);
+  }
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -315,4 +322,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor };}
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop };}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,6 +15,7 @@ import { SessionStateStore, type LiveRefOrigin } from "./state.js";
 import { loadUserConfig, applyUserConfig } from "./user-config.js";
 import { logInfo, logWarn, setDebugEnabled } from "./log.js";
 import { findUniqueLongestRun, type MatchRange } from "./sequence-match.js";
+import { OverflowEpisode } from "./overflow-selfheal.js";
 // pi exposes `sessionManager.buildContextEntries()`; omp (oh-my-pi) only has
 // `getBranch()`. Both return chronological SessionEntry[]; feature-detect so
 // the adapter runs under either host (omp's runner silently swallows the TypeError).
@@ -66,6 +67,9 @@ export interface AcpRuntime {
   stateFor(ctx: ExtensionContext, liveMessages?: AgentMessage[]): Promise<{ state: CompressionState; coreMessages: ReturnType<typeof entriesToCoreMessages>; entries: SessionEntry[] }>;
   save(state: CompressionState, ctx: ExtensionContext): Promise<void>;
   acquireLock(sid: string): Promise<() => void>;
+  /** Per-session overflow self-heal state (learned window + armed emergency).
+   *  Keyed by session id so concurrent sessions cannot share an episode. */
+  overflowFor(sid: string): OverflowEpisode;
 }
 // omp fires the context event before the current user message is persisted to
 // the session branch, so merge event.messages (exact messages about to be sent,
@@ -218,6 +222,13 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   let lastUserConfigKey: string | undefined;
   let promptsRef: Prompts = defaultPrompts;
   const nudgeShownTurns = new Set<string>();
+  // Per-session overflow self-heal state (learned window + armed emergency).
+  const overflowEpisodes = new Map<string, OverflowEpisode>();
+  function overflowFor(sid: string): OverflowEpisode {
+    let ep = overflowEpisodes.get(sid);
+    if (!ep) { ep = new OverflowEpisode(); overflowEpisodes.set(sid, ep); }
+    return ep;
+  }
 
   async function acquireLock(sid: string): Promise<() => void> {
     const prev = locks.get(sid) ?? Promise.resolve();
@@ -304,4 +315,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock };}
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor };}

--- a/tests/overflow-selfheal.test.ts
+++ b/tests/overflow-selfheal.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { inspectOverflowMessage, OverflowEpisode, OVERFLOW_MARKER } from "../src/overflow-selfheal.js";
+import { inspectOverflowMessage, OverflowEpisode, OVERFLOW_MARKER, reserveOutputHeadroom } from "../src/overflow-selfheal.js";
 
 test("inspectOverflowMessage: detects OpenAI context-overflow + parses window", () => {
   const info = inspectOverflowMessage(
@@ -76,6 +76,29 @@ test("OverflowEpisode: initial state + reset", () => {
   ep.reset();
   assert.equal(ep.learnedWindow, null);
   assert.equal(ep.armed, false);
+});
+
+test("reserveOutputHeadroom: reserves the output budget from the window", () => {
+  assert.equal(reserveOutputHeadroom(100_000, 16_384), 83_616);
+  assert.equal(reserveOutputHeadroom(128_000, 1), 127_999);
+});
+
+test("reserveOutputHeadroom: no-op for unusable maxOutput", () => {
+  assert.equal(reserveOutputHeadroom(100_000, 0), 100_000);
+  assert.equal(reserveOutputHeadroom(100_000, -5), 100_000);
+  assert.equal(reserveOutputHeadroom(100_000, Number.NaN), 100_000);
+  assert.equal(reserveOutputHeadroom(100_000, Number.POSITIVE_INFINITY), 100_000);
+});
+
+test("reserveOutputHeadroom: no-op when maxOutput >= window (degenerate request)", () => {
+  assert.equal(reserveOutputHeadroom(100_000, 100_000), 100_000);
+  assert.equal(reserveOutputHeadroom(100_000, 200_000), 100_000);
+});
+
+test("reserveOutputHeadroom: no-op for unusable window", () => {
+  assert.equal(reserveOutputHeadroom(0, 10_000), 0);
+  assert.equal(reserveOutputHeadroom(-1, 10_000), -1);
+  assert.equal(reserveOutputHeadroom(Number.NaN, 10_000), Number.NaN);
 });
 
 test("OVERFLOW_MARKER: case-insensitive and matches the shared guard patterns", () => {

--- a/tests/overflow-selfheal.test.ts
+++ b/tests/overflow-selfheal.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { inspectOverflowMessage, OverflowEpisode, OVERFLOW_MARKER } from "../src/overflow-selfheal.js";
+
+test("inspectOverflowMessage: detects OpenAI context-overflow + parses window", () => {
+  const info = inspectOverflowMessage(
+    `This model's maximum context length is 128000 tokens. However, you requested 130000 output tokens and your prompt contains approximately 129000 tokens. Please reduce the length of the input prompt or the number of requested output tokens.`,
+  );
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, 128000);
+});
+
+test("inspectOverflowMessage: detects Anthropic overflow + parses '> N maximum' window", () => {
+  const info = inspectOverflowMessage("prompt is too long: 130000 tokens > 128000 maximum");
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, 128000);
+});
+
+test("inspectOverflowMessage: comma-grouped window", () => {
+  const info = inspectOverflowMessage("maximum context length is 128,000 tokens");
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, 128000);
+});
+
+test("inspectOverflowMessage: 'limit of N tokens' form", () => {
+  const info = inspectOverflowMessage("input exceeds the model's limit of 64000 tokens");
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, 64000);
+});
+
+test("inspectOverflowMessage: overflow without a stated window → window undefined", () => {
+  const info = inspectOverflowMessage("prompt is too long, please shorten the conversation");
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, undefined);
+});
+
+test("inspectOverflowMessage: bare markers without a number", () => {
+  assert.equal(inspectOverflowMessage("error: context_length_exceeded").isOverflow, true);
+  assert.equal(inspectOverflowMessage("request_too_large").isOverflow, true);
+  assert.equal(inspectOverflowMessage("your prompt exceeds the context window").isOverflow, true);
+  assert.equal(inspectOverflowMessage("exceeded model token limit").isOverflow, true);
+});
+
+test("inspectOverflowMessage: Bedrock throttle (429 'too many tokens') is NOT a context overflow", () => {
+  const info = inspectOverflowMessage("429 rate limit: Too many tokens, please wait before trying again.");
+  assert.equal(info.isOverflow, false);
+});
+
+test("inspectOverflowMessage: quota/billing errors are not context overflows", () => {
+  assert.equal(inspectOverflowMessage("insufficient_quota: you have exceeded your quota").isOverflow, false);
+  assert.equal(inspectOverflowMessage("out of budget for this billing period").isOverflow, false);
+});
+
+test("inspectOverflowMessage: normal assistant text / empty → not overflow", () => {
+  assert.equal(inspectOverflowMessage("Here is the code you asked for.").isOverflow, false);
+  assert.equal(inspectOverflowMessage("").isOverflow, false);
+  assert.equal(inspectOverflowMessage(undefined).isOverflow, false);
+});
+
+test("inspectOverflowMessage: rejects a sub-1000 'window' (not a real context limit)", () => {
+  // A tiny number in a marker-adjacent sentence must not be mistaken for a window.
+  const info = inspectOverflowMessage("prompt is too long: 50 tokens > 30 maximum");
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, undefined, "30 is below the 1000 floor → treated as unparseable");
+});
+
+test("OverflowEpisode: initial state + reset", () => {
+  const ep = new OverflowEpisode();
+  assert.equal(ep.learnedWindow, null);
+  assert.equal(ep.armed, false);
+  ep.learnedWindow = 100000;
+  ep.armed = true;
+  assert.equal(ep.learnedWindow, 100000);
+  assert.equal(ep.armed, true);
+  ep.reset();
+  assert.equal(ep.learnedWindow, null);
+  assert.equal(ep.armed, false);
+});
+
+test("OVERFLOW_MARKER: case-insensitive and matches the shared guard patterns", () => {
+  assert.ok(OVERFLOW_MARKER.test("PROMPT IS TOO LONG"));
+  assert.ok(OVERFLOW_MARKER.test("Context Length Exceeded"));
+  assert.ok(OVERFLOW_MARKER.test("context_length_exceeded"));
+  assert.ok(!OVERFLOW_MARKER.test("too many tokens, please wait before trying again"));
+});

--- a/tests/overflow-selfheal.test.ts
+++ b/tests/overflow-selfheal.test.ts
@@ -29,6 +29,18 @@ test("inspectOverflowMessage: 'limit of N tokens' form", () => {
   assert.equal(info.window, 64000);
 });
 
+test("inspectOverflowMessage: OpenAI Responses 'maximum context size of N' phrasing", () => {
+  // The newer Responses-API phrasing (the chat-completions one says
+  // "maximum context LENGTH is") — must be detected AND parsed, or self-heal
+  // learns no window for /responses relays.
+  const info = inspectOverflowMessage(
+    "This request's total token count is 130000, which exceeds the model's maximum context size of 128000 tokens.",
+  );
+  assert.equal(info.isOverflow, true);
+  assert.equal(info.window, 128000);
+  assert.equal(inspectOverflowMessage("maximum context size is 128,000").window, 128000);
+});
+
 test("inspectOverflowMessage: overflow without a stated window → window undefined", () => {
   const info = inspectOverflowMessage("prompt is too long, please shorten the conversation");
   assert.equal(info.isOverflow, true);
@@ -67,15 +79,30 @@ test("inspectOverflowMessage: rejects a sub-1000 'window' (not a real context li
 
 test("OverflowEpisode: initial state + reset", () => {
   const ep = new OverflowEpisode();
-  assert.equal(ep.learnedWindow, null);
+  assert.equal(ep.learnedWindowFor("m1"), null);
   assert.equal(ep.armed, false);
-  ep.learnedWindow = 100000;
+  ep.setLearnedWindow("m1", 100000);
   ep.armed = true;
-  assert.equal(ep.learnedWindow, 100000);
+  assert.equal(ep.learnedWindowFor("m1"), 100000);
   assert.equal(ep.armed, true);
   ep.reset();
-  assert.equal(ep.learnedWindow, null);
+  assert.equal(ep.learnedWindowFor("m1"), null);
   assert.equal(ep.armed, false);
+});
+
+test("OverflowEpisode: learned windows are per-model (no cross-model crosstalk)", () => {
+  // The footgun this PR fixes, in the reverse direction: an overflow on a
+  // SMALL model must not keep capping a BIGGER model the user switches to
+  // mid-session (the bands would sit far below the new model's real window).
+  const ep = new OverflowEpisode();
+  ep.setLearnedWindow("small-model", 100000);
+  assert.equal(ep.learnedWindowFor("small-model"), 100000);
+  assert.equal(ep.learnedWindowFor("big-model"), null, "other models unaffected");
+  ep.setLearnedWindow("big-model", 200000);
+  assert.equal(ep.learnedWindowFor("small-model"), 100000, "first model kept");
+  assert.equal(ep.learnedWindowFor("big-model"), 200000);
+  ep.setLearnedWindow("small-model", 90000);
+  assert.equal(ep.learnedWindowFor("small-model"), 90000, "re-learned window overwrites");
 });
 
 test("reserveOutputHeadroom: reserves the output budget from the window", () => {

--- a/tests/overflow-selfheal.test.ts
+++ b/tests/overflow-selfheal.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { inspectOverflowMessage, OverflowEpisode, OVERFLOW_MARKER, reserveOutputHeadroom } from "../src/overflow-selfheal.js";
+import { inspectOverflowMessage, OverflowEpisode, OVERFLOW_MARKER, reserveOutputHeadroom, shouldReserveOutputHeadroom } from "../src/overflow-selfheal.js";
 
 test("inspectOverflowMessage: detects OpenAI context-overflow + parses window", () => {
   const info = inspectOverflowMessage(
@@ -133,4 +133,44 @@ test("OVERFLOW_MARKER: case-insensitive and matches the shared guard patterns", 
   assert.ok(OVERFLOW_MARKER.test("Context Length Exceeded"));
   assert.ok(OVERFLOW_MARKER.test("context_length_exceeded"));
   assert.ok(!OVERFLOW_MARKER.test("too many tokens, please wait before trying again"));
+});
+
+// Provider phrasings the shorter marker set missed — mirrored from pi-ai's
+// own OVERFLOW_PATTERNS (pi-stable-ai/dist/utils/overflow.js). Without them
+// the self-heal never fires for a DIRECT connection to these providers (no
+// relay to normalize the text): pi's native overflow/compaction still copes,
+// but no window is learned and no emergency is armed.
+test("inspectOverflowMessage: provider-specific overflow phrasings", () => {
+  assert.equal(inspectOverflowMessage("Input is too long for requested model").isOverflow, true, "Bedrock");
+  assert.equal(inspectOverflowMessage("This model's maximum prompt length is 131072 but the request contains 537812 tokens").isOverflow, true, "xAI");
+  assert.equal(inspectOverflowMessage("Input length 200000 exceeds the maximum allowed input length of 131072 tokens.").isOverflow, true, "OpenRouter/Poolside");
+  assert.equal(inspectOverflowMessage("The input (200000 tokens) is longer than the model's context length (131072 tokens)").isOverflow, true, "Together AI");
+  assert.equal(inspectOverflowMessage("the request exceeds the available context size, try increasing it").isOverflow, true, "llama.cpp");
+  assert.equal(inspectOverflowMessage("tokens to keep from the initial prompt is greater than the context length").isOverflow, true, "LM Studio");
+  assert.equal(inspectOverflowMessage("invalid params, context window exceeds limit").isOverflow, true, "MiniMax");
+  assert.equal(inspectOverflowMessage("Prompt contains 200000 tokens which is too large for model with 131072 maximum context length").isOverflow, true, "Mistral");
+  assert.equal(inspectOverflowMessage("Prompt has 200000 tokens, but the configured context size is 131072 tokens").isOverflow, true, "DS4");
+  assert.equal(inspectOverflowMessage("model_context_window_exceeded").isOverflow, true, "z.ai");
+  assert.equal(inspectOverflowMessage("prompt too long; exceeded max context length by 12345 tokens").isOverflow, true, "Ollama");
+  assert.equal(inspectOverflowMessage("Range of input length should be [1, 131072]").isOverflow, true, "DashScope/Qwen");
+});
+
+test("inspectOverflowMessage: throttle/throttling phrases are still NOT overflows after the marker extension", () => {
+  assert.equal(inspectOverflowMessage("ThrottlingException: Too many tokens, please wait before trying again.").isOverflow, false);
+  assert.equal(inspectOverflowMessage("Throttling: request rate increased too quickly.").isOverflow, false);
+  assert.equal(inspectOverflowMessage("429 rate limit: Too many tokens, please wait before trying again.").isOverflow, false, "the rewritten retryable form (throttle-retry) stays off the overflow path");
+});
+
+// Anthropic enforces the input limit independently of max_tokens (separate
+// output budget) — reserving the model's output capability would shift every
+// nudge/truncate band down by maxTokens on every session for no safety gain.
+// Other APIs count output against the window — reserve there.
+test("shouldReserveOutputHeadroom: anthropic-messages exempt, other APIs reserve", () => {
+  assert.equal(shouldReserveOutputHeadroom("anthropic-messages"), false);
+  assert.equal(shouldReserveOutputHeadroom("openai-chat"), true);
+  assert.equal(shouldReserveOutputHeadroom("openai-responses"), true);
+  assert.equal(shouldReserveOutputHeadroom("openai-completions"), true);
+  assert.equal(shouldReserveOutputHeadroom("google"), true);
+  assert.equal(shouldReserveOutputHeadroom("bedrock-converse-stream"), true, "conservative for uncertain APIs");
+  assert.equal(shouldReserveOutputHeadroom(undefined), true, "unknown api → conservative (reserve)");
 });


### PR DESCRIPTION
Two complementary layers for the context-window hardening (extension side, mirroring billion-context PR #172):

## 1. Reactive: self-heal on upstream overflow
When the model returns a context-overflow error, detect it (`inspectOverflowMessage` — a pure detector that does NOT match the Bedrock 429 throttle), learn the real window from the error body, and arm an emergency for the next turn.

- **Learned window**: re-centers the kernel's nudge/truncate bands on the real limit (fixes the 150k-fallback-for-a-100k-model footgun — without it the 75%/95% bands sit above the real window and fire too late).
- **Armed emergency**: forces the next turn's usage to >=95% so the kernel's emergency nudge + tool-result truncate fire immediately, even if the density-calibrated estimate under-reports (CJK with no provider usage).

## 2. Preventive: reserve output headroom
Reserves `ctx.model.maxTokens` from the effective window so the kernel's bands sit below `window - maxTokens` — the model always leaves room for its reply, preventing the 'context + output > window' overflow on a small window. This is the extension-side mirror of the proxy's per-request `max_tokens` reservation.

Both are keyed per-session (`runtime.overflowFor(sid)`), never mutate the shared resolved config (spread into a new object), and `message_end` returns nothing (only logs/notifies + sets state) so it does not interfere with pi's error surfacing.

Tests: 344/344 (16 overflow-selfheal unit tests incl. the 4 reserveOutputHeadroom cases). typecheck clean.