### PR TITLE
release v0.1.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.44",
+	"version": "0.1.45",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.44",
+			"version": "0.1.45",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.44",
+	"version": "0.1.45",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.45 — 自动更新修复（issue #8）。

包含 PR #185 的全部更新修复：
- 版本检查走 `npm view` 优先（尊重本机 registry/proxy），fetch 回退
- 安装失败/跳过写日志（`auto-install-failed` 含 npm stderr / `install-skip` 含原因）
- headless 模式 await 更新检查，进程退出不再杀掉进行中的安装
- 安装后验证（version/入口/smoke-import），坏发布自动回滚（anti-brick）

**为什么是 0.1.45 而不是 0.1.44**：v0.1.44 的 release 分支名为 `2026-08-21_release-0.1.44`，不符合 `release.yml` 检查要求的 `YYYY-MM-DD_release-v{VERSION}` 格式（缺 `v`），CI 判定非 release 合并，**publish 步骤被静默跳过**——master 已是 0.1.44 但 npm 仍是 0.1.43。本分支按规范命名 `2026-08-21_release-v0.1.45`，合并后 CI 将发布 0.1.45 并打 tag。

验证：typecheck 通过，409/409 测试通过，build 成功。

---

**Also in this release — acp-kernel 0.0.30 → 0.0.32** (#191, merged after this branch was cut):
- `KEEP_LAST_ORPHANED` 0 → 2 (kernel #104, reverts #18): the newest two orphaned compress call+result pairs stay visible in the sent view.
- Restores compress-failure observability and removes the fixed-point precondition behind the infinite no-op compress loop (issue #9) — the root cause that #190's tool-side circuit breaker worked around (now closed as redundant).
- This branch is BEHIND master but MERGEABLE: the 3-way merge keeps master's acp-kernel 0.0.32 (this branch only bumps the version), so the release ships 0.0.32. tsup inlines the kernel into dist.
