### PR TITLE
fix(ci): tolerate missing 'v' in release branch name, warn on near-miss

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,18 @@ jobs:
         run: |
           COMMIT_MSG=$(git log -1 --pretty=%B)
           MERGE_BRANCH=$(echo "$COMMIT_MSG" | sed -n 's/^Merge pull request #[0-9]* from [^/]*\/\(.*\)$/\1/p' || echo "")
-          if echo "$MERGE_BRANCH" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+          # Accept both `YYYY-MM-DD_release-vX.Y.Z` (documented) and the
+          # common `YYYY-MM-DD_release-X.Y.Z` variant (missing `v`).
+          if echo "$MERGE_BRANCH" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-(v)?[0-9]'; then
             echo "is_release=true" >> $GITHUB_OUTPUT
-          elif echo "$COMMIT_MSG" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-v'; then
+          elif echo "$COMMIT_MSG" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}_release-(v)?[0-9]'; then
             echo "is_release=true" >> $GITHUB_OUTPUT
           else
+            # A release-looking branch that does not match must not skip the
+            # publish silently (that is how v0.1.44 was lost on 2026-08-21).
+            if echo "$MERGE_BRANCH" | grep -qi 'release'; then
+              echo "::warning::Merge from release-looking branch '$MERGE_BRANCH' does not match the release pattern; publish skipped. Rename to YYYY-MM-DD_release-vX.Y.Z and re-merge."
+            fi
             echo "is_release=false" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## 背景

v0.1.44 发布事故（2026-08-21）：release 分支命名为 `2026-08-21_release-0.1.44`（漏了 `v`），`release.yml` 的检查正则要求 `release-v`，判定非 release 合并 → **所有 publish 步骤被静默跳过，workflow 仍显示 success**。master 停在 0.1.44，npm 停在 0.1.43，无人察觉。

## 改动（`.github/workflows/release.yml` 的 check 步骤）

1. 正则 `release-v` → `release-(v)?[0-9]`：同时接受 `YYYY-MM-DD_release-vX.Y.Z`（文档规范）和 `YYYY-MM-DD_release-X.Y.Z`（常见笔误变体）。
2. 近失保护：分支名含 `release` 但不匹配版本模式时，输出 `::warning::`（CI 日志醒目可见），提示改名重发——不再静默。

## 验证

- YAML 解析通过
- 正则模拟：`release-v0.1.45` ✓ / `release-0.1.44` ✓ / `fix-something` → not-release / `release-notes-docs` → not-release + warning