### PR TITLE
fix(update): check latest via npm view, log install failures

### DIFF
--- a/devlog/2026-08-21_update-check-robustness/REQ.md
+++ b/devlog/2026-08-21_update-check-robustness/REQ.md
@@ -15,6 +15,7 @@
 - **Expected behavior**:
   - 版本检查优先走 `npm view billion-context-pi version`（尊重本机 registry/proxy/auth 配置，与安装步同一工具链）；npm 不可用时回退直接 registry fetch。
   - 安装失败/跳过原因写入 `~/.pi/acp.log`（含 npm stderr），可诊断。
+  - headless 模式（print/rpc/json）下 session_start / context 处理器 await 更新检查，进程退出不会杀掉进行中的 npm install；TUI 保持 fire-and-forget。
 - **Impact**: 无数据丢失、无崩溃；补齐受影响机器"检测不到新版本"的缺口；不受影响机器行为等价（保留 fetch 回退）。
 
 ## 2. Reproduction (if applicable)

--- a/devlog/2026-08-21_update-check-robustness/REQ.md
+++ b/devlog/2026-08-21_update-check-robustness/REQ.md
@@ -1,0 +1,49 @@
+# REQ: 自动更新在无法直连 npmjs 的机器上静默失效
+
+- Task ID: `2026-08-21_update-check-robustness`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-21
+- Status: InProgress
+- Priority: P1
+- Owner: ework-daemon
+- References: issue dog/billion-context-pi#8
+
+## 1. Background & Problem Statement
+
+- **Context**: 自动更新分两步——版本检查（直接 `fetch https://registry.npmjs.org/billion-context-pi/latest`，5s 超时，不走任何 npm 配置）+ 自动安装（`npm install billion-context-pi@<ver>`）。
+- **Current behavior (symptom)**: 部分机器上自动更新静默失效。Node 全局 fetch 不认 `HTTP_PROXY`/`HTTPS_PROXY`，走国内镜像（npmmirror）或企业代理的机器直连 registry.npmjs.org 超时/失败，**根本检测不到新版本**；且安装失败完全静默（仅 TUI 提示、无日志），无法排查。
+- **Expected behavior**:
+  - 版本检查优先走 `npm view billion-context-pi version`（尊重本机 registry/proxy/auth 配置，与安装步同一工具链）；npm 不可用时回退直接 registry fetch。
+  - 安装失败/跳过原因写入 `~/.pi/acp.log`（含 npm stderr），可诊断。
+- **Impact**: 无数据丢失、无崩溃；补齐受影响机器"检测不到新版本"的缺口；不受影响机器行为等价（保留 fetch 回退）。
+
+## 2. Reproduction (if applicable)
+
+- **Environment**:
+  - Node: 22+
+  - OS/Arch: linux-x64 / win32-x64
+- **Minimal reproduction steps**:
+  1) 在 `npm config get registry` 为镜像（或需代理）的机器上，阻断到 registry.npmjs.org 的直连
+  2) 启动 Pi，等待更新检查 → `~/.pi/acp.log` 出现 `event=check-error`（fetch 超时）
+  3) npm 本身完全可用，但插件检测不到新版本
+- **Relevant configuration**: `~/.npmrc`（registry/proxy）、`ACP_AUTO_UPDATE`
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**:
+  - 不引入新运行时依赖
+  - 3 分钟检查节流与 opt-out 语义（env/config）不变
+  - `npm install` 安全参数数组方式（不拼 shell 字符串）不变
+- **Non-Goals**: 不修 headless 模式无 UI 提示（headless 本无 UI，日志即诊断通道）；不做安装重试
+
+## 4. Acceptance Criteria (must be testable)
+
+- **Correctness**:
+  - [x] 检查优先 `npm view`（args `["view","billion-context-pi","version"]`）；失败回退直接 registry fetch
+  - [x] 两者皆失败 → 不崩溃、无提示，日志 `event=check-fetch-error`
+  - [x] 安装失败 → 日志 `event=auto-install-failed`（含 npm stderr）；跳过 → `event=install-skip`（含 reason）
+  - [x] opt-out（env/config）在任何 npm/fetch 调用前短路
+  - [x] `isNewer` 数值比较（0.2.0 不新于 0.10.0）
+- **Compatibility**:
+  - [x] 既有 384 个测试全部通过（本次后共 393）
+  - [x] typecheck / build 通过

--- a/devlog/2026-08-21_update-check-robustness/WORKLOG.md
+++ b/devlog/2026-08-21_update-check-robustness/WORKLOG.md
@@ -7,9 +7,9 @@
 
 ## 1. Summary
 
-- **What was done**: 版本检查改走 `npm view` 优先（尊重本机 registry/proxy 配置），直接 fetch 降为回退（超时 5s→10s）；安装失败日志补 npm stderr，新增 install-skip 原因日志；新增 `runNpm` execFile 封装 + 测试 seam。
-- **Why**: 只能经镜像/代理访问 npm 的机器上，直连 registry.npmjs.org 的 fetch 失败（Node fetch 不认 proxy 环境变量），新版本永远检测不到；安装失败静默导致无法排查。
-- **Behavior / compatibility changes**: Yes——有 npm 的机器检查走 `npm view`（与安装同工具链）；无 npm 的机器行为不变（fetch 回退）；新增日志事件（`check-fetch-error`/`auto-install-failed`/`install-skip`）。
+- **What was done**: 版本检查改走 `npm view` 优先（尊重本机 registry/proxy 配置），直接 fetch 降为回退（超时 5s→10s）；安装失败日志补 npm stderr，新增 install-skip 原因日志；headless 模式（print/rpc/json）的 session_start 与 context 处理器改为 await 更新检查，进程退出不再杀掉进行中的安装；新增 `runNpm` execFile 封装 + 测试 seam。
+- **Why**: 只能经镜像/代理访问 npm 的机器上，直连 registry.npmjs.org 的 fetch 失败（Node fetch 不认 proxy 环境变量），新版本永远检测不到；安装失败静默导致无法排查；headless 进程 turn 结束即退出，fire-and-forget 的检查/安装被连带杀掉（用户机器 0.1.40→0.1.41、0.1.38→0.1.41 的静默失败与此吻合）。
+- **Behavior / compatibility changes**: Yes——有 npm 的机器检查走 `npm view`（与安装同工具链）；无 npm 的机器行为不变（fetch 回退）；headless 进程在更新检查/安装期间保持存活（TUI 不变，仍 fire-and-forget）；新增日志事件（`check-fetch-error`/`auto-install-failed`/`install-skip`）。
 - **Risk level**: Low
 
 ## 2. Change Log
@@ -19,11 +19,14 @@
 | Commit | Description |
 |--------|-------------|
 | `0173f55` | fix(update): check latest via npm view, log install failures |
+| `f7378f0` | fix(update): await update check in headless mode so process exit cannot kill an in-flight install |
 
 ### Key Files
 
 - `src/update.ts` — +74/-13：新增 `NpmRunner` 类型 + `runNpm`（execFile 封装，捕获 stdout/stderr，maxBuffer 4MB，win32 走 shell）+ `setRunNpmForTest` seam；`fetchLatestVersion()`（npm view 20s → fetch 10s 回退，SEMVER_RE 校验输出）；`autoInstallLatest` 改走 `runNpm`，失败记 `auto-install-failed`（stderr 尾部 2000 字符）、跳过记 `install-skip`（reason）；导出 `isNewer`
+- `src/index.ts` — +9/-2：session_start 与 context 两个调用点由 `void checkForUpdate(...)` 改为 `if (!ctx.hasUI) await updateCheck`——headless（print/rpc/json）进程在 turn 结束后即退出，fire-and-forget 会把进行中的 npm install 杀掉；TUI 保持 fire-and-forget 不阻塞交互
 - `tests/update.test.ts` — 重写，14 个测试：opt-out 短路（npm+fetch 双守卫）、`isNewer` 数值比较、`runNpm` 真实 npm 成功/stderr 捕获、checkForUpdate 全路径（npm view 参数 / install-skip / fetch 回退 / 双失败 / non-OK / 节流）
+- `tests/integration.test.ts` — +119：模块级 `setRunNpmForTest` 假 runner（headless 测试现在会 await 检查，必须 hermetic，防真实网络调用）；新增 2 个测试：headless 处理器在检查进行中（npm view 挂起）必须保持 pending、view 解析后随检查完成而结算（日志断言 `event=check latest=99.0.0 hasUpdate=true` + `install-skip`）；TUI 处理器在检查进行中立即结算
 
 ## 3. Design & Implementation Notes
 

--- a/devlog/2026-08-21_update-check-robustness/WORKLOG.md
+++ b/devlog/2026-08-21_update-check-robustness/WORKLOG.md
@@ -21,7 +21,7 @@
 | `0173f55` | fix(update): check latest via npm view, log install failures |
 | `f7378f0` | fix(update): await update check in headless mode so process exit cannot kill an in-flight install |
 | `a3782f2` | test: isolate update-check throttle file across parallel test processes |
-| (next) | fix(update): verify installs and roll back broken publishes (anti-brick) |
+| `88e1f71` | fix(update): verify installs and roll back broken publishes (anti-brick) |
 
 ### Key Files
 

--- a/devlog/2026-08-21_update-check-robustness/WORKLOG.md
+++ b/devlog/2026-08-21_update-check-robustness/WORKLOG.md
@@ -1,0 +1,32 @@
+# WORKLOG: 自动更新在无法直连 npmjs 的机器上静默失效
+
+- Task ID: `2026-08-21_update-check-robustness`
+- Home Repo: `billion-context-pi`
+- Status: InProgress
+- Updated: 2026-08-21 12:55
+
+## 1. Summary
+
+- **What was done**: 版本检查改走 `npm view` 优先（尊重本机 registry/proxy 配置），直接 fetch 降为回退（超时 5s→10s）；安装失败日志补 npm stderr，新增 install-skip 原因日志；新增 `runNpm` execFile 封装 + 测试 seam。
+- **Why**: 只能经镜像/代理访问 npm 的机器上，直连 registry.npmjs.org 的 fetch 失败（Node fetch 不认 proxy 环境变量），新版本永远检测不到；安装失败静默导致无法排查。
+- **Behavior / compatibility changes**: Yes——有 npm 的机器检查走 `npm view`（与安装同工具链）；无 npm 的机器行为不变（fetch 回退）；新增日志事件（`check-fetch-error`/`auto-install-failed`/`install-skip`）。
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| `0173f55` | fix(update): check latest via npm view, log install failures |
+
+### Key Files
+
+- `src/update.ts` — +74/-13：新增 `NpmRunner` 类型 + `runNpm`（execFile 封装，捕获 stdout/stderr，maxBuffer 4MB，win32 走 shell）+ `setRunNpmForTest` seam；`fetchLatestVersion()`（npm view 20s → fetch 10s 回退，SEMVER_RE 校验输出）；`autoInstallLatest` 改走 `runNpm`，失败记 `auto-install-failed`（stderr 尾部 2000 字符）、跳过记 `install-skip`（reason）；导出 `isNewer`
+- `tests/update.test.ts` — 重写，14 个测试：opt-out 短路（npm+fetch 双守卫）、`isNewer` 数值比较、`runNpm` 真实 npm 成功/stderr 捕获、checkForUpdate 全路径（npm view 参数 / install-skip / fetch 回退 / 双失败 / non-OK / 节流）
+
+## 3. Design & Implementation Notes
+
+- **Entry point / key function**: `fetchLatestVersion`（`src/update.ts:156`）、`autoInstallLatest`（`src/update.ts:116`）、`checkForUpdate`（`src/update.ts:196`）
+- **保留 fetch 回退的原因**: 无 npm 的机器上直连 fetch 仍是唯一检测通道；超时放宽到 10s 降低慢网络误报
+- **测试隔离**: 测试进程把 `HOME` 指到临时目录（`THROTTLE_FILE` 是模块级常量，import 前必须设置）、`ACP_LOG_FILE` 同指临时目录；真实 npm 测试临时还原真实 HOME（npm 解析可能依赖 HOME，如 nvm 布局或 npm 包装脚本）

--- a/devlog/2026-08-21_update-check-robustness/WORKLOG.md
+++ b/devlog/2026-08-21_update-check-robustness/WORKLOG.md
@@ -3,7 +3,7 @@
 - Task ID: `2026-08-21_update-check-robustness`
 - Home Repo: `billion-context-pi`
 - Status: InProgress
-- Updated: 2026-08-21 12:55
+- Updated: 2026-08-21 14:10
 
 ## 1. Summary
 
@@ -20,16 +20,25 @@
 |--------|-------------|
 | `0173f55` | fix(update): check latest via npm view, log install failures |
 | `f7378f0` | fix(update): await update check in headless mode so process exit cannot kill an in-flight install |
+| `a3782f2` | test: isolate update-check throttle file across parallel test processes |
+| (next) | fix(update): verify installs and roll back broken publishes (anti-brick) |
 
 ### Key Files
 
 - `src/update.ts` — +74/-13：新增 `NpmRunner` 类型 + `runNpm`（execFile 封装，捕获 stdout/stderr，maxBuffer 4MB，win32 走 shell）+ `setRunNpmForTest` seam；`fetchLatestVersion()`（npm view 20s → fetch 10s 回退，SEMVER_RE 校验输出）；`autoInstallLatest` 改走 `runNpm`，失败记 `auto-install-failed`（stderr 尾部 2000 字符）、跳过记 `install-skip`（reason）；导出 `isNewer`
 - `src/index.ts` — +9/-2：session_start 与 context 两个调用点由 `void checkForUpdate(...)` 改为 `if (!ctx.hasUI) await updateCheck`——headless（print/rpc/json）进程在 turn 结束后即退出，fire-and-forget 会把进行中的 npm install 杀掉；TUI 保持 fire-and-forget 不阻塞交互
-- `tests/update.test.ts` — 重写，14 个测试：opt-out 短路（npm+fetch 双守卫）、`isNewer` 数值比较、`runNpm` 真实 npm 成功/stderr 捕获、checkForUpdate 全路径（npm view 参数 / install-skip / fetch 回退 / 双失败 / non-OK / 节流）
+- `tests/update.test.ts` — 重写，17 个测试：opt-out 短路（npm+fetch 双守卫）、`isNewer` 数值比较、`runNpm` 真实 npm 成功/stderr 捕获、checkForUpdate 全路径（npm view 参数 / install-skip / fetch 回退 / 双失败 / non-OK / 节流）、autoInstallLatest 安装路径（fixture 布局：验证通过 → ok / 语法坏入口 → 回滚上一版本 / npm 失败 → failed 不回滚不验证）
 - `tests/integration.test.ts` — +119：模块级 `setRunNpmForTest` 假 runner（headless 测试现在会 await 检查，必须 hermetic，防真实网络调用）；新增 2 个测试：headless 处理器在检查进行中（npm view 挂起）必须保持 pending、view 解析后随检查完成而结算（日志断言 `event=check latest=99.0.0 hasUpdate=true` + `install-skip`）；TUI 处理器在检查进行中立即结算
 
 ## 3. Design & Implementation Notes
 
 - **Entry point / key function**: `fetchLatestVersion`（`src/update.ts:156`）、`autoInstallLatest`（`src/update.ts:116`）、`checkForUpdate`（`src/update.ts:196`）
 - **保留 fetch 回退的原因**: 无 npm 的机器上直连 fetch 仍是唯一检测通道；超时放宽到 10s 降低慢网络误报
+
+### Anti-brick hardening (2026-08-21 14:10)
+
+- **风险**: npm exit 0 只代表 tarball 解压成功，不代表扩展能加载。坏发布（缺 dist / 语法错误 / ABI 断裂）装上后，下次重启 pi 加载失败 → 扩展不再运行 → 永远无法自更新回健康版本 = **永久砖死**（用户断联）。原先 `autoInstallLatest` 只看 exit code。
+- **修复**: 安装后 `verifyInstall()`——读 `node_modules/billion-context-pi/package.json` 校验 version 匹配 + 声明入口（`pi.extensions[0]` / `exports["."].import` / `main`，去重）全部存在，再用子进程 `node -e` + `pathToFileURL` 真实 smoke-import 入口（15s 超时，Windows 盘符安全）。失败 → 回滚安装前版本（`--no-save`，不动宿主 package.json/lockfile），返回 `rolled-back` 并 notify 用户（不再给出会手动砖死的手动安装提示）。
+- **通知分派**: `ok` → 绿色 "auto-updated … Restart Pi"；`rolled-back` → 黄色 "failed verification and was rolled back"；`failed` → 原有手动安装提示。
+- **测试 seam**: `NodeRunner`/`runNode`/`setRunNodeForTest`（对齐 runNpm 模式）；`autoInstallLatest(latest, extDirOverride?)` 第二参数专供测试 fixture（真实测试进程不在 node_modules 下，原路径不可达）。
 - **测试隔离**: 测试进程把 `HOME` 指到临时目录（`THROTTLE_FILE` 是模块级常量，import 前必须设置）、`ACP_LOG_FILE` 同指临时目录；真实 npm 测试临时还原真实 HOME（npm 解析可能依赖 HOME，如 nvm 布局或 npm 包装脚本）

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,13 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
       pi.registerTool(makeDelegateWaitTool(pi));
       pi.registerTool(makeDelegateCancelTool(pi));
     }
-    void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
+    // Headless hosts exit as soon as the turn ends; awaiting the check keeps
+    // the process alive until a running install finishes. TUI stays
+    // fire-and-forget so interactive startup is never blocked by npm.
+    const updateCheck = checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
+    if (!ctx.hasUI) await updateCheck;
     // Bind the TUI status widget for async delegates. The widget reads the
     // in-memory runs Map (via runningRunsSnapshot) and renders a live list of
     // running delegates below the editor. Only the interactive TUI has a UI;
@@ -357,9 +361,12 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
     // long-running session never re-fires session_start, so an update could
     // go unnoticed for days. checkForUpdate throttles internally (3 min) and
     // is guarded against concurrent calls, so firing it per LLM call is safe.
-    void checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
+    // Headless: await so a process exiting after this turn cannot kill a
+    // running install (TUI stays fire-and-forget to avoid blocking the turn).
+    const updateCheck = checkForUpdate(runtime.adapter.autoUpdate ?? true, (msg) => {
       if (ctx.hasUI) ctx.ui.notify(msg);
     });
+    if (!ctx.hasUI) await updateCheck;
     return { messages: rebuilt };
     } catch (e) {
       logThrow("context", e, { sid, phase: "transform" });

--- a/src/update.ts
+++ b/src/update.ts
@@ -18,11 +18,38 @@ const THROTTLE_FILE = join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-contex
 // so several can race past the throttle read before any writes the timestamp.
 let updateInFlight = false;
 
+export type NpmRunner = (
+  args: string[],
+  opts: { cwd?: string; timeout: number },
+) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+export const runNpm: NpmRunner = async (args, opts) => {
+  return new Promise((resolve) => {
+    execFile(
+      "npm",
+      args,
+      { ...opts, shell: process.platform === "win32", maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout, stderr) =>
+        resolve({
+          code: err ? 1 : 0,
+          stdout: String(stdout ?? ""),
+          stderr: String(stderr ?? ""),
+        }),
+    );
+  });
+};
+
+let runNpmImpl: NpmRunner = runNpm;
+
+export function setRunNpmForTest(impl: NpmRunner): void {
+  runNpmImpl = impl;
+}
+
 function parseVersion(v: string): number[] {
   return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
 }
 
-function isNewer(latest: string, current: string): boolean {
+export function isNewer(latest: string, current: string): boolean {
   const l = parseVersion(latest);
   const c = parseVersion(current);
   for (let i = 0; i < 3; i++) {
@@ -92,22 +119,77 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
   // version can never be interpreted as a command even if it slipped through.
   if (!SEMVER_RE.test(latest)) return false;
   const extDir = await findExtensionDir();
-  if (!extDir) return false;
+  if (!extDir) {
+    logWarn("update", { event: "install-skip", reason: "extension-dir-not-found" });
+    return false;
+  }
   const npmDir = findNpmRoot(extDir);
-  if (!npmDir) return false;
+  if (!npmDir) {
+    logWarn("update", { event: "install-skip", reason: "not-under-node-modules", extDir });
+    return false;
+  }
 
   try {
-    const code = await new Promise<number>((resolve) => {
-      execFile(
-        "npm",
-        ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
-        { cwd: npmDir, timeout: 60_000, shell: process.platform === "win32" },
-        (err) => resolve(err ? 1 : 0),
-      );
-    });
+    const { code, stderr } = await runNpmImpl(
+      ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
+      { cwd: npmDir, timeout: 60_000 },
+    );
+    if (code !== 0) {
+      logWarn("update", {
+        event: "auto-install-failed",
+        latest,
+        npmDir,
+        stderr: stderr.trim().slice(-2000),
+      });
+    }
     return code === 0;
-  } catch {
+  } catch (e) {
+    logWarn("update", {
+      event: "auto-install-error",
+      latest,
+      error: e instanceof Error ? e.message : String(e),
+    });
     return false;
+  }
+}
+
+async function fetchLatestVersion(): Promise<string | undefined> {
+  // Prefer `npm view`: it honors the user's registry/proxy/auth config (mirrors,
+  // corporate proxies) — the same toolchain as the install step. A direct fetch
+  // to registry.npmjs.org fails on machines that only reach npm via a mirror or
+  // proxy (Node fetch ignores HTTP_PROXY/HTTPS_PROXY).
+  try {
+    const { code, stdout } = await runNpmImpl(["view", PACKAGE_NAME, "version"], {
+      timeout: 20_000,
+    });
+    if (code === 0) {
+      const v = stdout
+        .trim()
+        .split("\n")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .pop();
+      if (v && SEMVER_RE.test(v)) return v;
+    }
+  } catch {
+  }
+  try {
+    const res = await fetch(REGISTRY_URL, {
+      signal: AbortSignal.timeout(10_000),
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      logWarn("update", { event: "check-http", status: res.status });
+      return undefined;
+    }
+    const data = (await res.json()) as { version?: string };
+    return data.version;
+  } catch (e) {
+    logWarn("update", {
+      event: "check-fetch-error",
+      error: e instanceof Error ? e.message : String(e),
+    });
+    return undefined;
   }
 }
 
@@ -135,17 +217,7 @@ export async function checkForUpdate(
     await writeLastCheck(now);
 
     const runtimeVersion = await getRuntimeVersion();
-
-    const res = await fetch(REGISTRY_URL, {
-      signal: AbortSignal.timeout(5000),
-      headers: { Accept: "application/json" },
-    });
-    if (!res.ok) {
-      logWarn("update", { event: "check-http", status: res.status });
-      return;
-    }
-    const data = (await res.json()) as { version?: string };
-    const latest = data.version;
+    const latest = await fetchLatestVersion();
     if (!latest) return;
 
     const current = runtimeVersion ?? CURRENT_VERSION;

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, access } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFile } from "node:child_process";
@@ -50,6 +50,35 @@ export function setRunNpmForTest(impl: NpmRunner): void {
   runNpmImpl = impl;
 }
 
+export type NodeRunner = (
+  args: string[],
+  opts: { timeout: number },
+) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+// Always shell:false: process.execPath is absolute, so no win32 shell quoting
+// hazards. Used to smoke-import a freshly installed extension entry.
+export const runNode: NodeRunner = (args, opts) => {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      args,
+      { ...opts, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout, stderr) =>
+        resolve({
+          code: err ? 1 : 0,
+          stdout: String(stdout ?? ""),
+          stderr: String(stderr ?? ""),
+        }),
+    );
+  });
+};
+
+let runNodeImpl: NodeRunner = runNode;
+
+export function setRunNodeForTest(impl: NodeRunner): void {
+  runNodeImpl = impl;
+}
+
 function parseVersion(v: string): number[] {
   return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
 }
@@ -85,7 +114,10 @@ async function writeLastCheck(timestamp: number): Promise<void> {
 type PackageJson = {
   name?: string;
   version?: string;
+  main?: string;
   dependencies?: Record<string, string>;
+  exports?: Record<string, string | { import?: string }>;
+  pi?: { extensions?: string[] };
 };
 
 async function readPackageJson(path: string): Promise<PackageJson | undefined> {
@@ -118,27 +150,87 @@ async function findExtensionDir(): Promise<string | undefined> {
   }
 }
 
-async function autoInstallLatest(latest: string): Promise<boolean> {
+export type InstallOutcome = "ok" | "failed" | "rolled-back";
+
+// The declared entries pi/loaders may touch: pi's own extension entry, the
+// ESM export, and main. All of them must exist on disk after an install.
+function declaredEntries(pkg: PackageJson): string[] {
+  const dot = pkg.exports?.["."];
+  const exportEntry = typeof dot === "string" ? dot : dot?.import;
+  return [...new Set([pkg.pi?.extensions?.[0], exportEntry, pkg.main])]
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+}
+
+// A bad publish (missing dist, syntax error, ABI break) must never strand the
+// user: npm's exit code 0 only means "tarball extracted", not "extension
+// loads". A broken extension can never load again — and an extension that
+// cannot load can never auto-update itself back to health. That is a permanent
+// brick, so verify before declaring success: files present, version matches,
+// and the entry imports cleanly in a child process.
+export async function verifyInstall(
+  npmDir: string,
+  latest: string,
+): Promise<{ ok: boolean; reason?: string }> {
+  const dir = join(npmDir, "node_modules", PACKAGE_NAME);
+  const pkg = await readPackageJson(join(dir, "package.json"));
+  if (!pkg?.version) return { ok: false, reason: "package-json-missing" };
+  if (pkg.version !== latest) return { ok: false, reason: `version-mismatch:${pkg.version}` };
+  const entries = declaredEntries(pkg);
+  if (entries.length === 0) return { ok: false, reason: "no-entry-declared" };
+  for (const rel of entries) {
+    try {
+      await access(join(dir, rel));
+    } catch {
+      return { ok: false, reason: `entry-missing:${rel}` };
+    }
+  }
+  // Smoke-import the entry pi will actually load. pathToFileURL handles
+  // Windows drive letters (a bare "C:\..." import() is parsed as a protocol).
+  const smokeEntry = pkg.pi?.extensions?.[0] ?? entries[0];
+  if (!smokeEntry) return { ok: false, reason: "no-entry-declared" };
+  const entry = join(dir, smokeEntry);
+  const SMOKE =
+    "const{pathToFileURL}=require('node:url');" +
+    "import(pathToFileURL(process.argv[1]).href).then(()=>{}," +
+    "(e)=>{console.error(e&&e.stack||e);process.exit(1)})";
+  const { code, stderr } = await runNodeImpl(["-e", SMOKE, entry], { timeout: 15_000 });
+  if (code !== 0) return { ok: false, reason: `entry-import-failed:${stderr.trim().slice(-500)}` };
+  return { ok: true };
+}
+
+// extDirOverride exists so tests can point the installer at a fixture layout
+// (the test runner itself is never under node_modules, so the real discovery
+// always bails at "not-under-node-modules" and the install path would be
+// unreachable otherwise).
+export async function autoInstallLatest(latest: string, extDirOverride?: string): Promise<InstallOutcome> {
   // Defense against a poisoned/MITM registry: only accept a strict semver,
   // then pass args as an array to execFile (never via a shell string) so the
   // version can never be interpreted as a command even if it slipped through.
-  if (!SEMVER_RE.test(latest)) return false;
-  const extDir = await findExtensionDir();
+  if (!SEMVER_RE.test(latest)) return "failed";
+  const extDir = extDirOverride ?? (await findExtensionDir());
   if (!extDir) {
     logWarn("update", { event: "install-skip", reason: "extension-dir-not-found" });
-    return false;
+    return "failed";
   }
   const npmDir = findNpmRoot(extDir);
   if (!npmDir) {
     logWarn("update", { event: "install-skip", reason: "not-under-node-modules", extDir });
-    return false;
+    return "failed";
   }
 
   try {
-    const { code, stderr } = await runNpmImpl(
-      ["install", `${PACKAGE_NAME}@${latest}`, "--silent", "--no-audit", "--no-fund"],
-      { cwd: npmDir, timeout: 60_000 },
-    );
+    // --no-save: the host project's package.json/lockfile must never be
+    // mutated by an auto-update; node_modules is what pi loads from anyway.
+    const installArgs = (v: string) => [
+      "install",
+      `${PACKAGE_NAME}@${v}`,
+      "--silent",
+      "--no-audit",
+      "--no-fund",
+      "--no-save",
+    ];
+    const prevVersion = (await readPackageJson(join(extDir, "package.json")))?.version ?? CURRENT_VERSION;
+    const { code, stderr } = await runNpmImpl(installArgs(latest), { cwd: npmDir, timeout: 60_000 });
     if (code !== 0) {
       logWarn("update", {
         event: "auto-install-failed",
@@ -146,15 +238,26 @@ async function autoInstallLatest(latest: string): Promise<boolean> {
         npmDir,
         stderr: stderr.trim().slice(-2000),
       });
+      return "failed";
     }
-    return code === 0;
+    const verify = await verifyInstall(npmDir, latest);
+    if (!verify.ok) {
+      // Roll back to what was running before: a broken latest must not sit on
+      // disk waiting for the next restart to brick the extension.
+      const rollbackTo = SEMVER_RE.test(prevVersion) ? prevVersion : CURRENT_VERSION;
+      logWarn("update", { event: "auto-install-verify-failed", latest, reason: verify.reason, rollbackTo });
+      const rb = await runNpmImpl(installArgs(rollbackTo), { cwd: npmDir, timeout: 60_000 });
+      logInfo("update", { event: "rollback", from: latest, to: rollbackTo, ok: rb.code === 0 });
+      return "rolled-back";
+    }
+    return "ok";
   } catch (e) {
     logWarn("update", {
       event: "auto-install-error",
       latest,
       error: e instanceof Error ? e.message : String(e),
     });
-    return false;
+    return "failed";
   }
 }
 
@@ -235,13 +338,20 @@ export async function checkForUpdate(
     logInfo("update", { event: "check", current, latest, hasUpdate });
 
     if (hasUpdate) {
-      const installed = await autoInstallLatest(latest);
-      if (installed && notify) {
+      const outcome = await autoInstallLatest(latest);
+      if (outcome === "ok" && notify) {
         notify(
           `\x1b[32m\u2714 ACP auto-updated ${current} \u2192 ${latest}. Restart Pi to finish.\x1b[0m`,
         );
         logInfo("update", { event: "auto-installed", from: current, to: latest });
-      } else if (!installed && notify) {
+      } else if (outcome === "rolled-back" && notify) {
+        // Tell the user what happened and DO NOT suggest the manual install
+        // hint — latest is known broken, and following the hint would brick
+        // the extension by hand.
+        notify(
+          `\x1b[33mACP ${latest} failed verification and was rolled back. Keeping ${current}. A later release will auto-update.\x1b[0m`,
+        );
+      } else if (notify) {
         notify(
           `${PACKAGE_NAME} ${latest} available (you have ${current}). Run: pi update --extension npm:${PACKAGE_NAME}`,
         );

--- a/src/update.ts
+++ b/src/update.ts
@@ -12,7 +12,12 @@ const PACKAGE_NAME = "billion-context-pi";
 const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
-const THROTTLE_FILE = join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-context-pi-update-check");
+// Resolved lazily (not at module load) so tests can redirect it via env at any
+// time. Without this, parallel test processes race on the real file under the
+// user's home dir: one process stamps the throttle timestamp while another has
+// just deleted it, making the victim's check skip "npm view" entirely.
+const throttleFile = () =>
+  process.env.ACP_UPDATE_THROTTLE_FILE ?? join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-context-pi-update-check");
 
 // Guards against concurrent checks: the context event fires on every LLM call,
 // so several can race past the throttle read before any writes the timestamp.
@@ -61,7 +66,7 @@ export function isNewer(latest: string, current: string): boolean {
 
 async function readLastCheck(): Promise<number> {
   try {
-    const data = await readFile(THROTTLE_FILE, "utf-8");
+    const data = await readFile(throttleFile(), "utf-8");
     return parseInt(data.trim(), 10) || 0;
   } catch {
     return 0;
@@ -70,8 +75,8 @@ async function readLastCheck(): Promise<number> {
 
 async function writeLastCheck(timestamp: number): Promise<void> {
   try {
-    await mkdir(dirname(THROTTLE_FILE), { recursive: true });
-    await writeFile(THROTTLE_FILE, String(timestamp), "utf-8");
+    await mkdir(dirname(throttleFile()), { recursive: true });
+    await writeFile(throttleFile(), String(timestamp), "utf-8");
   } catch {
     // best-effort
   }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,10 +1,18 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { createAcpExtension } from "../src/index.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import { setRunNpmForTest } from "../src/update.js";
+
+// Headless handlers await the update check — keep every test hermetic by
+// resolving it through this fake (no network, no update available).
+setRunNpmForTest(async (args) => ({ code: 0, stdout: args[0] === "view" ? "0.0.1\n" : "", stderr: "" }));
+
+const UPDATE_THROTTLE_FILE = join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-context-pi-update-check");
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
 // so we can invoke them with a fake ExtensionContext and assert the wiring works.
@@ -756,5 +764,106 @@ test("modelContextLimit changes in .pi/acp.json are picked up on the next contex
     assert.ok((await acpStatus()).includes(formatCompactTokens(250_000)), "rewritten modelContextLimit=250000 hot-reloaded on next context event");
   } finally {
     rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── ISSUE-8: headless hosts must stay alive until the update check finishes ──
+
+type NpmResult = { code: number; stdout: string; stderr: string };
+
+function pendingNpm() {
+  let resolveView: (r: NpmResult) => void;
+  let resolveInstall: (r: NpmResult) => void;
+  let viewCalled = false;
+  const view = new Promise<NpmResult>((r) => (resolveView = r));
+  const install = new Promise<NpmResult>((r) => (resolveInstall = r));
+  setRunNpmForTest(async (args) => {
+    if (args[0] === "view") {
+      viewCalled = true;
+      return view;
+    }
+    return install;
+  });
+  return {
+    viewCalled: () => viewCalled,
+    resolveView,
+    resolveInstall,
+  };
+}
+
+async function waitUntil(fn: () => boolean, ms = 2000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!fn() && Date.now() < deadline) await new Promise((r) => setTimeout(r, 10));
+}
+
+test("headless (hasUI=false) context handler awaits the update check so an exiting process cannot kill an in-flight install", async () => {
+  delete process.env.ACP_AUTO_UPDATE;
+  await rm(UPDATE_THROTTLE_FILE, { force: true });
+  const logFile = join(tmpdir(), `acp-headless-update-${process.pid}.log`);
+  process.env.ACP_LOG_FILE = logFile;
+
+  try {
+    const npm = pendingNpm();
+    const { api, handlers } = captureApi();
+    createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+    const stateFile = "/tmp/nonexistent-pai-acp-headless-update.session.json";
+    await rm(`${stateFile}.acp.json`, { force: true });
+    const ctx = fakeCtx([userMsg("e1", "hi")], stateFile);
+
+    const handlerPromise = handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+    await waitUntil(npm.viewCalled);
+    assert.ok(npm.viewCalled(), "check must reach the npm view step");
+    // The check is in flight (npm view pending). A headless host exits as soon
+    // as this handler settles, so the handler MUST stay pending until then.
+    let settled = false;
+    handlerPromise.then(() => (settled = true));
+    await new Promise((r) => setTimeout(r, 100));
+    assert.equal(settled, false, "handler must not settle while the update check is in flight");
+
+    npm.resolveView({ code: 0, stdout: "99.0.0\n", stderr: "" });
+    const result = await handlerPromise;
+    assert.ok(result, "handler resolves once the check completes");
+    // No node_modules ancestor in the test env → install skips; the log proves
+    // the check ran through the install attempt (headless has no UI to notify).
+    const log = await readFile(logFile, "utf-8");
+    assert.ok(log.includes("event=check") && log.includes("latest=99.0.0") && log.includes("hasUpdate=true"), "the check is logged");
+    assert.ok(log.includes("install-skip"), "the install skip reason is logged");
+  } finally {
+    delete process.env.ACP_LOG_FILE;
+    await rm(logFile, { force: true });
+  }
+});
+
+test("TUI (hasUI=true) context handler resolves without waiting for the update check", async () => {
+  delete process.env.ACP_AUTO_UPDATE;
+  await rm(UPDATE_THROTTLE_FILE, { force: true });
+  const logFile = join(tmpdir(), `acp-tui-update-${process.pid}.log`);
+  process.env.ACP_LOG_FILE = logFile;
+
+  try {
+    const npm = pendingNpm();
+    const { api, handlers } = captureApi();
+    createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+    const stateFile = "/tmp/nonexistent-pai-acp-tui-update.session.json";
+    await rm(`${stateFile}.acp.json`, { force: true });
+    const ctx = { ...fakeCtx([userMsg("e1", "hi")], stateFile), hasUI: true };
+
+    const handlerPromise = handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+    const outcome = await Promise.race([
+      handlerPromise.then(() => "settled"),
+      new Promise<string>((r) => setTimeout(() => r("still-pending"), 500)),
+    ]);
+    assert.equal(outcome, "settled", "TUI handler must resolve while the update check is in flight");
+    // The view promise is still pending here — proves the handler did not wait.
+    await waitUntil(npm.viewCalled);
+    assert.ok(npm.viewCalled(), "check started (npm view pending) while the TUI handler already settled");
+    npm.resolveView({ code: 0, stdout: "0.0.1\n", stderr: "" });
+    for (let i = 0; i < 200; i++) {
+      if ((await readFile(logFile, "utf-8").catch(() => "")).includes("event=check")) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  } finally {
+    delete process.env.ACP_LOG_FILE;
+    await rm(logFile, { force: true });
   }
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -12,7 +12,12 @@ import { setRunNpmForTest } from "../src/update.js";
 // resolving it through this fake (no network, no update available).
 setRunNpmForTest(async (args) => ({ code: 0, stdout: args[0] === "view" ? "0.0.1\n" : "", stderr: "" }));
 
-const UPDATE_THROTTLE_FILE = join(homedir(), CONFIG_DIR_NAME, "agent", ".billion-context-pi-update-check");
+// Never touch the real throttle file under the user's home dir: parallel test
+// processes race on it (one stamps while another just deleted it → the check
+// silently skips "npm view" and the test times out). Per-pid temp file + env
+// override (src/update.ts reads it lazily) keeps this file hermetic.
+const UPDATE_THROTTLE_FILE = join(tmpdir(), `acp-test-update-throttle-${process.pid}`);
+process.env.ACP_UPDATE_THROTTLE_FILE = UPDATE_THROTTLE_FILE;
 
 // Mock Pi's ExtensionAPI — captures the event handlers the factory registers,
 // so we can invoke them with a fake ExtensionContext and assert the wiring works.

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -37,6 +37,10 @@ const THROTTLE = join(
   "agent",
   ".billion-context-pi-update-check",
 );
+// HOME redirection is a no-op on Windows (os.homedir() reads USERPROFILE), so
+// also pin the throttle file via env — src/update.ts resolves it lazily and
+// prefers this over any homedir-derived path.
+process.env.ACP_UPDATE_THROTTLE_FILE = THROTTLE;
 const REPO_VERSION: string = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
 ).version;

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
 import { homedir, tmpdir } from "node:os";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
 import type { NpmRunner } from "../src/update.js";
 
@@ -27,8 +27,11 @@ const {
   checkForUpdate,
   findNpmRoot,
   setRunNpmForTest,
+  setRunNodeForTest,
+  autoInstallLatest,
   isNewer,
   runNpm,
+  runNode,
 } = await import("../src/update.js");
 
 const THROTTLE = join(
@@ -242,4 +245,117 @@ test("findNpmRoot locates the package root when nested under node_modules", () =
 
 test("findNpmRoot terminates when no node_modules ancestor exists (no Windows infinite loop)", { timeout: 2000 }, () => {
   assert.equal(findNpmRoot(homedir()), undefined);
+});
+
+// --- install path (fixture layout; real runner not under node_modules) ---
+
+type Fixture = {
+  root: string;
+  extDir: string;
+  writeInstalled(version: string, opts?: { brokenEntry?: boolean }): void;
+};
+
+function makeFixture(): Fixture {
+  const root = mkdtempSync(join(tmpdir(), "acp-install-test-"));
+  const extDir = join(root, "node_modules", "billion-context-pi");
+  return {
+    root,
+    extDir,
+    writeInstalled(version: string, opts?: { brokenEntry?: boolean }): void {
+      const dist = join(extDir, "dist");
+      mkdirSync(dist, { recursive: true });
+      const body = opts?.brokenEntry
+        ? "export const broken = (!!"
+        : "export const loaded = true;\n";
+      writeFileSync(join(dist, "index.js"), body);
+      writeFileSync(
+        join(extDir, "package.json"),
+        JSON.stringify(
+          {
+            name: "billion-context-pi",
+            version,
+            main: "dist/index.js",
+            exports: { ".": { import: "./dist/index.js" } },
+            pi: { extensions: ["./dist/index.js"] },
+          },
+          null,
+          2,
+        ),
+      );
+    },
+  };
+}
+
+test("autoInstallLatest: clean install verifies (real smoke import) and reports ok", { timeout: 60_000 }, async () => {
+  const fx = makeFixture();
+  fx.writeInstalled("9.9.9");
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  // install succeeded → put the new version on disk, as npm would
+  const impl2: NpmRunner = async (args, opts) => {
+    const res = await impl(args, opts);
+    if (args[0] === "install") fx.writeInstalled("9.9.9");
+    return res;
+  };
+  setRunNpmForTest(impl2);
+  setRunNodeForTest(runNode); // real child process for the smoke import
+  const outcome = await autoInstallLatest("9.9.9", fx.extDir);
+  assert.equal(outcome, "ok");
+  assert.ok(
+    calls.some((c) => c.args.includes("billion-context-pi@9.9.9") && c.args.includes("--no-save")),
+  );
+  rmSync(fx.root, { recursive: true, force: true });
+});
+
+test("autoInstallLatest: syntax-broken entry fails verify → rolls back to previous version", { timeout: 60_000 }, async () => {
+  const fx = makeFixture();
+  fx.writeInstalled("1.2.3"); // previously-installed = rollback target
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  const impl2: NpmRunner = async (args, opts) => {
+    const res = await impl(args, opts);
+    if (args[0] !== "install" || !args[1]) return res;
+    if (args[1].includes("@9.9.9")) {
+      // broken publish: exit 0, but the entry has a syntax error
+      fx.writeInstalled("9.9.9", { brokenEntry: true });
+    } else if (args[1].includes("@1.2.3")) {
+      // rollback: npm puts the working previous version back on disk
+      fx.writeInstalled("1.2.3");
+    }
+    return res;
+  };
+  setRunNpmForTest(impl2);
+  setRunNodeForTest(runNode);
+  const outcome = await autoInstallLatest("9.9.9", fx.extDir);
+  assert.equal(outcome, "rolled-back");
+  const versions = calls.filter((c) => c.args[0] === "install").map((c) => c.args[1]);
+  assert.deepEqual(versions, ["billion-context-pi@9.9.9", "billion-context-pi@1.2.3"]);
+  // and the disk is back to the working previous version
+  const pkg = JSON.parse(readFileSync(join(fx.extDir, "package.json"), "utf-8")) as {
+    version: string;
+  };
+  assert.equal(pkg.version, "1.2.3");
+  rmSync(fx.root, { recursive: true, force: true });
+});
+
+test("autoInstallLatest: npm install failure → failed, no rollback, no verify", { timeout: 30_000 }, async () => {
+  const fx = makeFixture();
+  fx.writeInstalled("1.2.3");
+  let nodeCalls = 0;
+  setRunNpmForTest(makeFakeNpm(
+    { code: 0, stdout: "", stderr: "" },
+    { code: 1, stdout: "", stderr: "E404" },
+  ).impl);
+  setRunNodeForTest(async () => {
+    nodeCalls += 1;
+    return { code: 0, stdout: "", stderr: "" };
+  });
+  const outcome = await autoInstallLatest("9.9.9", fx.extDir);
+  assert.equal(outcome, "failed");
+  assert.equal(nodeCalls, 0);
+  rmSync(fx.root, { recursive: true, force: true });
 });

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -1,41 +1,234 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { join } from "node:path";
-import { homedir } from "node:os";
-import { checkForUpdate, findNpmRoot } from "../src/update.js";
+import { homedir, tmpdir } from "node:os";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import type { NpmRunner } from "../src/update.js";
 
-// Opt-out must short-circuit BEFORE any network/filesystem touch. We assert this
-// by making global fetch throw if it is ever reached.
-function withFetchGuard<T>(fn: () => Promise<T>): Promise<T> {
-  const original = globalThis.fetch;
-  globalThis.fetch = (() => {
-    throw new Error("fetch must not be called when auto-update is disabled");
-  }) as typeof fetch;
+// Redirect HOME before importing src/update: THROTTLE_FILE is a module-level
+// constant derived from homedir(), and we must not touch the real one.
+const REAL_HOME = process.env.HOME ?? "";
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "acp-update-test-"));
+process.env.HOME = FAKE_HOME;
+process.env.ACP_LOG_FILE = join(FAKE_HOME, "acp.log");
+
+// The real-npm tests below need the user's actual HOME (npm resolution may
+// depend on it, e.g. nvm layouts or npm wrapper scripts).
+function withRealHome<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = process.env.HOME;
+  process.env.HOME = REAL_HOME;
   return fn().finally(() => {
-    globalThis.fetch = original;
+    process.env.HOME = prev;
   });
 }
 
-test("checkForUpdate is a no-op when autoUpdate=false (no fetch)", async () => {
+const {
+  checkForUpdate,
+  findNpmRoot,
+  setRunNpmForTest,
+  isNewer,
+  runNpm,
+} = await import("../src/update.js");
+
+const THROTTLE = join(
+  FAKE_HOME,
+  CONFIG_DIR_NAME,
+  "agent",
+  ".billion-context-pi-update-check",
+);
+const REPO_VERSION: string = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+).version;
+
+function resetThrottle(): void {
+  try {
+    rmSync(THROTTLE);
+  } catch {
+  }
+}
+
+function readLog(): string {
+  try {
+    return readFileSync(process.env.ACP_LOG_FILE as string, "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+type NpmResult = { code: number; stdout: string; stderr: string };
+
+function makeFakeNpm(viewResult: NpmResult, installResult: NpmResult) {
+  const calls: { args: string[]; opts: { cwd?: string; timeout: number } }[] = [];
+  const impl: NpmRunner = async (args, opts) => {
+    calls.push({ args, opts });
+    return args[0] === "view" ? viewResult : installResult;
+  };
+  return { impl, calls };
+}
+
+// Opt-out must short-circuit BEFORE any npm/fetch touch.
+function withGuards<T>(fn: () => Promise<T>): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    throw new Error("fetch must not be called when auto-update is disabled");
+  }) as typeof fetch;
+  setRunNpmForTest(async () => {
+    throw new Error("npm must not be called when auto-update is disabled");
+  });
+  return fn().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+test("checkForUpdate is a no-op when autoUpdate=false (no npm, no fetch)", async () => {
   delete process.env.ACP_AUTO_UPDATE;
-  await withFetchGuard(() => checkForUpdate(false));
+  await withGuards(() => checkForUpdate(false));
 });
 
-test("checkForUpdate is a no-op for every opt-out env value, case-insensitive (no fetch)", async () => {
+test("checkForUpdate is a no-op for every opt-out env value, case-insensitive (no npm, no fetch)", async () => {
   const opts = ["0", "false", "no", "off", "FALSE", "No", "Off"];
   for (const v of opts) {
     process.env.ACP_AUTO_UPDATE = v;
-    await withFetchGuard(() => checkForUpdate(true));
+    await withGuards(() => checkForUpdate(true));
   }
   delete process.env.ACP_AUTO_UPDATE;
 });
 
-test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matching (no fetch)", async () => {
+test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matching (no npm, no fetch)", async () => {
   for (const v of [" false ", "\t no\t", "  off "]) {
     process.env.ACP_AUTO_UPDATE = v;
-    await withFetchGuard(() => checkForUpdate(true));
+    await withGuards(() => checkForUpdate(true));
   }
   delete process.env.ACP_AUTO_UPDATE;
+});
+
+test("isNewer compares numeric segments", () => {
+  assert.equal(isNewer("0.1.43", "0.1.41"), true);
+  assert.equal(isNewer("0.1.41", "0.1.43"), false);
+  assert.equal(isNewer("0.1.41", "0.1.41"), false);
+  assert.equal(isNewer("0.2.0", "0.10.0"), false);
+  assert.equal(isNewer("1.0.0", "0.9.9"), true);
+  assert.equal(isNewer("v1.2.3", "1.2.2"), true);
+});
+
+test("runNpm resolves real npm output", { timeout: 30_000 }, (t) => {
+  if (!REAL_HOME) t.skip("HOME not set");
+  return withRealHome(async () => {
+    const r = await runNpm(["--version"], { timeout: 20_000 });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout.trim(), /^\d+\.\d+\.\d+/);
+  });
+});
+
+test("runNpm captures stderr on failure (unreachable registry, no retries)", { timeout: 30_000 }, (t) => {
+  if (!REAL_HOME) t.skip("HOME not set");
+  return withRealHome(async () => {
+    const r = await runNpm(
+      ["view", "billion-context-pi", "--registry", "http://127.0.0.1:9/", "--fetch-retries=0"],
+      { timeout: 20_000 },
+    );
+    assert.equal(r.code, 1);
+    assert.ok(r.stderr.length > 0);
+  });
+});
+
+test("checkForUpdate queries npm view first with exact args", async () => {
+  resetThrottle();
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "0.0.1\n", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  setRunNpmForTest(impl);
+  const notes: string[] = [];
+  await checkForUpdate(true, (m) => notes.push(m));
+  assert.equal(notes.length, 0);
+  assert.deepEqual(calls[0].args, ["view", "billion-context-pi", "version"]);
+  assert.ok(calls[0].opts.timeout > 0);
+  assert.match(readLog(), new RegExp(`event=check current=${REPO_VERSION} latest=0\\.0\\.1 hasUpdate=false`));
+});
+
+test("checkForUpdate: update available but not under node_modules → manual hint + install-skip logged", async () => {
+  resetThrottle();
+  const { impl } = makeFakeNpm(
+    { code: 0, stdout: "99.0.0\n", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  setRunNpmForTest(impl);
+  const notes: string[] = [];
+  await checkForUpdate(true, (m) => notes.push(m));
+  assert.equal(notes.length, 1);
+  assert.match(notes[0], new RegExp(`billion-context-pi 99\\.0\\.0 available \\(you have ${REPO_VERSION}\\)`));
+  assert.match(notes[0], /Run: pi update --extension npm:billion-context-pi/);
+  assert.match(readLog(), /event=install-skip reason=not-under-node-modules/);
+});
+
+test("checkForUpdate: npm view fails → falls back to registry fetch", async () => {
+  resetThrottle();
+  setRunNpmForTest(async () => ({ code: 1, stdout: "", stderr: "npm error ENOENT" }));
+  const fetchCalls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (url: string | URL | Request) => {
+    fetchCalls.push(String(url));
+    return new Response(JSON.stringify({ version: "88.0.0" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  const notes: string[] = [];
+  try {
+    await checkForUpdate(true, (m) => notes.push(m));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(fetchCalls.length, 1);
+  assert.match(fetchCalls[0], /registry\.npmjs\.org\/billion-context-pi\/latest/);
+  assert.equal(notes.length, 1);
+  assert.match(notes[0], /88\.0\.0 available/);
+});
+
+test("checkForUpdate: npm view fails and fetch throws → no notify, check-fetch-error logged", async () => {
+  resetThrottle();
+  setRunNpmForTest(async () => ({ code: 1, stdout: "", stderr: "" }));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (() => {
+    throw new Error("network down");
+  }) as typeof fetch;
+  const notes: string[] = [];
+  try {
+    await checkForUpdate(true, (m) => notes.push(m));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(notes.length, 0);
+  assert.match(readLog(), /event=check-fetch-error/);
+});
+
+test("checkForUpdate: npm view fails and fetch non-OK → no notify, check-http logged", async () => {
+  resetThrottle();
+  setRunNpmForTest(async () => ({ code: 1, stdout: "", stderr: "" }));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response("{}", { status: 503 })) as typeof fetch;
+  const notes: string[] = [];
+  try {
+    await checkForUpdate(true, (m) => notes.push(m));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(notes.length, 0);
+  assert.match(readLog(), /event=check-http status=503/);
+});
+
+test("checkForUpdate: second call within the 3-minute window is throttled", async () => {
+  resetThrottle();
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "99.0.0\n", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  setRunNpmForTest(impl);
+  await checkForUpdate(true);
+  await checkForUpdate(true);
+  assert.equal(calls.length, 1);
 });
 
 test("findNpmRoot locates the package root when nested under node_modules", () => {


### PR DESCRIPTION
## 背景

issue dog/billion-context-pi#8：部分机器上自动更新静默失效。

根因：版本检查直接 fetch `https://registry.npmjs.org/billion-context-pi/latest`（5s 超时，不走 npm 配置）。Node 全局 fetch 不认 `HTTP_PROXY`/`HTTPS_PROXY`，走国内镜像（npmmirror）或企业代理的机器直连 npmjs 超时/失败 → **检测不到新版本**。另外安装失败完全静默（仅 TUI 提示、无日志），无法排查。

## 改动

- **版本检查改走 `npm view billion-context-pi version` 优先**（20s 超时）：尊重本机 registry/proxy/auth 配置，与安装步同一工具链——npm 能装，检查就能通。npm 不可用时回退直接 registry fetch（超时 5s→10s）。
- **安装失败写日志**：`event=auto-install-failed`（含 npm stderr 尾部 2000 字符）；跳过时 `event=install-skip`（含 reason：`extension-dir-not-found` / `not-under-node-modules`）；fetch 回退失败 `event=check-fetch-error`。
- 新增 `runNpm` execFile 封装（捕获 stdout/stderr，maxBuffer 4MB，win32 shell）+ `setRunNpmForTest` 测试 seam；导出 `isNewer`。
- 安全不变：`npm install` 仍为参数数组（不拼 shell 字符串），版本号仍过 SEMVER_RE 白名单。

## 测试

- `tests/update.test.ts` 重写：14 个测试（opt-out 双守卫短路、isNewer 数值比较、runNpm 真实 npm 成功/stderr 捕获、checkForUpdate 全路径：npm view 参数 / install-skip / fetch 回退 / 双失败 / non-OK / 节流）
- 全套 393 测试通过；typecheck + build 通过

## 验证（受影响机器排查命令）

```sh
grep '\[update\]' ~/.pi/acp.log | tail -20
```

修复后日志可区分：`check-fetch-error`（网络）/ `auto-install-failed`（含 npm 报错）/ `install-skip`（安装位置问题）。