### PR TITLE
fix(compress): treat 0-block panels as neutral so retry cap can't be bypassed

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -94,12 +94,19 @@ function normalizeRanges(content: CompressArgs["content"]): RangeEntry[] | strin
 }
 
 /** True when a (non-error) compress toolResult text represents a completed
- *  compression run — the "▣ ACP | …" panel. Other non-error strings ("No
- *  ranges provided.", semantic "Errors: …" panels with nothing reclaimed)
- *  are neutral outcomes that neither reset nor advance the retry counter
- *  (see noteCompressOutcomes in runtime.ts). */
+ *  compression run — a "▣ ACP | …" panel with at least one block created.
+ *  Other non-error strings ("No ranges provided.") and 0-block panels
+ *  (semantic "Errors: …" / "already compressed" outcomes that reclaimed
+ *  nothing) are neutral: they neither reset nor advance the retry counter
+ *  (see noteCompressOutcomes in runtime.ts). Counting a 0-block panel as
+ *  success would let alternating failure modes (thrown arg error → 0-block
+ *  panel → thrown arg error …) reset the counter forever and bypass
+ *  MAX_COMPRESS_ATTEMPTS — an unbounded "compress again NOW" prompt loop. */
 export function isCompressSuccessText(text: string): boolean {
-  return text.trimStart().startsWith("▣ ACP |");
+  const t = text.trimStart();
+  if (!t.startsWith("▣ ACP |")) return false;
+  const header = t.split("\n", 1)[0] ?? "";
+  return !/,\s*0 blocks?\)/.test(header);
 }
 
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {

--- a/tests/compress-retry.test.ts
+++ b/tests/compress-retry.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { rm } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
 import { createRuntime, MAX_COMPRESS_ATTEMPTS } from "../src/runtime.js";
+import { isCompressSuccessText } from "../src/compress-tool.js";
 
 // Failure-triggered compress retry (session 01a00a38 post-mortem): the model's
 // ONLY compress call in a 3-hour session was rejected by pi's typebox
@@ -311,5 +312,53 @@ test("neutral outcomes freeze the counter; success resets; new turn gets a fresh
   entries = [...entries, userMsg("e7", "next question")];
   const r6 = await fire(handlers, ctx);
   assert.equal(retryMsgs(r6).length, 0, "pre-turn failure out of scope after user message");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+// ─── issue #4: 0-block panels must not reset the retry counter ─────────────
+
+const ZERO_BLOCK_ERRORS = "▣ ACP | 50.0K → 50.0K tokens (~0 reclaimed, 0 blocks)\nErrors: Total compressible content too small (2000 chars across 1 range(s), min 5000). Combine more messages into your range(s) to meet the threshold.";
+const ZERO_BLOCK_CONSUMED = "▣ ACP | 50.0K → 50.0K tokens (~0 reclaimed, 0 blocks)\n⚠️ Skipped range (m00001..m00005) — already compressed (messages consumed by existing block(s)); nothing to compress.";
+
+test("isCompressSuccessText: success panels true; 0-block panels and non-panels neutral", () => {
+  assert.equal(isCompressSuccessText(SUCCESS_PANEL), true);
+  assert.equal(isCompressSuccessText("▣ ACP | 50.0K → 49.0K tokens (~1.0K reclaimed, 1 block)"), true);
+  assert.equal(isCompressSuccessText("▣ ACP | 50.0K → 49.0K tokens (~1.0K reclaimed, 2 blocks)\nErrors: range m00006..m00007: unknown ref"), true, "partial batch (blocks created) is still a success");
+  assert.equal(isCompressSuccessText(ZERO_BLOCK_ERRORS), false, "0-block semantic error panel is neutral, not success");
+  assert.equal(isCompressSuccessText(ZERO_BLOCK_CONSUMED), false, "0-block already-compressed panel is neutral");
+  assert.equal(isCompressSuccessText(NEUTRAL_TEXT), false);
+  assert.equal(isCompressSuccessText(""), false);
+});
+
+test("alternating failure modes cannot bypass the retry cap via 0-block panels (issue #4)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-it4.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  let entries: any[] = [userMsg("e1", ZH)];
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx);
+
+  // thrown failure (attempt 1) → 0-block error panel (neutral) → failure must
+  // be attempt 2, not a reset-to-1
+  entries = [...entries, toolResultMsg("e2", "call_1", VALIDATION_ERR, true)];
+  const r1 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r1).length, 1);
+  assert.match(retryText(r1), /attempt 1 of 3/);
+
+  entries = [...entries, toolResultMsg("e3", "call_2", ZERO_BLOCK_ERRORS, false)];
+  const r2 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r2).length, 0, "0-block panel as newest outcome → no prompt");
+
+  entries = [...entries, toolResultMsg("e4", "call_3", VALIDATION_ERR, true)];
+  const r3 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r3).length, 1);
+  assert.match(retryText(r3), /attempt 2 of 3/, "0-block panel must not reset the counter");
+
+  // third thrown failure → capped despite the interleaved 0-block panels
+  entries = [...entries, toolResultMsg("e5", "call_4", VALIDATION_ERR, true)];
+  const r4 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r4).length, 0, "cap reached → no retry nudge");
   await rm(`${stateFile}.acp.json`, { force: true });
 });


### PR DESCRIPTION
## Problem (ework issue #4: 检查项目中是否存在无限压缩的情况)

`isCompressSuccessText` (src/compress-tool.ts) classified ANY non-error `▣ ACP | …` panel as a success — including **0-block panels** produced by semantic failures (minCompressRange gate, unknown ref, all-covered ranges, summary length errors). The panel header is always `▣ ACP | X → Y tokens (~Z reclaimed, N blocks)` even when `N=0` and `Errors: …` follow.

A 0-block panel therefore **reset** `compressFailCount` to 0 in `noteCompressOutcomes` (src/runtime.ts). Alternating failure modes — thrown argument error → 0-block panel → thrown argument error → … — reset the counter on every other call, so `MAX_COMPRESS_ATTEMPTS` (3) could never be reached: an unbounded "call compress again NOW" retry-prompt loop within a single user turn.

This contradicted the function's own doc comment, the f6e5d3d commit message ("semantic error strings are classified NEUTRAL: no reset, no advance"), and the neutral-freeze tests, which only covered non-panel neutral text (`No ranges provided.`) — never 0-block panels.

## Fix

`isCompressSuccessText` now returns `false` for 0-block panels (header matches `, 0 blocks)`); panels with ≥1 block (including partial batches with per-range errors) still count as success. 0-block panels are neutral: no reset, no advance.

## Tests (384 pass, 0 fail)

- Unit: `isCompressSuccessText` — success panels true; 0-block error/consumed panels, `No ranges provided.`, empty string → false.
- Integration (new): alternating failure modes cannot bypass the retry cap — fail → "attempt 1 of 3"; 0-block panel → no prompt; fail → "attempt 2 of 3" (was "attempt 1" pre-fix); fail → capped, no prompt. Verified the integration test FAILS against the pre-fix implementation (repro).

## Audit summary (full report in ework issue #4)

No true infinite compression: tier cap at 3 (T3 terminal), minCompressRange 5K-char gate, consumed-range rejection, growth-gated nudges that self-suppress when nothing is compressible, idempotent tool-output truncation. The retry-cap bypass above was the one real defect.