### PR TITLE
fix(setup): subagent ACP tool injection becomes an explicit /acp-subagents command (#179)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
   b3 (T2)  3.3K→1.0K  age=1m  "Architecture review"
 ```
 
+## `/acp-subagents` command
+
+**Optional, one-time setup — only if you also use [pi-subagents](https://github.com/nicobailon/pi-subagents).**
+
+billion-context-pi's own `acp_delegate` tool works standalone. If you additionally keep pi-subagents installed and want its builtin sub-agents to have ACP context tools (`compress`/`decompress`/`search_context`/`acp_status`) for long-running tasks, run:
+
+```
+/acp-subagents
+```
+
+It discovers the agents and their tool baselines from the installed pi-subagents package and appends the four ACP tools to `subagents.agentOverrides` in `~/.pi/agent/settings.json` (safe write: backup + verify). Nothing is written automatically — this command is the only write path. Re-run it after upgrading pi-subagents. For git installs or forks, pass the package directory explicitly: `/acp-subagents <installDir>`.
+
 ## Configuration
 
 billion-context-pi works out of the box with no configuration — it reads your model's context window automatically and applies sensible defaults.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,18 @@ Blocks: 3 active (3.7K summary, 15.2K original compressed)
   b3 (T2)  3.3K→1.0K  age=1m  "Architecture review"
 ```
 
+## `/acp-subagents` 命令
+
+**可选、一次性设置——仅当你同时使用 [pi-subagents](https://github.com/nicobailon/pi-subagents) 时需要。**
+
+billion-context-pi 自带的 `acp_delegate` 工具可独立工作。如果你另外保留了 pi-subagents,并希望它的内置子代理在长任务中也能使用 ACP 上下文工具(`compress`/`decompress`/`search_context`/`acp_status`),运行:
+
+```
+/acp-subagents
+```
+
+它会从已安装的 pi-subagents 包中发现 agent 名单与工具基线,并向 `~/.pi/agent/settings.json` 的 `subagents.agentOverrides` 追加这四个 ACP 工具(安全写入:备份 + 校验)。不会自动写入——该命令是唯一的写入路径。升级 pi-subagents 后重新运行即可。git 安装或 fork 请显式传入包目录:`/acp-subagents <installDir>`。
+
 ## 配置
 
 billion-context-pi 开箱即用,无需任何配置——它会自动读取模型的上下文窗口并应用合理的默认值。

--- a/devlog/2026-08-21_issue179-detect-pi-subagents/REQ.md
+++ b/devlog/2026-08-21_issue179-detect-pi-subagents/REQ.md
@@ -1,0 +1,38 @@
+# REQ: 未安装 pi-subagents 时不再向 settings.json 注入 agentOverrides（issue #179）
+
+- Task ID: `2026-08-21_issue179-detect-pi-subagents`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-21
+- Status: In Progress
+- Priority: P1
+- References: issue #179
+
+## 1. Background & Problem Statement
+
+- **Context**: `src/setup-subagent-tools.ts` 在每次 session 启动时（`src/index.ts` session_start，fire-and-forget）向 `~/.pi/agent/settings.json` 的 `subagents.agentOverrides` 注入 9 个硬编码 agent（advisor/context-builder/delegate/oracle/planner/researcher/scout/worker）的 ACP 工具白名单。
+- **Current behavior (symptom)**: 用户未安装 `pi-subagents`（或只装了不兼容的 fork）时，扩展仍会创建/重建这些 `agentOverrides` 条目；手动删除后下次启动又被写回（issue #179，Windows 用户报告）。旧表还携带 pi-subagents 已不存在的 agent 与过期的 `intercom` 工具。
+- **Expected behavior**: 仅当检测到已安装的 pi-subagents 时才注入；注入的 agent 名单与 baseline tools 从安装包自身的 `agents/*.md` frontmatter 发现，而非硬编码。
+- **Impact**: 全局 settings.json 被无主条目污染；用户删除无效且会被重建。
+
+## 2. Reproduction
+
+1. 安装 billion-context-pi，**不**安装 pi-subagents
+2. 启动 Pi（任意会话）
+3. `~/.pi/agent/settings.json` 出现 `subagents.agentOverrides`（9 个 agent + ACP 工具）
+4. 手动删除该块 → 下次启动再次出现
+
+## 3. Constraints & Non-Goals
+
+- 已安装 pi-subagents 时，功能必须保持可用：override `tools` 是**替换**语义（pi-subagents `src/agents/agents.ts` 合并逻辑），因此必须写完整 baseline + ACP 列表，不能只追加 ACP 四件套（issue 选项 1 单独使用会削弱功能）。
+- 保留既有安全写入机制：`.acp-bak` 备份、mtime 乐观锁、写后校验、失败回滚。
+- 不删除用户已有的旧条目（只不动它们）；不清理 `*.acp-bak`。
+- 非目标：不支持 git 安装与 legacy global npm 路径的探测（miss = 安全 no-op，不注入）。
+
+## 4. Acceptance Criteria
+
+- [x] 未检测到 pi-subagents → 不读改写 settings.json，无备份文件，stale 条目原样保留
+- [x] 检测到（user-scope `<agentDir>/npm/node_modules` / project-scope `<cwd>/.pi/npm/node_modules` / extensions 目录）→ 按 frontmatter 发现 agent，写 baseline + ACP
+- [x] frontmatter 无 `tools`（无限制 agent）→ 不创建条目
+- [x] 已有 override tools（用户自定义或含部分 ACP）→ 保留原列表并补齐 ACP
+- [x] 幂等：第二次运行 skipped（`already have ACP tools`）
+- [x] settings.json 缺失 → skipped；JSON 损坏 → failed 且文件不被修改

--- a/devlog/2026-08-21_issue179-detect-pi-subagents/REQ.md
+++ b/devlog/2026-08-21_issue179-detect-pi-subagents/REQ.md
@@ -11,7 +11,7 @@
 
 - **Context**: `src/setup-subagent-tools.ts` 在每次 session 启动时（`src/index.ts` session_start，fire-and-forget）向 `~/.pi/agent/settings.json` 的 `subagents.agentOverrides` 注入 9 个硬编码 agent（advisor/context-builder/delegate/oracle/planner/researcher/scout/worker）的 ACP 工具白名单。
 - **Current behavior (symptom)**: 用户未安装 `pi-subagents`（或只装了不兼容的 fork）时，扩展仍会创建/重建这些 `agentOverrides` 条目；手动删除后下次启动又被写回（issue #179，Windows 用户报告）。旧表还携带 pi-subagents 已不存在的 agent 与过期的 `intercom` 工具。
-- **Expected behavior**: 仅当检测到已安装的 pi-subagents 时才注入；注入的 agent 名单与 baseline tools 从安装包自身的 `agents/*.md` frontmatter 发现，而非硬编码。
+- **Expected behavior**: 不自动写全局 settings.json；用户显式触发才注入，且 agent 名单与 baseline tools 从安装包自身发现。
 - **Impact**: 全局 settings.json 被无主条目污染；用户删除无效且会被重建。
 
 ## 2. Reproduction
@@ -23,16 +23,19 @@
 
 ## 3. Constraints & Non-Goals
 
-- 已安装 pi-subagents 时，功能必须保持可用：override `tools` 是**替换**语义（pi-subagents `src/agents/agents.ts` 合并逻辑），因此必须写完整 baseline + ACP 列表，不能只追加 ACP 四件套（issue 选项 1 单独使用会削弱功能）。
+- 已安装 pi-subagents 时功能必须可用：override `tools` 是**替换**语义（pi-subagents 合并逻辑），必须写完整 baseline + ACP 列表，不能只追加 ACP 四件套（issue 选项 1 单独使用会削弱功能）。
+- **设计演进**：第一版做"启动时自动探测 + 自动注入"；评审后改为**显式命令、绝不自动写**——探测必然有洞（git 安装/fork/legacy npm），静默 no-op 比显式一步更难排查；且 #179 根源是"扩展未经同意改全局 settings.json"，自动探测只是缩小爆炸半径、没消除该模式。功能属边际 sugar（长任务 delegate 自管上下文），不值得自动写入。
 - 保留既有安全写入机制：`.acp-bak` 备份、mtime 乐观锁、写后校验、失败回滚。
-- 不删除用户已有的旧条目（只不动它们）；不清理 `*.acp-bak`。
-- 非目标：不支持 git 安装与 legacy global npm 路径的探测（miss = 安全 no-op，不注入）。
+- 不删除用户已有的旧条目（只不动它们）。
+- 非目标：git 安装与 legacy global npm 的自动探测（命令支持显式 `<installDir>` 参数覆盖该场景）。
 
 ## 4. Acceptance Criteria
 
-- [x] 未检测到 pi-subagents → 不读改写 settings.json，无备份文件，stale 条目原样保留
-- [x] 检测到（user-scope `<agentDir>/npm/node_modules` / project-scope `<cwd>/.pi/npm/node_modules` / extensions 目录）→ 按 frontmatter 发现 agent，写 baseline + ACP
-- [x] frontmatter 无 `tools`（无限制 agent）→ 不创建条目
-- [x] 已有 override tools（用户自定义或含部分 ACP）→ 保留原列表并补齐 ACP
-- [x] 幂等：第二次运行 skipped（`already have ACP tools`）
+- [x] session 启动**不再**触碰 settings.json（删除 session_start 自动调用）
+- [x] 新命令 `/acp-subagents [installDir]`：显式触发才写
+- [x] 无参数时探测（user/project npm scope + extensions 目录）；未检测到 → 提示安装或传目录，不写
+- [x] 显式 `installDir` 覆盖 git/fork 安装；非法目录 → 明确报错
+- [x] 按 frontmatter 发现 agent，写 baseline + ACP；无 `tools` frontmatter（无限制 agent）→ 不建条目
+- [x] 已有 override tools → 保留原列表补齐 ACP；幂等
 - [x] settings.json 缺失 → skipped；JSON 损坏 → failed 且文件不被修改
+- [x] README（EN+ZH）文档说明命令用法

--- a/devlog/2026-08-21_issue179-detect-pi-subagents/WORKLOG.md
+++ b/devlog/2026-08-21_issue179-detect-pi-subagents/WORKLOG.md
@@ -7,36 +7,37 @@
 
 ## 1. Summary
 
-- **What was done**: 重写 `src/setup-subagent-tools.ts`——先探测 pi-subagents 安装，再从安装包 `agents/*.md` frontmatter 发现 agent 名单与 baseline tools；未安装则完全不写 settings.json。删除硬编码 `BUILTIN_DEFAULT_TOOLS`（9 agent + 过期 intercom 表）。
-- **Why**: pi-subagents 的 `agentOverrides.tools` 合并是替换语义，功能上必须创建完整条目；但无 pi-subagents 时创建条目纯属污染（#179），故选 issue 选项 2（安装探测）+ frontmatter 发现，同时保留功能完整性（选项 1 单独使用会失去为 builtin agent 注入 ACP 的能力）。
-- **Behavior / compatibility changes**: 已安装 pi-subagents 的用户行为不变（仍获得 ACP 工具注入，且 baseline 跟随安装包版本更新）；未安装用户不再被写入。`intercom` 不再由本扩展注入（pi-subagents 运行时自行注入 contact_supervisor/intercom bridge）。
+- **What was done**: 删除 session_start 自动注入；改为一次性命令 `/acp-subagents [installDir]` 显式触发。`src/setup-subagent-tools.ts` 保留探测 + frontmatter 发现（`agents/*.md`）+ 安全写入机制；删除硬编码 `BUILTIN_DEFAULT_TOOLS`（9 agent + 过期 intercom 表）与 `runSetupAndNotify`。
+- **Why**: pi-subagents 的 `agentOverrides.tools` 是替换语义，注入必须写完整条目；但自动写入是 #179 的根源（"扩展未经同意改全局 settings.json"）。自动探测方案探测有洞（git/fork/legacy npm，含报告者的 fork）且耦合 pi-subagents 内部布局；显式命令把写入变成用户动作，miss 是可见报错而非静默 no-op，frontmatter 运行时发现使文档永不腐化。
+- **Behavior / compatibility changes**: 所有用户：settings.json 不再被自动写入（已有条目保留不动，零影响）；想给 pi-subagents 子代理 ACP 工具的用户需跑一次 `/acp-subagents`（升级 pi-subagents 后再跑）。
 - **Risk level**: Low
 
 ## 2. Change Log
 
 ### Key Files
 
-- `src/setup-subagent-tools.ts` — 重写：新增 `findPiSubagentsInstall(agentDir, cwd)`、`discoverBuiltinAgents(installDir)`、`parseFrontmatterTools()`；`ensureSubagentAcpTools(settingsPath?, options?: {agentDir?, cwd?})`；仅 patch 安装包实际携带的 agent；保留备份/mtime 锁/写后校验/回滚
-- `tests/setup-subagent-tools.test.ts` — 重写：13 个测试（fake 包 fixture），覆盖未安装 no-op、三种安装位置探测、stale 条目不重建、merge/幂等/备份/错误路径
-- `src/index.ts` — 注释更新（行为说明）
+- `src/setup-subagent-tools.ts` — 重写：`findPiSubagentsInstall(agentDir, cwd)`、`discoverBuiltinAgents(installDir)`、`parseFrontmatterTools()`；`ensureSubagentAcpTools(settingsPath?, options?: {agentDir?, cwd?, installDir?})`——`installDir` 显式指定时跳过探测（校验 package.json 存在）；删除 `runSetupAndNotify`；保留备份/mtime 锁/写后校验/回滚
+- `src/index.ts` — 删除 session_start 的 `runSetupAndNotify` 自动调用与 import
+- `src/commands.ts` — 新增 `/acp-subagents [installDir]` 命令（updated/skipped/failed 三态通知文案）
+- `tests/setup-subagent-tools.test.ts` — 重写：15 个测试（fake 包 fixture），覆盖未安装 no-op、三种安装位置探测、显式 installDir、stale 条目不重建、merge/幂等/备份/错误路径
+- `README.md` / `README.zh-CN.md` — 新增 `/acp-subagents` 命令小节（可选、一次性、唯一写入路径）
 - `devlog/2026-08-21_issue179-detect-pi-subagents/` — REQ.md + WORKLOG.md
 
 ## 3. Design & Implementation Notes
 
-- **检测优先级**: ① `<agentDir>/npm/node_modules/pi-subagents` ② `<cwd>/.pi/npm/node_modules/pi-subagents` ③ `<agentDir>/extensions/<name>/package.json` ④ `<cwd>/.pi/extensions/<name>/package.json`（③④ 校验 `name === "pi-subagents"`）。路径与 pi 的 PackageManager（`getManagedNpmInstallPath`、auto-discovered extensions 目录）一致；git 安装与 legacy global npm 不探测（miss = 安全 no-op）。
+- **检测优先级（无参数时）**: ① `<agentDir>/npm/node_modules/pi-subagents` ② `<cwd>/.pi/npm/node_modules/pi-subagents` ③ `<agentDir>/extensions/<name>/package.json` ④ `<cwd>/.pi/extensions/<name>/package.json`（③④ 校验 `name === "pi-subagents"`）。git/legacy 安装不自动探测 → 命令的 `<installDir>` 参数兜底。
 - **baseline 优先级**: 已有 override `tools`（非空）> frontmatter `tools` > 均无（无限制 agent）→ 跳过不建条目。
-- **写后校验**改为只校验发现的 agent（不再硬编码 9 个）。
 - **JSDoc 陷阱**: 注释内出现 `*/package.json` 会提前闭合块注释（TS1005）——改用 `<name>/package.json` 表述。
 
 ## 4. Testing & Verification
 
 ```sh
 npm run typecheck   # PASS
-npm test            # PASS 387/387（本模块 13/13）
+npm test            # PASS（本模块 15/15）
 npm run build       # PASS
 ```
 
 ## 5. Follow-ups
 
-- [ ] 发布后回复 issue #179（说明探测范围与 git/legacy 安装不覆盖的边界）
-- [ ] 可选：探测 miss 时在 debug 日志记一行原因（当前 `skipped: pi-subagents not installed` 已进 debug.event）
+- [ ] PR #183 描述与 issue #179 留言需更新为最终方案（显式命令，非自动探测）
+- [ ] 发布后跟进 issue #179

--- a/devlog/2026-08-21_issue179-detect-pi-subagents/WORKLOG.md
+++ b/devlog/2026-08-21_issue179-detect-pi-subagents/WORKLOG.md
@@ -1,0 +1,42 @@
+# WORKLOG: 未安装 pi-subagents 时不再注入 agentOverrides（issue #179）
+
+- Task ID: `2026-08-21_issue179-detect-pi-subagents`
+- Home Repo: `billion-context-pi`
+- Status: In Progress
+- Updated: 2026-08-21
+
+## 1. Summary
+
+- **What was done**: 重写 `src/setup-subagent-tools.ts`——先探测 pi-subagents 安装，再从安装包 `agents/*.md` frontmatter 发现 agent 名单与 baseline tools；未安装则完全不写 settings.json。删除硬编码 `BUILTIN_DEFAULT_TOOLS`（9 agent + 过期 intercom 表）。
+- **Why**: pi-subagents 的 `agentOverrides.tools` 合并是替换语义，功能上必须创建完整条目；但无 pi-subagents 时创建条目纯属污染（#179），故选 issue 选项 2（安装探测）+ frontmatter 发现，同时保留功能完整性（选项 1 单独使用会失去为 builtin agent 注入 ACP 的能力）。
+- **Behavior / compatibility changes**: 已安装 pi-subagents 的用户行为不变（仍获得 ACP 工具注入，且 baseline 跟随安装包版本更新）；未安装用户不再被写入。`intercom` 不再由本扩展注入（pi-subagents 运行时自行注入 contact_supervisor/intercom bridge）。
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Key Files
+
+- `src/setup-subagent-tools.ts` — 重写：新增 `findPiSubagentsInstall(agentDir, cwd)`、`discoverBuiltinAgents(installDir)`、`parseFrontmatterTools()`；`ensureSubagentAcpTools(settingsPath?, options?: {agentDir?, cwd?})`；仅 patch 安装包实际携带的 agent；保留备份/mtime 锁/写后校验/回滚
+- `tests/setup-subagent-tools.test.ts` — 重写：13 个测试（fake 包 fixture），覆盖未安装 no-op、三种安装位置探测、stale 条目不重建、merge/幂等/备份/错误路径
+- `src/index.ts` — 注释更新（行为说明）
+- `devlog/2026-08-21_issue179-detect-pi-subagents/` — REQ.md + WORKLOG.md
+
+## 3. Design & Implementation Notes
+
+- **检测优先级**: ① `<agentDir>/npm/node_modules/pi-subagents` ② `<cwd>/.pi/npm/node_modules/pi-subagents` ③ `<agentDir>/extensions/<name>/package.json` ④ `<cwd>/.pi/extensions/<name>/package.json`（③④ 校验 `name === "pi-subagents"`）。路径与 pi 的 PackageManager（`getManagedNpmInstallPath`、auto-discovered extensions 目录）一致；git 安装与 legacy global npm 不探测（miss = 安全 no-op）。
+- **baseline 优先级**: 已有 override `tools`（非空）> frontmatter `tools` > 均无（无限制 agent）→ 跳过不建条目。
+- **写后校验**改为只校验发现的 agent（不再硬编码 9 个）。
+- **JSDoc 陷阱**: 注释内出现 `*/package.json` 会提前闭合块注释（TS1005）——改用 `<name>/package.json` 表述。
+
+## 4. Testing & Verification
+
+```sh
+npm run typecheck   # PASS
+npm test            # PASS 387/387（本模块 13/13）
+npm run build       # PASS
+```
+
+## 5. Follow-ups
+
+- [ ] 发布后回复 issue #179（说明探测范围与 git/legacy 安装不覆盖的边界）
+- [ ] 可选：探测 miss 时在 debug 日志记一行原因（当前 `skipped: pi-subagents not installed` 已进 debug.event）

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,6 +5,7 @@ import { getSystemPromptText } from "./compat.js";
 import { collectCoveredMessageIds, estimateTokens, calibrateTokens } from "./tokens.js";
 import { buildStatusPanel } from "billion-context-kit";
 import { getDelegateUsage } from "./delegate-tool.js";
+import { ensureSubagentAcpTools } from "./setup-subagent-tools.js";
 
 declare const CURRENT_VERSION: string;
 
@@ -69,6 +70,28 @@ export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options
           }
           const lines = hits.map((b) => `[${b.blockId}] (t${b.tier}) ${b.topic ?? ""}`.trim());
           ctx.ui.notify(lines.join("\n"));
+        },
+      },
+    },
+    {
+      name: "acp-subagents",
+      options: {
+        description:
+          "Add ACP context tools (compress/decompress/search_context/acp_status) to pi-subagents' builtin agents. " +
+          "One-time setup — re-run after upgrading pi-subagents. Usage: /acp-subagents [installDir]",
+        handler: async (args, ctx) => {
+          const installDir = args.trim();
+          const result = ensureSubagentAcpTools(undefined, installDir ? { installDir } : undefined);
+          if (result.action === "updated") {
+            ctx.ui.notify(`ACP tools enabled for pi-subagents agents in ${result.path}`);
+          } else if (result.action === "skipped") {
+            ctx.ui.notify(
+              `Nothing to do: ${result.reason ?? ""}. ` +
+                "Install pi-subagents (pi install npm:pi-subagents) or pass its directory: /acp-subagents <installDir>",
+            );
+          } else {
+            ctx.ui.notify(`Failed to update ${result.path}: ${result.reason ?? "unknown"}`);
+          }
         },
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,8 +111,9 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
-    // Idempotently ensure all builtin pi-subagents have ACP context tools
-    // (compress/decompress/search_context/acp_status) in their allowlists.
+    // If pi-subagents is installed, idempotently ensure its builtin agents
+    // have ACP context tools (compress/decompress/search_context/acp_status)
+    // in their allowlists (no-op otherwise — see issue #179).
     // Settings.json is patched safely (backup + optimistic mtime lock + verify).
     void runSetupAndNotify(ctx.hasUI ? (m) => ctx.ui.notify(m) : undefined);
     // Bind the TUI status widget for async delegates. The widget reads the

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,6 @@ import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
-import { runSetupAndNotify } from "./setup-subagent-tools.js";
 import {
   THROTTLE_RETRY_ERROR_MESSAGE,
   THROTTLE_KICK_TEXT,
@@ -111,11 +110,6 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
-    // If pi-subagents is installed, idempotently ensure its builtin agents
-    // have ACP context tools (compress/decompress/search_context/acp_status)
-    // in their allowlists (no-op otherwise — see issue #179).
-    // Settings.json is patched safely (backup + optimistic mtime lock + verify).
-    void runSetupAndNotify(ctx.hasUI ? (m) => ctx.ui.notify(m) : undefined);
     // Bind the TUI status widget for async delegates. The widget reads the
     // in-memory runs Map (via runningRunsSnapshot) and renders a live list of
     // running delegates below the editor. Only the interactive TUI has a UI;

--- a/src/setup-subagent-tools.ts
+++ b/src/setup-subagent-tools.ts
@@ -1,21 +1,18 @@
 /**
- * Setup: inject ACP context tools into pi-subagents' agent overrides.
+ * One-shot setup: inject ACP context tools into pi-subagents' agent overrides.
+ * Invoked explicitly via the `/acp-subagents` command — never at session
+ * start, so global settings.json is only ever touched on user request.
  *
  * pi-subagents' agentOverrides merge semantics REPLACE the frontmatter
  * `tools` list, so an override without ACP tools strips them from the
  * builtin agents. This module detects an installed pi-subagents package,
  * discovers each builtin agent's frontmatter tools, and writes
  * `subagents.agentOverrides[name].tools = frontmatter tools + ACP tools`.
- *
- * If no compatible pi-subagents installation is detected, nothing is
- * written (issue #179): stale agentOverrides entries for agents that
- * pi-subagents no longer ships must not be created.
  */
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
-import { debug, logError, logWarn } from "./log.js";
 
 /** The four ACP tools to ensure on every pi-subagents builtin agent. */
 export const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
@@ -31,6 +28,8 @@ export interface SetupOptions {
   agentDir?: string;
   /** Injectable cwd for project-scope detection (defaults to process.cwd()). */
   cwd?: string;
+  /** Explicit install directory (skips detection; for git installs or forks). */
+  installDir?: string;
 }
 
 /**
@@ -172,9 +171,18 @@ export function ensureSubagentAcpTools(settingsPath?: string, options?: SetupOpt
   const cwd = options?.cwd ?? process.cwd();
   const path_ = settingsPath ?? path.join(agentDir, "settings.json");
 
-  const installDir = findPiSubagentsInstall(agentDir, cwd);
-  if (!installDir) {
-    return { path: path_, action: "skipped", reason: "pi-subagents not installed" };
+  let installDir: string;
+  if (options?.installDir) {
+    installDir = path.resolve(options.installDir);
+    if (!fs.existsSync(path.join(installDir, "package.json"))) {
+      return { path: path_, action: "failed", reason: `not a package: ${installDir}` };
+    }
+  } else {
+    const detected = findPiSubagentsInstall(agentDir, cwd);
+    if (!detected) {
+      return { path: path_, action: "skipped", reason: "pi-subagents not installed" };
+    }
+    installDir = detected;
   }
   const builtins = discoverBuiltinAgents(installDir);
   if (builtins.length === 0) {
@@ -278,28 +286,5 @@ export function ensureSubagentAcpTools(settingsPath?: string, options?: SetupOpt
       try { fs.copyFileSync(backupPath, path_); } catch { /* ignore restore failure */ }
     }
     return { path: path_, action: "failed", reason: message };
-  }
-}
-
-/**
- * Run the subagent ACP tools setup and surface a UI notification on success.
- * Safe to call fire-and-forget from the session_start handler.
- */
-export function runSetupAndNotify(notify?: (message: string) => void): void {
-  try {
-    const result = ensureSubagentAcpTools();
-    debug.event("setup-subagent-tools", { action: result.action, reason: result.reason });
-    if (result.action === "updated") {
-      notify?.(`ACP: enabled context tools (compress/decompress/search_context/acp_status) for subagents`);
-    } else if (result.action === "failed") {
-      logWarn("setup", { event: "subagent-tools", action: result.action, reason: result.reason });
-    }
-  } catch (err) {
-    debug.event("setup-subagent-tools-error", { msg: String(err) });
-    logError("setup", {
-      event: "subagent-tools-error",
-      error: err instanceof Error ? err.message : String(err),
-      stack: err instanceof Error ? err.stack ?? "" : "",
-    });
   }
 }

--- a/src/setup-subagent-tools.ts
+++ b/src/setup-subagent-tools.ts
@@ -1,30 +1,24 @@
-import { readFile, writeFile, stat, copyFile, rename } from "node:fs/promises";
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+/**
+ * Setup: inject ACP context tools into pi-subagents' agent overrides.
+ *
+ * pi-subagents' agentOverrides merge semantics REPLACE the frontmatter
+ * `tools` list, so an override without ACP tools strips them from the
+ * builtin agents. This module detects an installed pi-subagents package,
+ * discovers each builtin agent's frontmatter tools, and writes
+ * `subagents.agentOverrides[name].tools = frontmatter tools + ACP tools`.
+ *
+ * If no compatible pi-subagents installation is detected, nothing is
+ * written (issue #179): stale agentOverrides entries for agents that
+ * pi-subagents no longer ships must not be created.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import { debug, logError, logWarn } from "./log.js";
 
-const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
-
-const BUILTIN_DEFAULT_TOOLS: Record<string, string[]> = {
-  advisor: ["read", "grep", "find", "ls", "bash", "intercom"],
-  "context-builder": ["read", "grep", "find", "ls", "bash", "write", "web_search", "intercom"],
-  delegate: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-  oracle: ["read", "grep", "find", "ls", "bash", "intercom"],
-  planner: ["read", "grep", "find", "ls", "intercom"],
-  researcher: ["read", "write", "web_search", "fetch_content", "get_search_content", "intercom"],
-  reviewer: ["read", "grep", "find", "ls", "bash", "edit", "write", "intercom"],
-  scout: ["read", "grep", "find", "ls", "bash", "write", "intercom"],
-  worker: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"],
-};
-
-export function resolveAgentDir(): string {
-  const configured = process.env.PI_CODING_AGENT_DIR;
-  if (configured === "~") return homedir();
-  if (configured?.startsWith("~/")) return join(homedir(), configured.slice(2));
-  return configured || join(homedir(), CONFIG_DIR_NAME, "agent");
-}
+/** The four ACP tools to ensure on every pi-subagents builtin agent. */
+export const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"] as const;
 
 export interface SetupResult {
   path: string;
@@ -32,123 +26,280 @@ export interface SetupResult {
   reason?: string;
 }
 
-type OverrideEntry = { tools?: string[]; [k: string]: unknown };
-
-function desiredTools(existing: OverrideEntry | undefined, name: string): { tools: string[]; changed: boolean } {
-  const base = Array.isArray(existing?.tools) && existing!.tools!.length > 0
-    ? [...(existing!.tools as string[])]
-    : [...(BUILTIN_DEFAULT_TOOLS[name] ?? [])];
-  const hasAll = ACP_TOOLS.every((t) => base.includes(t));
-  if (hasAll) return { tools: base, changed: false };
-  for (const t of ACP_TOOLS) if (!base.includes(t)) base.push(t);
-  return { tools: base, changed: true };
+export interface SetupOptions {
+  /** Injectable agent directory (defaults to env PI_CODING_AGENT_DIR or ~/.pi/agent). */
+  agentDir?: string;
+  /** Injectable cwd for project-scope detection (defaults to process.cwd()). */
+  cwd?: string;
 }
 
-export async function ensureSubagentAcpTools(settingsPath?: string): Promise<SetupResult> {
-  const path = settingsPath ?? join(resolveAgentDir(), "settings.json");
+/**
+ * Resolve the pi agent config directory (e.g. ~/.pi/agent), honoring the
+ * PI_CODING_AGENT_DIR environment variable (mirroring pi's own resolution).
+ */
+export function resolveAgentDir(): string {
+  const envDir = process.env.PI_CODING_AGENT_DIR;
+  if (envDir) {
+    if (envDir === "~") return os.homedir();
+    if (envDir.startsWith("~/")) return path.join(os.homedir(), envDir.slice(2));
+    return envDir;
+  }
+  return path.join(os.homedir(), CONFIG_DIR_NAME, "agent");
+}
 
-  let raw: string;
-  let mtimeMs: number;
+interface AgentOverride {
+  model?: string;
+  tools?: string[];
+  thinking?: string;
+}
+
+interface ParsedBuiltin {
+  name: string;
+  /** Frontmatter `tools` list; undefined when the agent is unrestricted. */
+  tools?: string[];
+}
+
+function parseFrontmatterTools(content: string): ParsedBuiltin | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+  const body = match[1];
+  if (!body) return null;
+  let name: string | undefined;
+  let tools: string[] | undefined;
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.startsWith("name:")) {
+      name = line.slice(5).trim().replace(/^["']|["']$/g, "");
+    } else if (line.startsWith("tools:")) {
+      const value = line.slice(6).trim();
+      if (value) {
+        tools = value.split(",").map((t) => t.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+      }
+    }
+  }
+  if (!name) return null;
+  return tools ? { name, tools } : { name };
+}
+
+/**
+ * Detect an installed pi-subagents package and return its directory, or null
+ * when no installation is found.
+ *
+ * Checked in priority order:
+ *  1. user-scope npm install:    <agentDir>/npm/node_modules/pi-subagents
+ *  2. project-scope npm install: <cwd>/.pi/npm/node_modules/pi-subagents
+ *  3. user-scope extension dir:  <agentDir>/extensions/<name>/package.json where name === "pi-subagents"
+ *  4. project-scope extension dir: <cwd>/.pi/extensions/<name>/package.json
+ *
+ * Git installs and the legacy global npm location are intentionally not
+ * checked: a miss there is a safe no-op (ACP tools stay un-injected).
+ */
+export function findPiSubagentsInstall(agentDir: string, cwd: string): string | null {
+  const candidates: string[] = [
+    path.join(agentDir, "npm", "node_modules", "pi-subagents"),
+    path.join(cwd, CONFIG_DIR_NAME, "npm", "node_modules", "pi-subagents"),
+  ];
+  const extensionRoots = [
+    path.join(agentDir, "extensions"),
+    path.join(cwd, CONFIG_DIR_NAME, "extensions"),
+  ];
+  for (const dir of candidates) {
+    if (fs.existsSync(path.join(dir, "package.json"))) return dir;
+  }
+  for (const root of extensionRoots) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const pkgPath = path.join(root, entry.name, "package.json");
+      try {
+        if (JSON.parse(fs.readFileSync(pkgPath, "utf-8")).name === "pi-subagents") {
+          return path.join(root, entry.name);
+        }
+      } catch {
+        // Not a readable package — keep scanning.
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Discover the builtin agents shipped by the detected pi-subagents package
+ * from its agents/*.md frontmatter (name + tools). Returns an empty list
+ * when the package ships no agents directory.
+ */
+export function discoverBuiltinAgents(installDir: string): ParsedBuiltin[] {
+  const agentsDir = path.join(installDir, "agents");
+  let entries: fs.Dirent[];
   try {
-    raw = await readFile(path, "utf-8");
-    mtimeMs = (await stat(path)).mtimeMs;
+    entries = fs.readdirSync(agentsDir, { withFileTypes: true });
   } catch {
-    return { path, action: "skipped", reason: "settings.json not found; will retry next session" };
+    return [];
+  }
+  const parsed: ParsedBuiltin[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+    try {
+      const result = parseFrontmatterTools(fs.readFileSync(path.join(agentsDir, entry.name), "utf-8"));
+      if (result) parsed.push(result);
+    } catch {
+      // Unreadable agent file — skip it.
+    }
+  }
+  return parsed;
+}
+
+/** Frontmatter tools + ACP tools, preserving order and removing duplicates. */
+function desiredTools(baseTools: string[] | undefined): string[] {
+  const tools = baseTools ? [...baseTools] : [];
+  for (const tool of ACP_TOOLS) {
+    if (!tools.includes(tool)) tools.push(tool);
+  }
+  return tools;
+}
+
+/**
+ * Ensure ACP context tools are present in pi-subagents' agent overrides.
+ * No-op (skipped) unless a pi-subagents installation is detected.
+ */
+export function ensureSubagentAcpTools(settingsPath?: string, options?: SetupOptions): SetupResult {
+  const agentDir = options?.agentDir ?? resolveAgentDir();
+  const cwd = options?.cwd ?? process.cwd();
+  const path_ = settingsPath ?? path.join(agentDir, "settings.json");
+
+  const installDir = findPiSubagentsInstall(agentDir, cwd);
+  if (!installDir) {
+    return { path: path_, action: "skipped", reason: "pi-subagents not installed" };
+  }
+  const builtins = discoverBuiltinAgents(installDir);
+  if (builtins.length === 0) {
+    return { path: path_, action: "skipped", reason: "pi-subagents ships no agents/*.md" };
+  }
+
+  let settingsRaw: string;
+  try {
+    settingsRaw = fs.readFileSync(path_, "utf-8");
+  } catch {
+    return { path: path_, action: "skipped", reason: "not found" };
   }
 
   let settings: Record<string, unknown>;
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return { path, action: "failed", reason: "settings.json root is not a JSON object" };
-    }
-    settings = parsed as Record<string, unknown>;
-  } catch (e) {
-    return { path, action: "failed", reason: `settings.json is not valid JSON: ${(e as Error).message}` };
-  }
-
-  const subagents = (typeof settings.subagents === "object" && settings.subagents !== null && !Array.isArray(settings.subagents))
-    ? { ...(settings.subagents as Record<string, unknown>) }
-    : {};
-  const overridesRaw = (typeof subagents.agentOverrides === "object" && subagents.agentOverrides !== null && !Array.isArray(subagents.agentOverrides))
-    ? { ...(subagents.agentOverrides as Record<string, unknown>) }
-    : {};
-
-  const updatedOverrides: Record<string, unknown> = { ...overridesRaw };
-  let anyChanged = false;
-  for (const name of Object.keys(BUILTIN_DEFAULT_TOOLS)) {
-    const existing = (overridesRaw[name] ?? undefined) as OverrideEntry | undefined;
-    const { tools, changed } = desiredTools(existing, name);
-    if (changed) {
-      updatedOverrides[name] = { ...(existing ?? {}), tools };
-      anyChanged = true;
-    }
-  }
-
-  if (!anyChanged) {
-    return { path, action: "skipped", reason: "all builtin agents already have ACP tools" };
-  }
-
-  const backupPath = `${path}.acp-bak`;
-  if (!existsSync(backupPath)) {
-    try { await copyFile(path, backupPath); } catch { /* best effort */ }
-  }
-
-  // Optimistic concurrency guard: bail if the file changed since we read it.
-  try {
-    if ((await stat(path)).mtimeMs !== mtimeMs) {
-      return { path, action: "skipped", reason: "settings.json changed during setup (concurrent write); will retry next session" };
+    settings = JSON.parse(settingsRaw) as Record<string, unknown>;
+    if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+      return { path: path_, action: "failed", reason: "settings.json root is not an object" };
     }
   } catch {
-    return { path, action: "failed", reason: "settings.json disappeared during setup" };
+    return { path: path_, action: "failed", reason: "settings.json is not valid JSON" };
   }
 
-  const next: Record<string, unknown> = {
-    ...settings,
-    subagents: { ...subagents, agentOverrides: updatedOverrides },
-  };
+  const subagents = (typeof settings.subagents === "object" && settings.subagents !== null
+    ? settings.subagents
+    : {}) as Record<string, unknown>;
+  const existingOverrides = (typeof subagents.agentOverrides === "object" && subagents.agentOverrides !== null
+    ? subagents.agentOverrides
+    : {}) as Record<string, AgentOverride | undefined>;
 
-  const tmpPath = `${path}.tmp-${process.pid}`;
-  try {
-    await writeFile(tmpPath, `${JSON.stringify(next, null, 2)}\n`, "utf-8");
-    await rename(tmpPath, path);
-  } catch (e) {
-    return { path, action: "failed", reason: `write failed: ${(e as Error).message}` };
+  let changed = false;
+  const overrides: Record<string, AgentOverride> = {};
+  for (const [name, existing] of Object.entries(existingOverrides)) overrides[name] = existing ?? {};
+
+  // Only patch agents the installed pi-subagents actually ships. Agents that
+  // are unrestricted (no frontmatter tools) already have every tool — skip.
+  const frontmatterByName = new Map(builtins.map((b) => [b.name, b.tools]));
+  for (const name of builtins.map((b) => b.name)) {
+    const existing = overrides[name];
+    const baseTools =
+      existing?.tools && Array.isArray(existing.tools) && existing.tools.length > 0
+        ? existing.tools
+        : frontmatterByName.get(name);
+    if (baseTools === undefined) continue; // Unrestricted agent — nothing to grant.
+    const wanted = desiredTools(baseTools);
+    const current = existing?.tools;
+    if (
+      Array.isArray(current) &&
+      current.length > 0 &&
+      wanted.every((tool) => current.includes(tool))
+    ) {
+      continue; // Already complete — keep the existing list untouched.
+    }
+    overrides[name] = { ...existing, tools: wanted };
+    changed = true;
   }
 
+  if (!changed) {
+    return { path: path_, action: "skipped", reason: "already have ACP tools" };
+  }
+
+  subagents.agentOverrides = overrides;
+  settings.subagents = subagents;
+
+  // Write with backup + verify, never leaving settings.json invalid.
+  const backupPath = `${path_}.acp-bak`;
   try {
-    const verify = JSON.parse(await readFile(path, "utf-8")) as Record<string, unknown>;
-    const sub = verify.subagents as Record<string, unknown> | undefined;
-    const v = sub?.agentOverrides;
-    if (typeof v !== "object" || v === null) throw new Error("agentOverrides missing after write");
-    for (const name of Object.keys(BUILTIN_DEFAULT_TOOLS)) {
-      const tools = (v as Record<string, OverrideEntry>)[name]?.tools;
-      if (!Array.isArray(tools) || !ACP_TOOLS.every((t) => tools.includes(t))) {
-        throw new Error(`${name} missing ACP tools after write`);
+    if (!fs.existsSync(backupPath)) fs.copyFileSync(path_, backupPath);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { path: path_, action: "failed", reason: `backup failed: ${message}` };
+  }
+
+  const expectedMtimeMs = fs.statSync(path_).mtimeMs;
+  const tmpPath = `${path_}.tmp-${process.pid}`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+    // Guard against concurrent modification between read and write.
+    if (fs.statSync(path_).mtimeMs !== expectedMtimeMs) {
+      fs.unlinkSync(tmpPath);
+      return { path: path_, action: "failed", reason: "settings.json changed during write" };
+    }
+    fs.renameSync(tmpPath, path_);
+
+    // Post-write sanity check: settings.json still valid and overrides intact.
+    const written = JSON.parse(fs.readFileSync(path_, "utf-8")) as Record<string, unknown>;
+    const writtenSub = written.subagents as Record<string, unknown> | undefined;
+    const writtenOverrides = (writtenSub?.agentOverrides ?? {}) as Record<string, AgentOverride | undefined>;
+    for (const b of builtins) {
+      const entry = writtenOverrides[b.name];
+      const tools = entry?.tools ?? [];
+      if (frontmatterByName.get(b.name) !== undefined && !ACP_TOOLS.every((t) => tools.includes(t))) {
+        fs.copyFileSync(backupPath, path_);
+        return { path: path_, action: "failed", reason: "post-write verification failed" };
       }
     }
-  } catch (e) {
-    try { await copyFile(backupPath, path); } catch { /* leave as-is */ }
-    return { path, action: "failed", reason: `verification failed; restored backup: ${(e as Error).message}` };
+    return { path: path_, action: "updated" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (fs.existsSync(backupPath)) {
+      try { fs.copyFileSync(backupPath, path_); } catch { /* ignore restore failure */ }
+    }
+    return { path: path_, action: "failed", reason: message };
   }
-
-  return { path, action: "updated" };
 }
 
-export async function runSetupAndNotify(notify?: (msg: string) => void): Promise<SetupResult> {
+/**
+ * Run the subagent ACP tools setup and surface a UI notification on success.
+ * Safe to call fire-and-forget from the session_start handler.
+ */
+export function runSetupAndNotify(notify?: (message: string) => void): void {
   try {
-    const result = await ensureSubagentAcpTools();
+    const result = ensureSubagentAcpTools();
     debug.event("setup-subagent-tools", { action: result.action, reason: result.reason });
-    if (result.action === "updated" && notify) {
-      notify(`ACP: enabled context tools (compress/decompress/search_context/acp_status) for subagents`);
-    }
-    if (result.action === "failed") {
+    if (result.action === "updated") {
+      notify?.(`ACP: enabled context tools (compress/decompress/search_context/acp_status) for subagents`);
+    } else if (result.action === "failed") {
       logWarn("setup", { event: "subagent-tools", action: result.action, reason: result.reason });
     }
-    return result;
-  } catch (e) {
-    debug.event("setup-subagent-tools-error", { msg: String(e) });
-    logError("setup", { event: "subagent-tools-error", error: e instanceof Error ? e.message : String(e), stack: e instanceof Error ? e.stack ?? "" : "" });
-    return { path: "", action: "failed", reason: String(e) };
+  } catch (err) {
+    debug.event("setup-subagent-tools-error", { msg: String(err) });
+    logError("setup", {
+      event: "subagent-tools-error",
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack ?? "" : "",
+    });
   }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -46,12 +46,12 @@ function userMsg(id: string, text: string) {
   return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
 }
 
-test("factory registers the compress tool and 4 flat commands", () => {
+test("factory registers the compress tool and 5 flat commands", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);
 
   assert.ok(api.tools.some((t) => t.name === "compress"), "compress tool registered");
-  assert.deepEqual([...api.commands.keys()].sort(), ["acp", "acp-decompress", "acp-search", "acp-status"]);
+  assert.deepEqual([...api.commands.keys()].sort(), ["acp", "acp-decompress", "acp-search", "acp-status", "acp-subagents"]);
   assert.ok(handlers.has("context"), "context event wired");
   assert.ok(handlers.has("session_before_compact"), "compaction-disable wired");
   assert.ok(handlers.has("before_agent_start"), "system-prompt wired");

--- a/tests/setup-subagent-tools.test.ts
+++ b/tests/setup-subagent-tools.test.ts
@@ -125,6 +125,25 @@ describe("ensureSubagentAcpTools — pi-subagents detection (#179)", () => {
     assert.ok(ACP_TOOLS.every((t) => (overrides.reviewer.tools as string[]).includes(t)));
   });
 
+  it("accepts an explicit installDir outside the detected locations", () => {
+    const hidden = path.join(projectDir, "vendor", "pi-subagents-fork");
+    installPiSubagents(hidden);
+    writeSettings({});
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir, installDir: hidden });
+    assert.equal(result.action, "updated");
+    const overrides = overridesOf(readSettings());
+    assert.ok(ACP_TOOLS.every((t) => (overrides.worker.tools as string[]).includes(t)));
+  });
+
+  it("fails with a clear reason when the explicit installDir is not a package", () => {
+    writeSettings({});
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir, installDir: path.join(projectDir, "nope") });
+    assert.equal(result.action, "failed");
+    assert.match(result.reason ?? "", /not a package/);
+    assert.deepEqual(readSettings(), {});
+  });
+
   it("skips when the install ships no agents/*.md", () => {
     const installDir = path.join(agentDir, "npm", "node_modules", "pi-subagents");
     fs.mkdirSync(installDir, { recursive: true });

--- a/tests/setup-subagent-tools.test.ts
+++ b/tests/setup-subagent-tools.test.ts
@@ -1,149 +1,243 @@
-import assert from "node:assert/strict";
-import { test } from "node:test";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { ensureSubagentAcpTools } from "../src/setup-subagent-tools.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { strict as assert } from "node:assert";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { ACP_TOOLS } from "../src/setup-subagent-tools.js";
 
-const ACP_TOOLS = ["compress", "decompress", "search_context", "acp_status"];
+const { ensureSubagentAcpTools } = await import("../src/setup-subagent-tools.js");
 
-function tmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "acp-setup-"));
+let tmp: string;
+let agentDir: string;
+let projectDir: string;
+let settingsPath: string;
+
+function writeSettings(data: Record<string, unknown>): void {
+  fs.writeFileSync(settingsPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
 }
 
-function writeSettings(dir: string, obj: unknown): string {
-  const p = join(dir, "settings.json");
-  writeFileSync(p, JSON.stringify(obj, null, 2));
-  return p;
+function readSettings(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
 }
 
-function readSettings(path: string): Record<string, unknown> {
-  return JSON.parse(readFileSync(path, "utf-8"));
+function overridesOf(settings: Record<string, unknown>): Record<string, Record<string, unknown>> {
+  const sub = settings.subagents as Record<string, unknown>;
+  return (sub.agentOverrides ?? {}) as Record<string, Record<string, unknown>>;
 }
 
-function allAgentsHaveAcp(path: string): boolean {
-  const s = readSettings(path);
-  const o = (s.subagents as Record<string, unknown> | undefined)?.agentOverrides as Record<string, { tools?: string[] }> | undefined;
-  if (!o) return false;
-  const names = ["advisor", "context-builder", "delegate", "oracle", "planner", "researcher", "reviewer", "scout", "worker"];
-  return names.every((n) => Array.isArray(o[n]?.tools) && ACP_TOOLS.every((t) => o[n]!.tools!.includes(t)));
+/** Create a fake pi-subagents install with the agent set from v0.53.0. */
+function installPiSubagents(dir: string): void {
+  fs.mkdirSync(path.join(dir, "agents"), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "pi-subagents", version: "0.53.0" }, null, 2) + "\n",
+  );
+  const agents: Array<[string, string[] | null]> = [
+    ["worker", ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor"]],
+    ["reviewer", ["read", "grep", "find", "ls"]],
+    ["oracle", null], // unrestricted — no tools line in frontmatter
+  ];
+  for (const [name, tools] of agents) {
+    const lines = ["---", `name: ${name}`];
+    if (tools) lines.push(`tools: ${tools.join(", ")}`);
+    lines.push("---", `# ${name}`);
+    fs.writeFileSync(path.join(dir, "agents", `${name}.md`), lines.join("\n") + "\n");
+  }
 }
 
-test("creates overrides for all builtin agents when settings has no subagents", async () => {
-  const dir = tmpDir();
-  const path = writeSettings(dir, { theme: "dark", defaultModel: "gpt-4" });
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "updated");
-  assert.ok(allAgentsHaveAcp(path), "all agents should have ACP tools");
-  const s = readSettings(path);
-  assert.equal(s.theme, "dark", "preserves existing fields");
-  assert.equal(s.defaultModel, "gpt-4", "preserves existing fields");
-  rmSync(dir, { recursive: true, force: true });
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "acp-setup-test-"));
+  agentDir = path.join(tmp, "agent");
+  projectDir = path.join(tmp, "proj");
+  fs.mkdirSync(agentDir, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  settingsPath = path.join(agentDir, "settings.json");
 });
 
-test("is idempotent — second run skips and does not rewrite file", async () => {
-  const dir = tmpDir();
-  const path = writeSettings(dir, { theme: "dark" });
-  const first = await ensureSubagentAcpTools(path);
-  assert.equal(first.action, "updated");
-  const firstMtime = statSync(path).mtimeMs;
-  const second = await ensureSubagentAcpTools(path);
-  assert.equal(second.action, "skipped");
-  assert.match(second.reason!, /already have ACP tools/);
-  assert.equal(statSync(path).mtimeMs, firstMtime, "file not rewritten on skip");
-  rmSync(dir, { recursive: true, force: true });
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-test("preserves user-customized override tools and appends ACP", async () => {
-  const dir = tmpDir();
-  const path = writeSettings(dir, {
-    subagents: {
-      agentOverrides: {
-        delegate: { tools: ["read", "bash", "myCustomTool"] },
+describe("ensureSubagentAcpTools — pi-subagents detection (#179)", () => {
+  it("skips without touching settings when pi-subagents is not installed", () => {
+    const stale = {
+      subagents: {
+        agentOverrides: {
+          advisor: { model: "test-model", tools: ["read", "grep", "find", "ls", "compress"] },
+        },
       },
-    },
-  });
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "updated");
-  const s = readSettings(path);
-  const tools = (s.subagents as Record<string, unknown>).agentOverrides.delegate.tools as string[];
-  assert.ok(tools.includes("myCustomTool"), "preserves user custom tool");
-  assert.ok(ACP_TOOLS.every((t) => tools.includes(t)), "has ACP tools");
-  assert.ok(tools.includes("read") && tools.includes("bash"), "preserves original tools");
-  rmSync(dir, { recursive: true, force: true });
-});
+    };
+    writeSettings(stale);
 
-test("does not duplicate ACP tools when already partially present", async () => {
-  const dir = tmpDir();
-  const path = writeSettings(dir, {
-    subagents: {
-      agentOverrides: {
-        delegate: { tools: ["read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor", ...ACP_TOOLS] },
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "skipped");
+    assert.match(result.reason ?? "", /not installed/);
+
+    const after = readSettings();
+    assert.deepEqual(
+      overridesOf(after).advisor.tools,
+      ["read", "grep", "find", "ls", "compress"],
+    );
+    assert.ok(!fs.existsSync(`${settingsPath}.acp-bak`), "no backup when skipped");
+  });
+
+  it("does not create settings-related artifacts when pi-subagents is absent", () => {
+    writeSettings({});
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "skipped");
+    assert.deepEqual(readSettings(), {});
+  });
+
+  it("detects a user-scope npm install under <agentDir>/npm/node_modules", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({});
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+
+    const overrides = overridesOf(readSettings());
+    assert.deepEqual(overrides.worker.tools, [
+      "read", "grep", "find", "ls", "bash", "edit", "write", "contact_supervisor",
+      ...ACP_TOOLS,
+    ]);
+    assert.deepEqual(overrides.reviewer.tools, ["read", "grep", "find", "ls", ...ACP_TOOLS]);
+    assert.ok(!("oracle" in overrides), "unrestricted agent must not get an override entry");
+  });
+
+  it("detects a project-scope npm install under <cwd>/.pi/npm/node_modules", () => {
+    installPiSubagents(path.join(projectDir, ".pi", "npm", "node_modules", "pi-subagents"));
+    writeSettings({});
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+    const overrides = overridesOf(readSettings());
+    assert.ok(ACP_TOOLS.every((t) => (overrides.worker.tools as string[]).includes(t)));
+  });
+
+  it("detects pi-subagents placed in the extensions directory", () => {
+    const extDir = path.join(agentDir, "extensions", "pi-subagents");
+    installPiSubagents(extDir);
+    writeSettings({});
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+    const overrides = overridesOf(readSettings());
+    assert.ok(ACP_TOOLS.every((t) => (overrides.reviewer.tools as string[]).includes(t)));
+  });
+
+  it("skips when the install ships no agents/*.md", () => {
+    const installDir = path.join(agentDir, "npm", "node_modules", "pi-subagents");
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "pi-subagents" }));
+    writeSettings({});
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "skipped");
+    assert.match(result.reason ?? "", /no agents/);
+    assert.deepEqual(readSettings(), {});
+  });
+
+  it("never recreates the stale 9-agent set — only agents the package ships", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({
+      subagents: {
+        agentOverrides: {
+          // Leftovers from older billion-context-pi versions.
+          advisor: { tools: ["read", "bash", "intercom", "compress"] },
+          planner: { tools: ["read", "grep", "find", "ls", "bash", "intercom"] },
+        },
       },
-    },
+    });
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+
+    const overrides = overridesOf(readSettings());
+    // Stale entries are preserved byte-for-byte (we never rewrite them).
+    assert.deepEqual(overrides.advisor.tools, ["read", "bash", "intercom", "compress"]);
+    assert.deepEqual(overrides.planner.tools, ["read", "grep", "find", "ls", "bash", "intercom"]);
+    assert.deepEqual(Object.keys(overrides).sort(), ["advisor", "planner", "reviewer", "worker"]);
   });
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "updated");
-  const s = readSettings(path);
-  const delegateTools = (s.subagents as Record<string, unknown>).agentOverrides.delegate.tools as string[];
-  assert.equal(delegateTools.length, 12, "delegate unchanged (no duplicate added)");
-  rmSync(dir, { recursive: true, force: true });
 });
 
-test("preserves other override fields (model, thinking)", async () => {
-  const dir = tmpDir();
-  const path = writeSettings(dir, {
-    subagents: {
-      agentOverrides: {
-        delegate: { model: "custom-model", thinking: "high", tools: ["read", "bash"] },
+describe("ensureSubagentAcpTools — merge behavior", () => {
+  it("appends missing ACP tools to a user-custom override", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({
+      subagents: {
+        agentOverrides: {
+          worker: { tools: ["bash", "read"], model: "my-model" },
+        },
       },
-    },
+    });
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+
+    const worker = overridesOf(readSettings()).worker;
+    assert.deepEqual(worker.tools, ["bash", "read", ...ACP_TOOLS]);
+    assert.equal(worker.model, "my-model", "non-tools fields are preserved");
   });
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "updated");
-  const s = readSettings(path);
-  const delegate = (s.subagents as Record<string, unknown>).agentOverrides.delegate as Record<string, unknown>;
-  assert.equal(delegate.model, "custom-model", "preserves model override");
-  assert.equal(delegate.thinking, "high", "preserves thinking override");
-  rmSync(dir, { recursive: true, force: true });
+
+  it("completes an override that already has some ACP tools without reordering", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({
+      subagents: {
+        agentOverrides: {
+          worker: { tools: ["read", "compress"] },
+        },
+      },
+    });
+
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "updated");
+
+    const tools = overridesOf(readSettings()).worker.tools as string[];
+    assert.deepEqual(tools, ["read", "compress", "decompress", "search_context", "acp_status"]);
+  });
+
+  it("is idempotent — second run is a no-op", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({});
+
+    assert.equal(ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir }).action, "updated");
+    const snapshot = fs.readFileSync(settingsPath, "utf-8");
+    const second = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(second.action, "skipped");
+    assert.match(second.reason ?? "", /already have ACP tools/);
+    assert.equal(fs.readFileSync(settingsPath, "utf-8"), snapshot);
+  });
+
+  it("creates a backup once and keeps it on later updates", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    writeSettings({});
+
+    assert.equal(ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir }).action, "updated");
+    assert.ok(fs.existsSync(`${settingsPath}.acp-bak`));
+    const backupSnapshot = fs.readFileSync(`${settingsPath}.acp-bak`, "utf-8");
+    // Simulate a further user edit then another update.
+    fs.writeFileSync(settingsPath, JSON.stringify({ subagents: {} }, null, 2) + "\n");
+    assert.equal(ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir }).action, "updated");
+    assert.equal(fs.readFileSync(`${settingsPath}.acp-bak`, "utf-8"), backupSnapshot);
+  });
 });
 
-test("returns failed on invalid JSON without modifying file", async () => {
-  const dir = tmpDir();
-  const path = join(dir, "settings.json");
-  writeFileSync(path, "{ not valid json");
-  const before = statSync(path).mtimeMs;
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "failed");
-  assert.match(result.reason!, /not valid JSON/);
-  assert.equal(statSync(path).mtimeMs, before, "file untouched on parse failure");
-  rmSync(dir, { recursive: true, force: true });
-});
+describe("ensureSubagentAcpTools — error handling", () => {
+  it("skips when settings.json is missing", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "skipped");
+    assert.match(result.reason ?? "", /not found/);
+  });
 
-test("returns skipped when settings.json does not exist", async () => {
-  const dir = tmpDir();
-  const path = join(dir, "settings.json");
-  const result = await ensureSubagentAcpTools(path);
-  assert.equal(result.action, "skipped");
-  assert.match(result.reason!, /not found/);
-  rmSync(dir, { recursive: true, force: true });
-});
+  it("fails on invalid JSON without modifying the file", () => {
+    installPiSubagents(path.join(agentDir, "npm", "node_modules", "pi-subagents"));
+    const broken = "{ not valid json";
+    fs.writeFileSync(settingsPath, broken, "utf-8");
 
-test("creates backup on first write, not on subsequent skips", async () => {
-  const dir = tmpDir();
-  const original = { theme: "light", customField: 42 };
-  const path = writeSettings(dir, original);
-  const backupPath = `${path}.acp-bak`;
-
-  const first = await ensureSubagentAcpTools(path);
-  assert.equal(first.action, "updated");
-
-  const backupContent = readSettings(backupPath);
-  assert.deepEqual(backupContent, original, "backup contains pre-edit content");
-
-  const backupMtime = statSync(backupPath).mtimeMs;
-  const second = await ensureSubagentAcpTools(path);
-  assert.equal(second.action, "skipped");
-  assert.equal(statSync(backupPath).mtimeMs, backupMtime, "backup not rewritten");
-  rmSync(dir, { recursive: true, force: true });
+    const result = ensureSubagentAcpTools(settingsPath, { agentDir, cwd: projectDir });
+    assert.equal(result.action, "failed");
+    assert.match(result.reason ?? "", /not valid JSON/);
+    assert.equal(fs.readFileSync(settingsPath, "utf-8"), broken);
+  });
 });


### PR DESCRIPTION
## Fixes #179

billion-context-pi rewrote a `subagents.agentOverrides` block (9 hardcoded agents + ACP tools) into `~/.pi/agent/settings.json` on every startup — **even when pi-subagents was not installed** — and the stale entries came back after manual deletion.

### Final design: no auto-writes, explicit one-time command

After review we went one step further than detection: **the extension no longer touches global settings.json at all unless the user asks**.

- **Removed** the session-start auto-injection (`runSetupAndNotify` + the `session_start` call).
- **New `/acp-subagents [installDir]` command** — the only write path. It detects the installed pi-subagents package (user/project npm scopes + `extensions/` dirs) and discovers builtin agents + baseline `tools` from the package's own `agents/*.md` frontmatter, then writes `frontmatter tools + compress/decompress/search_context/acp_status` into `agentOverrides` (required because override `tools` *replace*, not merge, frontmatter tools).
  - Detection miss → visible "install it or pass the directory" message, not a silent no-op.
  - `<installDir>` argument covers git installs and forks explicitly.
- The hardcoded `BUILTIN_DEFAULT_TOOLS` table (9 agents incl. ones pi-subagents no longer ships, plus obsolete `intercom` entries) is gone.
- Safe-write machinery unchanged: `.acp-bak` backup, optimistic mtime lock, post-write verification, rollback on failure.

### Why a command instead of auto-detection

- Detection is inherently incomplete (git installs, legacy global npm, forks) — a silent no-op is harder to debug than one explicit step.
- #179's root cause is "an extension silently rewriting my global settings.json"; shrinking the blast radius with detection doesn't remove the pattern.
- Per-agent `tools` baselines are version-dependent, so a static doc snippet would rot — the command reads frontmatter at run time and never goes stale.

**Impact on existing users:** none — already-written override entries are preserved and never deleted; only the automatic re-write is removed. Users who want ACP context tools in pi-subagents run `/acp-subagents` once (re-run after pi-subagents upgrades). Documented in README (EN + ZH).

### Tests

- `tests/setup-subagent-tools.test.ts` rewritten: 15 cases (not-installed no-op, 3 install locations, explicit `installDir`, stale-entry preservation, merge/idempotency/backup/error paths)
- `tests/integration.test.ts`: factory now registers 5 flat commands
- Full suite: 389/389 pass; typecheck + build clean; CI on Windows (reporter's platform) included

Devlog: `devlog/2026-08-21_issue179-detect-pi-subagents/`