### PR TITLE
release v0.1.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.42",
+	"version": "0.1.43",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.42",
+			"version": "0.1.43",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.42",
+	"version": "0.1.43",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release PR for v0.1.43 (issue #3 wrap-up). Contains everything merged via #181 plus the version bump:

- **fix(compress)**: T3→T3 self-rewrite loop guard — `compress(bN..bN)` on a terminal tier-3 block reclaimed 0 tokens and could repeat forever; now rejected with recovery guidance + state rollback (`d941e0c`)
- **deps**: acp-kernel 0.0.28 → **0.0.30** — anchor-snap (multi-block distill `compress(bN..bM)` no longer misrejected "consumed" on the pruned view, kernel #32) + stale-refs aggregate error (all-unknown batches now say "refs expired — run acp_status" instead of misleading "too small", billion-context-pi#178) (`1a3145b`, `18461fc`)
- **docs(prompt)**: stale-ref recovery guidance — renumbering causality, same-turn acp_status, single batch call (`9b78834`, billion-context-pi#178)
- **release**: version 0.1.42 → 0.1.43 (acp-kernel pin already at exact 0.0.30 from #181)

Validation: tsc clean, 384/384 tests, build OK. Merge → CI publishes 0.1.43. Merge: human-only per AGENTS.md.