### PR TITLE
feat: salvage malformed compress content strings (omp#121)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.32",
+				"acp-kernel": "file:../acp-kernel/acp-kernel-0.0.33.tgz",
 				"billion-context-kit": "0.2.0",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
@@ -3186,9 +3186,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
-			"integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
+			"version": "0.0.33",
+			"resolved": "file:../acp-kernel/acp-kernel-0.0.33.tgz",
+			"integrity": "sha512-zTuOCINsAGhR58gVrniKyTeFdL77Jj1ZmMC91iUZLr0puFmuhAEpau/LT2yXYubU8/20owdijO0DFH1f4QkV8w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.32",
+		"acp-kernel": "file:../acp-kernel/acp-kernel-0.0.33.tgz",
 		"billion-context-kit": "0.2.0",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -7,7 +7,7 @@ import type {
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
-import { defaultCountTokens, type CompressionBlock } from "acp-kernel";
+import { defaultCountTokens, salvageParseRanges, type CompressionBlock } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 
 function formatK(n: number): string {
@@ -78,6 +78,20 @@ function normalizeRanges(content: CompressArgs["content"]): RangeEntry[] | strin
     try {
       ranges = JSON.parse(ranges);
     } catch (e) {
+      // Weak/local models emit truncated or malformed JSON here ~50% of the
+      // time (see billion-context-omp#121). Before giving up, run the kernel's
+      // salvage ladder (fences / comma+newline repairs / truncated-array
+      // prefix / field-regex). Recovered entries proceed as normal ranges.
+      const sal = salvageParseRanges(ranges as string);
+      logWarn("compress", {
+        event: "content-salvage",
+        layer: sal.layer,
+        note: sal.note,
+        ranges: sal.ranges.length,
+      });
+      if (sal.ranges.length > 0) {
+        return sal.ranges.map((r) => ({ startId: r.startRef, endId: r.endRef, summary: r.summary, ...(r.topic ? { topic: r.topic } : {}) })) as RangeEntry[];
+      }
       return `Invalid content: not valid JSON (${e instanceof Error ? e.message : String(e)}). content must be an ARRAY of {startId, endId, summary} objects — pass the array directly, not a string.`;
     }
   }

--- a/tests/compress-retry.test.ts
+++ b/tests/compress-retry.test.ts
@@ -175,6 +175,26 @@ test("compress tool accepts JSON-encoded string content (non-strict-tool provide
   await rm(`${stateFile}.acp.json`, { force: true });
 });
 
+test("compress tool SALVAGES truncated JSON string content (omp#121)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-salvage.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const entries = [userMsg("e1", ZH)];
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx); // assigns refs
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  // truncated mid-second-entry: strict parse fails, the first complete entry
+  // must be salvaged by the kernel ladder instead of throwing
+  const truncated =
+    '[{"startId":"m00001","endId":"m00001","summary":"first entry fully intact and salvageable"},{"startId":"m0';
+  const out = await compressTool.execute("tc1", { content: truncated }, undefined, undefined, ctx);
+  const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  assert.ok(/ACP \|/.test(text), `expected success panel: ${text}`);
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
 test("compress tool THROWS on garbage string content (isError:true → retry nudge fires)", async () => {
   const { api, handlers } = captureApi();
   createAcpExtension({ modelContextLimit: 200_000 })(api as any);


### PR DESCRIPTION
## Why

Weak/local models (vLLM qwen etc.) emit compress tool arguments that fail strict JSON.parse ~50% of the time — truncated output caps, raw newlines inside summary strings, trailing commas, or plain prose (see billion-context-omp#121). The ACP host extension's `normalizeRanges` threw `Invalid content: not valid JSON` on the first strict-parse failure and relied entirely on the retry nudge — but weak models fail the *retry* the same way ~50% of the time, so compress became effectively unusable with local models.

## What

Before throwing, run the kernel's `salvageParseRanges` ladder (fences / comma+newline repairs / truncated-array prefix / field-regex): recoverable entries proceed as normal ranges (logWarn records the layer); truly unparseable input still throws, so the `isError:true` → retry-nudge contract is unchanged.

Bumps acp-kernel to ^0.0.34 (introduces `salvageParseRanges` + `extractRanges` double-encode normalization).

## Tests

New truncated-content salvage case in `tests/compress-retry.test.ts` (first complete entry recovered from a blob truncated mid-second-entry). Full suite 410/410, typecheck clean.

Companion PRs: acp-kernel#109 (parser), billion-context (proxy), billion-context-omp (replay).

--- DEPENDENCY NOTE (pre-publish) ---
> ⚠️ **Do not merge yet**: `package.json` currently pins `acp-kernel` to a local `file:` tarball so the diff is reviewable now. Depends on acp-kernel PR #109 landing and npm publish of **0.0.34** (0.0.33's publish failed with npm 404 — expired NPM_TOKEN). Before merge this PR will be updated to `"acp-kernel": "^0.0.34"` from from the registry and the full suite re-run.
