### PR TITLE
chore(deps): bump acp-kernel 0.0.30 -> 0.0.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.30",
+				"acp-kernel": "0.0.32",
 				"billion-context-kit": "0.2.0",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
@@ -3186,9 +3186,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.30.tgz",
-			"integrity": "sha512-eE9F7sDHxbylQnRG9CIRxObKwNWKnEbPdpc9YjWaY8nqalMIc0w+RcMg9kDoNfpjOhMYaYGykAffk0QC1N+CJA==",
+			"version": "0.0.32",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
+			"integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.30",
+		"acp-kernel": "0.0.32",
 		"billion-context-kit": "0.2.0",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",


### PR DESCRIPTION
Bumps acp-kernel 0.0.30 -> 0.0.32 (tsup inlines the kernel into dist, so this is the only way users get it).

## 0.0.32 — compress failure observability (kernel #104, reverts #18)

- `KEEP_LAST_ORPHANED` 0 → 2: the newest two orphaned compress call+result pairs stay visible in the sent view instead of being hidden.
- Restores failure observability and removes the fixed-point precondition behind the infinite no-op compress loop (issue #9): with failed calls visible again, the sent view changes on every retry, so a deterministic model can no longer sit pinned at an unobservable fixed point.
- Residue stays bounded at 2 pairs in all pipeline paths (bounding test added upstream); #18's unbounded accumulation does not return.

## Verification

- lockfile pins acp-kernel 0.0.32 (single deduped copy; `overrides` keeps `billion-context-kit` on the same version)
- typecheck clean, **409/409 tests pass**, build OK (dist/index.js 493 KB)
- dist/index.js contains `KEEP_LAST_ORPHANED = 2`

## Notes

- Open PR #190 (tool-side circuit breaker for issue #9) addresses the same fixed-point loop as a workaround. With 0.0.32 fixing the root cause upstream, #190 may become redundant — left open for a separate decision.
