### PR TITLE
release v0.1.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.45",
+			"version": "0.1.46",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.36",
+				"acp-kernel": "0.0.40",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.39.tgz",
-			"integrity": "sha512-Q2nXtEfJ+ai16IssZ0pHTVD3L/BCGnxTrMBINnCEviV6zkkrbalKuKaJ/NogKkJJs6dYlpnYeoY0UWT+f4A2zw==",
+			"version": "0.0.40",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.40.tgz",
+			"integrity": "sha512-ofKAhtGsQ/aD3Na2lUxg6Xc/P9k8ie8dXKZyEWkHpVd5/37E8+WlcpWqJypOohP5LrSsFVZaPRqVC/5NOdJfgA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.45",
+	"version": "0.1.46",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.36",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.36.tgz",
-			"integrity": "sha512-w3lyfah74H35HHBzmw/jwLVixPRfC1K7wbFjKrwoV1qdw5847kjzNxiJ3i6upEY3YPJI517A5FyPhne0vbvSVg==",
+			"version": "0.0.39",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.39.tgz",
+			"integrity": "sha512-Q2nXtEfJ+ai16IssZ0pHTVD3L/BCGnxTrMBINnCEviV6zkkrbalKuKaJ/NogKkJJs6dYlpnYeoY0UWT+f4A2zw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.39",
+		"acp-kernel": "0.0.40",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.45",
+	"version": "0.1.46",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.36",
+		"acp-kernel": "0.0.39",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Dual bump: billion-context-pi 0.1.45 → 0.1.46, acp-kernel 0.0.36 → 0.0.38 (the #195 promote-after-prune fix — see acp-kernel PR #122).

Validated locally against the acp-kernel v0.0.38 build (dist overlaid into node_modules): typecheck clean, all tests pass, tsup build OK.

⚠️ **CI will fail at `npm ci` until acp-kernel 0.0.38 is published** (lockfile integrity still carries the 0.0.36 hash). Merge order: acp-kernel PR #122 first → once `npm view acp-kernel version` = 0.0.38, run `npm install && git commit --amend --no-edit && git push -f` on this branch (or ask the bot to do it), then merge.