### PR TITLE
chore(release): v0.1.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.43",
+	"version": "0.1.44",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.43",
+			"version": "0.1.44",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.43",
+	"version": "0.1.44",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## What's in 0.1.44

Ships PR #185 (update-check robustness + anti-brick):

- **fix(update): check latest via `npm view`** (e4c4a10) — version check no longer silently fails on machines that can't reach npmjs directly; npm registry query first, fetch fallback, install failures logged
- **fix(update): await update check in headless mode** (1b1d555) — process exit can no longer kill an in-flight npm install
- **test: isolate update-check throttle file** (a3782f2) — parallel test processes no longer fight over the throttle stamp (this was the Windows CI flake)
- **fix(update): verify installs and roll back broken publishes (anti-brick)** (88e1f71) — after install: version + entry checks + real smoke-import; on failure auto-rollback to previous version; `--no-save` never mutates host lockfile. A broken npm publish can no longer brick the extension permanently

Also includes everything already in master since 0.1.43 (#183 subagent detection, #184).

## After merge

```
git tag v0.1.44 && git push origin v0.1.44
npm publish
```