### PR TITLE
chore: acp-kernel 0.0.36, drop billion-context-kit (absorbed into kernel)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.32",
-				"billion-context-kit": "0.2.0",
+				"acp-kernel": "0.0.36",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3186,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.32",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.32.tgz",
-			"integrity": "sha512-iOJPF+X6NMGkpGsAbxHV0Fcvymzf9a0c5Mf/z3padNVgPgMNxwG1snxYravVccRePgHOzWgpNYikqtpGYhiInA==",
+			"version": "0.0.36",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.36.tgz",
+			"integrity": "sha512-w3lyfah74H35HHBzmw/jwLVixPRfC1K7wbFjKrwoV1qdw5847kjzNxiJ3i6upEY3YPJI517A5FyPhne0vbvSVg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3201,19 +3200,6 @@
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/billion-context-kit": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/billion-context-kit/-/billion-context-kit-0.2.0.tgz",
-			"integrity": "sha512-KBO8MYaOBNcdp3cU5h2Z0f3OsJrGf0+OBqbeJHt5yKXPU7cngRhlUInMbWC7cw6AdIcvurs7u8U1esMijizhdQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acp-kernel": "0.0.23"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/bundle-require": {
 			"version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -60,15 +60,9 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.32",
-		"billion-context-kit": "0.2.0",
+		"acp-kernel": "0.0.36",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"
-	},
-	"overrides": {
-		"billion-context-kit": {
-			"acp-kernel": "$acp-kernel"
-		}
 	}
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,7 @@ import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 import { collectCoveredMessageIds, estimateTokens, calibrateTokens } from "./tokens.js";
-import { buildStatusPanel } from "billion-context-kit";
+import { buildStatusPanel } from "acp-kernel/panel";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { ensureSubagentAcpTools } from "./setup-subagent-tools.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type {
   SessionMessageEntry,
 } from "@earendil-works/pi-coding-agent";
 import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-kernel";
-import { renderNudgeText, resolvePrompts, defaultPrompts } from "acp-kernel";
+import { renderNudgeText, resolvePrompts, defaultPrompts, viableRanges } from "acp-kernel";
 import { type AdapterConfig, resolveDelegate } from "./config.js";
 import { createRuntime, type AcpRuntime, MAX_COMPRESS_ATTEMPTS } from "./runtime.js";
 import { makeCompressTool, isCompressSuccessText, isCompressNoopText } from "./compress-tool.js";
@@ -15,7 +15,6 @@ import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages, extractText } from "./messages.js";
-import { viableRanges } from "billion-context-kit";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
@@ -311,7 +310,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const emergency = turn.nudge.breakdown?.emergencyOverride === 1;
       // Recommend only ranges the model can actually compress: a tiny
       // fragmented range in the list makes batched attempts fail atomically
-      // (kernel validates the whole batch). See viableRanges in billion-context-kit.
+      // (kernel validates the whole batch). See viableRanges in acp-kernel.
       turn.nudge.compressibleRanges = viableRanges(turn.nudge.compressibleRanges);
       // Retry-cap circuit breaker (issue #6): emergency nudges re-inject on
       // every LLM call, so a model answering each one with a failed/no-op

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -1,10 +1,9 @@
 import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
-import { buildStatusReport, defaultCountTokens, formatRanges } from "acp-kernel";
+import { buildStatusReport, defaultCountTokens, formatRanges, viableRanges } from "acp-kernel";
 import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
 import { getSystemPromptText } from "./compat.js";
-import { viableRanges } from "billion-context-kit";
 import { logThrow } from "./log.js";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { resolveDelegate } from "./config.js";

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -735,7 +735,7 @@ test("modelContextLimit changes in .pi/acp.json are picked up on the next contex
   const { mkdtempSync, writeFileSync, rmSync, mkdirSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const { join } = await import("node:path");
-  const { formatCompactTokens } = await import("billion-context-kit");
+  const { formatCompactTokens } = await import("acp-kernel/panel");
 
   const tmp = mkdtempSync(join(tmpdir(), "acp-hotreload-"));
   const piDir = join(tmp, ".pi");

--- a/tests/viable-ranges.test.ts
+++ b/tests/viable-ranges.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "billion-context-kit";
+import { VIABLE_RANGE_MIN_TOKENS, viableRanges } from "acp-kernel";
 import { buildStatusReport, createCore, createInitialState } from "acp-kernel";
 import { resolveConfig } from "../src/config.js";
 


### PR DESCRIPTION
Follow-up to acp-kernel#116/#117 (kit absorbed, v0.0.36 released).

- acp-kernel 0.0.32 → 0.0.36
- billion-context-kit removed: viableRanges → acp-kernel root; buildStatusPanel/formatCompactTokens/topicFallback → acp-kernel/panel
- npm overrides block for kit's nested acp-kernel no longer needed (kit gone)

Test plan: npm test all pass; tsc --noEmit clean.