### PR TITLE
fix(compress): count no-op runs as failures; cap emergency nudge re-injection

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -93,13 +93,26 @@ function normalizeRanges(content: CompressArgs["content"]): RangeEntry[] | strin
   return ranges as RangeEntry[];
 }
 
-/** True when a (non-error) compress toolResult text represents a completed
- *  compression run — the "▣ ACP | …" panel. Other non-error strings ("No
- *  ranges provided.", semantic "Errors: …" panels with nothing reclaimed)
- *  are neutral outcomes that neither reset nor advance the retry counter
- *  (see noteCompressOutcomes in runtime.ts). */
+/** Panel block count ("… (~N reclaimed, B blocks)"), or -1 for non-panels. */
+function compressPanelBlocks(text: string): number {
+  if (!text.trimStart().startsWith("▣ ACP |")) return -1;
+  const m = text.match(/, (\d+) blocks?\)/);
+  return m ? Number(m[1]) : -1;
+}
+
+/** Success = completed run that created >= 1 block (partial range errors
+ *  still count: progress was made). A 0-block panel must NOT be success —
+ *  it would reset the retry counter while the emergency nudge re-fires,
+ *  looping no-op compressions (issue #6). */
 export function isCompressSuccessText(text: string): boolean {
-  return text.trimStart().startsWith("▣ ACP |");
+  return compressPanelBlocks(text) > 0;
+}
+
+/** No-op = completed run that compressed nothing (0-block panel: every
+ *  range skipped). Counted as a FAILED attempt by noteCompressOutcomes so
+ *  the retry cap applies. Non-panels ("No ranges provided.") stay neutral. */
+export function isCompressNoopText(text: string): boolean {
+  return compressPanelBlocks(text) === 0;
 }
 
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-
 import { renderNudgeText, resolvePrompts, defaultPrompts } from "acp-kernel";
 import { type AdapterConfig, resolveDelegate } from "./config.js";
 import { createRuntime, type AcpRuntime, MAX_COMPRESS_ATTEMPTS } from "./runtime.js";
-import { makeCompressTool, isCompressSuccessText } from "./compress-tool.js";
+import { makeCompressTool, isCompressSuccessText, isCompressNoopText } from "./compress-tool.js";
 import { makeDecompressTool } from "./decompress-tool.js";
 import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
@@ -278,6 +278,23 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 
     const turnKey = lastUserMessageId(entries) ?? sid;
 
+    // Failure-triggered compress retry (defense in depth): when the model
+    // ATTEMPTED a compress call and it failed (bad arguments, invalid
+    // boundaries, or every range skipped as a no-op), the kernel's
+    // growth-gated nudge stays silent — the attempt consumed the turn's
+    // nudge budget while nothing got compressed, and the model often just
+    // continues (session 01a00a38: one validation failure at 11:41Z, then 95
+    // minutes of nudge silence). Re-prompt IMMEDIATELY after a failure,
+    // quoting the error so the failed call is salient, capped at
+    // MAX_COMPRESS_ATTEMPTS per user turn; a successful compress resets the
+    // counter. Only outcomes from the CURRENT user turn are considered — a
+    // stale failure from an earlier turn must never re-prompt (the user has
+    // moved on) and the cap must stay reachable. Processed BEFORE the nudge
+    // block so the retry-cap suppression below sees the newest outcome
+    // (a success on this fire must lift the cap on this same fire).
+    const compressOutcomes = collectCompressOutcomes(entries, turnStartIndex(entries));
+    const outcome = compressOutcomes.length > 0 ? runtime.noteCompressOutcomes(turnKey, compressOutcomes) : null;
+
     if (turn.nudge?.shouldInject) {
       // Two independent channels for the nudge:
       //  1. CONTEXT injection (always on): the nudge is appended to the
@@ -297,7 +314,14 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // fragmented range in the list makes batched attempts fail atomically
       // (kernel validates the whole batch). See viableRanges in billion-context-kit.
       turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
-      const alreadyShown = !emergency && runtime.nudgeShownFor(turnKey);
+      // Retry-cap circuit breaker (issue #6): emergency nudges re-inject on
+      // every LLM call, so a model answering each one with a failed/no-op
+      // compress call loops forever (each attempt adds protected tokens and
+      // keeps usage pinned at emergency). Once this turn burned
+      // MAX_COMPRESS_ATTEMPTS attempts, stop re-injecting the nudge — the
+      // kernel's emergency truncation still shrinks context mechanically.
+      const retryCapped = runtime.compressRetryCappedFor(turnKey);
+      const alreadyShown = retryCapped || (!emergency && runtime.nudgeShownFor(turnKey));
       if (!alreadyShown) {
         rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active), runtime.prompts));
         const rendered = renderNudgeText(turn.nudge, runtime.prompts);
@@ -316,20 +340,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       }
     }
 
-    // Failure-triggered compress retry (defense in depth): when the model
-    // ATTEMPTED a compress call and it failed (bad arguments, invalid
-    // boundaries...), the kernel's growth-gated nudge stays silent — the
-    // attempt consumed the turn's nudge budget while nothing got compressed,
-    // and the model often just continues (session 01a00a38: one validation
-    // failure at 11:41Z, then 95 minutes of nudge silence). Re-prompt
-    // IMMEDIATELY after a failure, quoting the error so the failed call is
-    // salient, capped at MAX_COMPRESS_ATTEMPTS per user turn; a successful
-    // compress resets the counter. Only outcomes from the CURRENT user turn
-    // are considered — a stale failure from an earlier turn must never
-    // re-prompt (the user has moved on) and the cap must stay reachable.
-    const compressOutcomes = collectCompressOutcomes(entries, turnStartIndex(entries));
-    if (compressOutcomes.length > 0) {
-      const outcome = runtime.noteCompressOutcomes(turnKey, compressOutcomes);
+    if (outcome !== null) {
       const failed = outcome.retryFor !== null ? compressOutcomes.find((o) => o.toolCallId === outcome.retryFor) : undefined;
       if (failed) {
         rebuilt.push(compressRetryMessage(failed.text, outcome.count, MAX_COMPRESS_ATTEMPTS));
@@ -517,15 +528,15 @@ function turnStartIndex(entries: Array<{ type: string; message?: { role?: string
 // session would keep an old failure as the "newest outcome" forever, and the
 // per-turn counter reset would then re-prompt it with count 0 on every LLM
 // call of every later turn (review finding on 7ddd2c6).
-function collectCompressOutcomes(entries: Array<{ type: string; id: string; message?: AgentMessage }>, startIndex: number): Array<{ toolCallId: string; isError: boolean; success: boolean; text: string }> {
-  const out: Array<{ toolCallId: string; isError: boolean; success: boolean; text: string }> = [];
+function collectCompressOutcomes(entries: Array<{ type: string; id: string; message?: AgentMessage }>, startIndex: number): Array<{ toolCallId: string; isError: boolean; success: boolean; noop: boolean; text: string }> {
+  const out: Array<{ toolCallId: string; isError: boolean; success: boolean; noop: boolean; text: string }> = [];
   for (let i = Math.max(startIndex, -1) + 1; i < entries.length; i++) {
     const entry = entries[i]!;
     if (entry.type !== "message" || !entry.message) continue;
     const m = entry.message as { role?: string; toolName?: string; toolCallId?: string; isError?: boolean; content?: unknown };
     if (m.role !== "toolResult" || m.toolName !== "compress" || !m.toolCallId) continue;
     const text = extractText(m.content);
-    out.push({ toolCallId: m.toolCallId, isError: m.isError === true, success: m.isError !== true && isCompressSuccessText(text), text });
+    out.push({ toolCallId: m.toolCallId, isError: m.isError === true, success: m.isError !== true && isCompressSuccessText(text), noop: m.isError !== true && isCompressNoopText(text), text });
   }
   return out;
 }
@@ -545,6 +556,7 @@ function compressRetryMessage(errorText: string, attempt: number, maxAttempts: n
     '- Example: compress({ content: [{ startId: "m00005", endId: "m00080", summary: "..." }] })',
     '- startId/endId are the mNNNNN refs from the <acp> tags (or block ids like "b3").',
     attempt >= maxAttempts - 1 ? "- This is your LAST retry for this turn — if it fails again, compression pauses until the next user message." : null,
+    "- If ranges were skipped (already compressed / too small), do NOT retry the same refs — run acp_status and use its CURRENT compressible ranges.",
   ].filter((l): l is string => l !== null).join("\n");
   return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() } as AgentMessage;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -70,12 +70,16 @@ export interface AcpRuntime {
   nudgeShownFor(turnKey: string): boolean;
   /** Process compress toolResults for the CURRENT user turn only (the caller
    *  scopes the list — see collectCompressOutcomes in src/index.ts); idempotent
-   *  per toolCallId. Outcome classes: isError → failure (count++), success
-   *  panel text → reset, other non-error text → neutral (count unchanged).
-   *  Returns the failure count, the toolCallId of the newest failure that
-   *  still needs a retry prompt (null when none, capped, or count 0), and
-   *  whether the cap was just reached by this call. */
-  noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean };
+   *  per toolCallId. Outcome classes: isError or noop (0-block panel) →
+   *  failure (count++), success panel (>= 1 block) → reset, other non-error
+   *  text → neutral (count unchanged). Returns the failure count, the
+   *  toolCallId of the newest failure that still needs a retry prompt (null
+   *  when none, capped, or count 0), and whether the cap was just reached. */
+  noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean };
+  /** True when this turn already burned MAX_COMPRESS_ATTEMPTS failed/no-op
+   *  compress calls — used to stop re-injecting the (dedup-exempt) emergency
+   *  nudge that would otherwise keep looping no-op compressions (issue #6). */
+  compressRetryCappedFor(turnKey: string): boolean;
   clearNudgeTracking(): void;
   clearCompressRetryTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
@@ -286,7 +290,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   let compressFailTurnKey: string | null = null;
   let compressFailCount = 0;
 
-  function noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean } {
+  function noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean } {
     if (compressFailTurnKey !== turnKey) {
       compressFailTurnKey = turnKey;
       compressFailCount = 0;
@@ -295,7 +299,7 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     for (const o of outcomes) {
       if (compressOutcomeSeen.has(o.toolCallId)) continue;
       compressOutcomeSeen.add(o.toolCallId);
-      if (o.isError) {
+      if (o.isError || o.noop === true) {
         compressFailCount += 1;
       } else if (o.success) {
         compressFailCount = 0;
@@ -306,9 +310,13 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     // count >= 1 guards against a deduped stale failure sliding in with a
     // reset-to-0 counter (defense in depth; the caller's turn scoping already
     // prevents it — an "attempt 0 of 3" prompt must be impossible).
-    const retryFor = latest && latest.isError && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS ? latest.toolCallId : null;
+    const retryFor = latest && (latest.isError || latest.noop === true) && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS ? latest.toolCallId : null;
     const cappedNow = compressFailCount >= MAX_COMPRESS_ATTEMPTS && prevCount < MAX_COMPRESS_ATTEMPTS;
     return { count: compressFailCount, retryFor, cappedNow };
+  }
+
+  function compressRetryCappedFor(turnKey: string): boolean {
+    return compressFailTurnKey === turnKey && compressFailCount >= MAX_COMPRESS_ATTEMPTS;
   }
 
   function clearCompressRetryTracking(): void {
@@ -402,4 +410,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}

--- a/tests/compress-retry.test.ts
+++ b/tests/compress-retry.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { rm } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
 import { createRuntime, MAX_COMPRESS_ATTEMPTS } from "../src/runtime.js";
+import { isCompressSuccessText, isCompressNoopText } from "../src/compress-tool.js";
 
 // Failure-triggered compress retry (session 01a00a38 post-mortem): the model's
 // ONLY compress call in a 3-hour session was rejected by pi's typebox
@@ -56,6 +57,8 @@ function toolResultMsg(id: string, toolCallId: string, text: string, isError: bo
 // handleCompress's own argument checks).
 const VALIDATION_ERR = 'Validation failed for tool "compress":\n  - content.0: must be object\n\nReceived arguments:\n{"content":"[{\\"topic\\":\\"x\\"}]"}';
 const SUCCESS_PANEL = "▣ ACP | 58.5K → 5.7K tokens (~52.8K reclaimed, 4 blocks)";
+const PARTIAL_PANEL = "▣ ACP | 58.5K → 30K tokens (~28.5K reclaimed, 3 blocks)\nErrors: range m00009..m00012: Summary too long";
+const NOOP_PANEL = "▣ ACP | 58.5K → 58.5K tokens (~0 reclaimed, 0 blocks)\nErrors: range m00001..m00002: Requested range(s) already compressed; nothing to compress";
 const NEUTRAL_TEXT = "No ranges provided.";
 
 function fakeCtx(getEntries: () => any[], stateFile: string) {
@@ -311,5 +314,115 @@ test("neutral outcomes freeze the counter; success resets; new turn gets a fresh
   entries = [...entries, userMsg("e7", "next question")];
   const r6 = await fire(handlers, ctx);
   assert.equal(retryMsgs(r6).length, 0, "pre-turn failure out of scope after user message");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+// ─── issue #6: no-op compress runs must not bypass the retry cap ────────────
+//
+// handleCompress returns a "▣ ACP | …" panel even when blocksCreated === 0
+// (every range skipped: already compressed / below min). The old
+// isCompressSuccessText matched ANY panel prefix → no-op runs counted as
+// success → counter reset → the (dedup-exempt) emergency nudge re-fired on
+// every LLM call → unbounded emergency-nudge ↔ no-op-compress ping-pong.
+
+test("classification: 0-block panels are no-ops, not successes; >=1 block is success", () => {
+  assert.equal(isCompressSuccessText(SUCCESS_PANEL), true);
+  assert.equal(isCompressSuccessText(PARTIAL_PANEL), true, "partial errors with progress still count as success");
+  assert.equal(isCompressSuccessText(NOOP_PANEL), false, "0-block panel must NOT be success (the issue #6 bug)");
+  assert.equal(isCompressSuccessText(NEUTRAL_TEXT), false);
+  assert.equal(isCompressSuccessText("Validation failed"), false);
+  assert.equal(isCompressNoopText(NOOP_PANEL), true);
+  assert.equal(isCompressNoopText(SUCCESS_PANEL), false);
+  assert.equal(isCompressNoopText(PARTIAL_PANEL), false);
+  assert.equal(isCompressNoopText(NEUTRAL_TEXT), false, "non-panels stay neutral");
+});
+
+test("noteCompressOutcomes: no-op panels advance the counter and are retry-eligible", () => {
+  const rt = createRuntime({});
+  const noop = (id: string) => ({ toolCallId: id, isError: false, success: false, noop: true });
+
+  let r = rt.noteCompressOutcomes("u1", [noop("t0")]);
+  assert.equal(r.count, 1);
+  assert.equal(r.retryFor, "t0", "no-op is retry-eligible: model gets corrective guidance");
+
+  r = rt.noteCompressOutcomes("u1", [noop("t0"), noop("t1")]);
+  assert.equal(r.count, 2);
+
+  r = rt.noteCompressOutcomes("u1", [noop("t0"), noop("t1"), noop("t2")]);
+  assert.equal(r.count, 3);
+  assert.equal(r.retryFor, null, "capped after 3 no-ops");
+  assert.equal(r.cappedNow, true);
+  assert.equal(rt.compressRetryCappedFor("u1"), true, "capped state is queryable per turn");
+  assert.equal(rt.compressRetryCappedFor("u2"), false, "other turns are unaffected");
+
+  const success = (id: string) => ({ toolCallId: id, isError: false, success: true, noop: false });
+  r = rt.noteCompressOutcomes("u1", [noop("t0"), noop("t1"), noop("t2"), success("ts")]);
+  assert.equal(r.count, 0, "genuine success lifts the cap");
+  assert.equal(rt.compressRetryCappedFor("u1"), false);
+});
+
+test("no-op compress toolResult triggers the retry nudge and caps at 3 (integration)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-noop.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  let entries: any[] = [userMsg("e1", ZH)];
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx);
+
+  entries = [...entries, toolResultMsg("e2", "call_1", NOOP_PANEL, false)];
+  const r1 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r1).length, 1, "no-op → corrective retry nudge");
+  assert.match(retryText(r1), /attempt 1 of 3/);
+  assert.match(retryText(r1), /already compressed/, "quotes the skip reason");
+  assert.match(retryText(r1), /acp_status/, "guides to current compressible ranges");
+
+  entries = [...entries, toolResultMsg("e3", "call_2", NOOP_PANEL, false)];
+  const r2 = await fire(handlers, ctx);
+  assert.match(retryText(r2), /attempt 2 of 3/);
+
+  entries = [...entries, toolResultMsg("e4", "call_3", NOOP_PANEL, false)];
+  const r3 = await fire(handlers, ctx);
+  assert.equal(retryMsgs(r3).length, 0, "third no-op → capped, no more prompts");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+test("emergency nudge stops re-injecting once the turn's retry cap is burned (issue #6 loop breaker)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 180_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-emerg.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  // ~270K tokens of sent view vs a 180K window → kernel goes EMERGENCY and
+  // the nudge re-injects on every context fire (dedup bypass).
+  const MID = "lorem ".repeat(3000);
+  const roleMsg = (id: string, role: string, text: string) => ({
+    type: "message", id, parentId: null, timestamp: "",
+    message: { role, content: text, timestamp: Date.now() },
+  });
+  let entries: any[] = [roleMsg("e0", "user", "start " + MID)];
+  for (let i = 1; i <= 59; i++) entries.push(roleMsg(`e${i}`, i % 2 ? "assistant" : "user", `f${i} ` + MID));
+  const ctx = fakeCtx(() => entries, stateFile);
+  const nudgeCount = (r: any) =>
+    (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached/.test(JSON.stringify(m.content))).length;
+
+  const r0 = await fire(handlers, ctx);
+  assert.ok(nudgeCount(r0) >= 1, "emergency nudge fires on real overflow");
+  assert.equal(retryMsgs(r0).length, 0);
+
+  // model "answers" each emergency nudge with a no-op compress (stale refs)
+  for (let i = 1; i <= 3; i++) {
+    entries = [...entries, toolResultMsg(`ec${i}`, `call_${i}`, NOOP_PANEL, false)];
+    await fire(handlers, ctx);
+  }
+  const rCapped = await fire(handlers, ctx);
+  assert.equal(nudgeCount(rCapped), 0, "retry cap burned → emergency nudge no longer re-injects");
+  assert.equal(retryMsgs(rCapped).length, 0, "retry prompts also capped");
+
+  // a genuine success lifts the cap → emergency guidance resumes
+  entries = [...entries, toolResultMsg("ec4", "call_4", SUCCESS_PANEL, false)];
+  const rRe = await fire(handlers, ctx);
+  assert.ok(nudgeCount(rRe) >= 1, "after a successful compress the emergency nudge may resume");
   await rm(`${stateFile}.acp.json`, { force: true });
 });


### PR DESCRIPTION
## Summary
Fixes the repeated/infinite compression loop reported in #6.

**Root cause:** a compress run that created 0 blocks (every range skipped: already compressed / below min) still returned a `▣ ACP |` panel, so `isCompressSuccessText` classified it as **success** and reset the retry counter — contradicting its own docstring. Under emergency pressure (usage ≥ 95%) the nudge re-injects on **every** LLM call (dedup bypass), so a model answering each nudge with a no-op compress looped forever; each attempt added protected toolcall+result tokens, pinning usage at emergency (positive feedback).

**Changes**
- `isCompressSuccessText` requires ≥ 1 block; new `isCompressNoopText` matches 0-block panels (non-panels like "No ranges provided." stay neutral)
- `noteCompressOutcomes` treats no-ops as failed attempts → corrective retry nudge + MAX_COMPRESS_ATTEMPTS=3 cap apply
- Once a turn's cap is burned, the emergency nudge stops re-injecting (kernel emergency truncation still shrinks context mechanically); a genuine success lifts the cap on the same fire (outcome processing hoisted before the nudge block)
- Retry message steers skipped-range cases to `acp_status`

**Analysis verdict** (full detail in #6): the state machine has no mathematically infinite loop — every path terminates (pending → 0 → nudge suppressed; kernel resets nudge baseline on successful compression; retry cap 3/turn; overflow self-heal arms for one turn). The bug above was the one unbounded intra-turn loop.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 386/386 (4 new tests: classification units, noop counter semantics, noop retry integration, emergency re-injection breaker + cap lift)
- [x] `npm run build`

🤖 Generated by ework-daemon (GLM)