### PR TITLE
fix: count image tokens in sent-view estimate

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,7 @@ import type { ExtensionCommandContext, RegisteredCommand, SessionEntry } from "@
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
-import { collectCoveredMessageIds, estimateTokens, calibrateTokens } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, calibrateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
 import { buildStatusPanel } from "acp-kernel/panel";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { ensureSubagentAcpTools } from "./setup-subagent-tools.js";
@@ -128,10 +128,12 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   // EMERGENCY at 204%). The tree-scale number stays in the log only.
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-  const sessionTokens = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n"));
+  const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
+  const imageTokensTotal = [...imageTokens.values()].reduce((a, b) => a + b, 0);
+  const sessionTokens = realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n")) + imageTokensTotal;
   const coveredIds = collectCoveredMessageIds(state);
   const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
-  const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
+  const sentTokens = estimateTokens(coreMessages, coveredIds, imageTokens) + systemPromptTokens;
   const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount: calibrateTokens(sentTokens, runtime.density.densityFor(modelId)) });
 
   // Shared kit surface renders the panel (dual accounting, viability
@@ -147,7 +149,7 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
     state: turn.state,
     nudge: turn.nudge,
     modelContextLimit: config.modelContextLimit,
-    unprunedTokens: coreMessages.reduce((sum, m) => sum + defaultCountTokens(m.text ?? ""), 0),
+    unprunedTokens: coreMessages.reduce((sum, m) => sum + defaultCountTokens(m.text ?? "") + (imageTokens.get(m.id) ?? 0), 0),
     cacheUsages: cacheUsageSamples(entries ?? []),
   });
 

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -6,7 +6,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
-import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, calibrateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
 import { defaultCountTokens, parseCompressArgs, type CompressionBlock, type CompressParseDiagnostics } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 
@@ -146,14 +146,15 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   if (typeof maybeRanges === "string") throw new Error(maybeRanges);
   const ranges = maybeRanges;
   if (ranges.length === 0) return "No ranges provided.";
-  const { state: initialState, coreMessages } = await runtime.stateFor(ctx);
+  const { state: initialState, coreMessages, entries } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
   // Sent-view arbitration — the same scale as the context transform and
   // acp_status (see src/index.ts): never the session-tree tokenCount.
   const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-  const sentTokens = estimateTokens(coreMessages, collectCoveredMessageIds(initialState)) + systemPromptTokens;
+  const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
+  const sentTokens = estimateTokens(coreMessages, collectCoveredMessageIds(initialState), imageTokens) + systemPromptTokens;
   const turn = runtime.core.processTurn({
     messages: coreMessages,
     state: initialState,
@@ -166,7 +167,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   // the same scale as the kernel's injected countTokens (which already carries
   // density), so the numbers the model sees match real usage.
   const density = runtime.density.densityFor(modelId);
-  const beforeTokens = calibrateTokens(estimateTokens(messages, collectCoveredMessageIds(state)), density);
+  const beforeTokens = calibrateTokens(estimateTokens(messages, collectCoveredMessageIds(state), imageTokens), density);
   const summaryMaxChars = args.summaryMaxChars;
   const topLevelTopic = args.topic;
 
@@ -215,7 +216,7 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     config,
     tokenCount: calibrateTokens(sentTokens, density),
   });
-  const afterTokens = calibrateTokens(estimateTokens(afterTurn.messages, collectCoveredMessageIds(applied.state)), density);
+  const afterTokens = calibrateTokens(estimateTokens(afterTurn.messages, collectCoveredMessageIds(applied.state), imageTokens), density);
   const reclaimed = Math.max(0, beforeTokens - afterTokens);
 
   const newBlocks = applied.state.blocks.slice(-blocksCreated);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
-import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
 import { checkForUpdate } from "./update.js";
 import {
   THROTTLE_RETRY_ERROR_MESSAGE,
@@ -190,7 +190,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const realUsage = ctx.getContextUsage?.();
       const systemPromptText = getSystemPromptText(ctx);
       const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-      const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
+      const sentTokens = estimateTokens(coreMessages, coveredIds, collectImageTokens(entries, modelSupportsImages(ctx.model))) + systemPromptTokens;
       // Usage/emergency arbitration on the CALIBRATED sent view: density is
       // the provider-anchored real/estimate ratio learned by the estimator
       // (docs/token-calibration-plan.md §3.2). Raw CJK-aware estimates

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -118,6 +118,16 @@ export function extractText(content: unknown): string {
 function stripRefTag(text: string): string {
   return text.replace(REF_TAG, "").replace(TRAILING_REF_TAG, "");
 }
+
+export function countImageBlocks(content: unknown): number {
+  if (!Array.isArray(content)) return 0;
+  let n = 0;
+  for (const block of content) {
+    const b = block as { type?: string };
+    if (b?.type === "image") n++;
+  }
+  return n;
+}
 export function messageIdentity(message: unknown): string {
   return JSON.stringify(normalizeIdentityValue(message, true));
 }

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens, formatRanges, viableRanges } from "acp-kernel";
-import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, calibrateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
 import { getSystemPromptText } from "./compat.js";
 import { logThrow } from "./log.js";
 import { getDelegateUsage } from "./delegate-tool.js";
@@ -45,7 +45,7 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
 }
 
 async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: ExtensionContext): Promise<string> {
-  const { state, coreMessages } = await runtime.stateFor(ctx);
+  const { state, coreMessages, entries } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
   // Run the same pipeline (assign-refs → prune → hide-compress-calls → ...) that
   // the context transform runs, so what acp_status reports matches what the
@@ -59,7 +59,7 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   const modelId = (ctx.model as { id?: string } | undefined)?.id ?? "default";
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-  const sentTokens = estimateTokens(coreMessages, coveredIds) + systemPromptTokens;
+  const sentTokens = estimateTokens(coreMessages, coveredIds, collectImageTokens(entries, modelSupportsImages(ctx.model))) + systemPromptTokens;
   const turn = runtime.core.processTurn({
     messages: coreMessages,
     state,

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,8 @@
 import { defaultCountTokens, type CoreMessage } from "acp-kernel";
+import type { SessionMessageEntry } from "@earendil-works/pi-coding-agent";
+import { countImageBlocks } from "./messages.js";
+
+type AgentMessage = SessionMessageEntry["message"];
 
 export function collectCoveredMessageIds(state: { blocks: { active: boolean; effectiveMessageIds: string[] }[] }): Set<string> {
   const ids = new Set<string>();
@@ -9,12 +13,35 @@ export function collectCoveredMessageIds(state: { blocks: { active: boolean; eff
   return ids;
 }
 
-export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>): number {
+// ~Anthropic screenshot cost; real per-model cost (85..2.8K) converges via density calibration.
+export const IMAGE_TOKEN_COST = 1600;
+
+// pi-ai silently drops image blocks for non-vision models, so they cost nothing there.
+export function modelSupportsImages(model: unknown): boolean {
+  const input = (model as { input?: string[] } | null | undefined)?.input;
+  return Array.isArray(input) && input.includes("image");
+}
+
+// Keyed by entry id — the core id of user/toolResult messages (assistant tool-call cores split as `${id}#callId` and never carry images).
+export function collectImageTokens(entries: { id: string; type?: string; message?: AgentMessage }[], visionCapable: boolean): Map<string, number> {
+  const out = new Map<string, number>();
+  if (!visionCapable) return out;
+  for (const e of entries) {
+    if (e.type !== "message") continue;
+    const n = countImageBlocks((e.message as { content?: unknown } | undefined)?.content);
+    if (n > 0) out.set(e.id, n * IMAGE_TOKEN_COST);
+  }
+  return out;
+}
+
+export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>, imageTokensById?: Map<string, number>): number {
   let tokens = 0;
   for (const m of messages) {
     if (m.toolName === "compress") continue;
     if (coveredIds?.has(m.id)) continue;
     tokens += defaultCountTokens(m.text ?? "");
+    const img = imageTokensById?.get(m.id);
+    if (img) tokens += img;
   }
   return tokens;
 }

--- a/tests/image-tokens.test.ts
+++ b/tests/image-tokens.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
 import { estimateTokens, collectImageTokens, modelSupportsImages, IMAGE_TOKEN_COST } from "../src/tokens.js";
 import { countImageBlocks } from "../src/messages.js";
@@ -105,16 +105,62 @@ test("estimateTokens adds image tokens and skips covered ids", () => {
   assert.equal(estimateTokens(msgs, new Set(["m1"]), imageTokens), 4);
 });
 
-test("images count toward sent-view arbitration (vision model)", async () => {
-  await rm(`${STATE_FILE}.acp.json`, { force: true });
+const lastTurnLine = async (logFile: string) => {
+  const lines = (await readFile(logFile, "utf8")).split("\n").filter((l) => l.includes("[turn]"));
+  return lines[lines.length - 1] ?? "";
+};
+
+test("sent-view token count includes image tokens (vision model)", async () => {
+  const logFile = `${STATE_FILE}.vision.log`;
+  await rm(logFile, { force: true });
+  process.env.ACP_LOG_FILE = logFile;
   const { api, handlers } = captureApi();
   createAcpExtension({ modelContextLimit: 10_000 })(api as any);
   const entries = Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`));
   const ctx = ctxWithModel(entries, 10_000, ["text", "image"]);
+  await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // 8 × 1600 = 12800 → 128% of the 10K window, despite empty visible text.
+  assert.match(await lastTurnLine(logFile), /tokens=12800 pct=128 limit=10000/, "image tokens must land in the sent-view estimate");
+  await rm(logFile, { force: true });
+});
+
+test("sent-view token count ignores images for non-vision models", async () => {
+  const logFile = `${STATE_FILE}.novision.log`;
+  await rm(logFile, { force: true });
+  process.env.ACP_LOG_FILE = logFile;
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const entries = Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`));
+  const ctx = ctxWithModel(entries, 10_000, ["text"]);
+  await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // pi-ai silently drops image blocks for non-vision models — counting them
+  // would fabricate 12.8K of phantom usage.
+  const m = (await lastTurnLine(logFile)).match(/tokens=(\d+)/);
+  assert.ok(m, "[turn] line present");
+  assert.ok(Number(m[1]) < 1000, `non-vision model must not count image tokens, got ${m[1]}`);
+  await rm(logFile, { force: true });
+});
+
+test("emergency nudge fires when images push the sent view past the window", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const filler = "lorem ".repeat(300);
+  const entries = [
+    ...Array.from({ length: 30 }, (_, i) => ({
+      type: "message",
+      id: `f${i}`,
+      parentId: null,
+      timestamp: "",
+      message: { role: i % 2 ? "assistant" : "user", content: `${i} ${filler}`, timestamp: Date.now() },
+    })),
+    ...Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`)),
+  ];
+  const ctx = ctxWithModel(entries, 10_000, ["text", "image"]);
   const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
-  // 8 × 1600 = 12.8K > 10K window — the nudge must fire even though the
-  // visible text of every message is empty.
-  assert.ok(nudgeCount(r) >= 1, "image tokens must push the sent view past the window");
+  // ~30 × 450 filler + 8 × 1600 images ≈ 26K vs 10K window; the older filler
+  // sits outside the recent-protection window, so a compressible range exists.
+  assert.ok(nudgeCount(r) >= 1, "filler + images must overflow the window and trip the nudge");
   await rm(`${STATE_FILE}.acp.json`, { force: true });
 });
 
@@ -126,19 +172,6 @@ test("identical text-only session stays quiet (same window)", async () => {
   const ctx = ctxWithModel(entries, 10_000, ["text", "image"]);
   const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
   assert.equal(nudgeCount(r), 0, "eight one-char messages must not trip the nudge");
-  await rm(`${STATE_FILE}.acp.json`, { force: true });
-});
-
-test("images cost nothing for non-vision models", async () => {
-  await rm(`${STATE_FILE}.acp.json`, { force: true });
-  const { api, handlers } = captureApi();
-  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
-  const entries = Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`));
-  const ctx = ctxWithModel(entries, 10_000, ["text"]);
-  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
-  // pi-ai silently drops image blocks for non-vision models — counting them
-  // would fabricate 12.8K of phantom usage.
-  assert.equal(nudgeCount(r), 0, "non-vision model must not count image tokens");
   await rm(`${STATE_FILE}.acp.json`, { force: true });
 });
 

--- a/tests/image-tokens.test.ts
+++ b/tests/image-tokens.test.ts
@@ -1,0 +1,161 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+import { estimateTokens, collectImageTokens, modelSupportsImages, IMAGE_TOKEN_COST } from "../src/tokens.js";
+import { countImageBlocks } from "../src/messages.js";
+
+// Image blocks were invisible to the sent-view estimate (extractText drops
+// them), so usage under-counted image-heavy sessions and density calibration
+// chased a phantom gap (real includes image tokens, estimate did not).
+// dog/billion-context-pi#200.
+
+const STATE_FILE = "/tmp/pai-acp-image-tokens-it.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+// pi's injected nudge text: "⚠️ Context limit reached — compress now. …"
+const nudgeCount = (r: any) =>
+  (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached|compress/i.test(JSON.stringify(m.content))).length;
+
+function ctxWithModel(entries: any[], limit: number, input: string[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: limit, input },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "image-tokens-session",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+const imgEntry = (id: string) => ({
+  type: "message",
+  id,
+  parentId: null,
+  timestamp: "",
+  message: { role: "user", content: [{ type: "image", data: `payload-${id}`, mimeType: "image/png" }], timestamp: Date.now() },
+});
+
+const textEntry = (id: string, text: string) => ({
+  type: "message",
+  id,
+  parentId: null,
+  timestamp: "",
+  message: { role: "user", content: text, timestamp: Date.now() },
+});
+
+test("countImageBlocks counts only image blocks", () => {
+  assert.equal(countImageBlocks([{ type: "text", text: "hi" }, { type: "image", data: "a", mimeType: "image/png" }]), 1);
+  assert.equal(countImageBlocks([{ type: "image", data: "a", mimeType: "image/png" }, { type: "image", data: "b", mimeType: "image/jpeg" }]), 2);
+  assert.equal(countImageBlocks("plain string"), 0);
+  assert.equal(countImageBlocks(undefined), 0);
+});
+
+test("modelSupportsImages reads the model input capability", () => {
+  assert.equal(modelSupportsImages({ input: ["text", "image"] }), true);
+  assert.equal(modelSupportsImages({ input: ["text"] }), false);
+  assert.equal(modelSupportsImages({}), false);
+  assert.equal(modelSupportsImages(undefined), false);
+});
+
+test("collectImageTokens maps entry ids to per-image cost", () => {
+  const entries = [
+    { id: "e1", type: "message", message: { role: "user", content: [{ type: "text", text: "see" }, { type: "image", data: "x", mimeType: "image/png" }] } },
+    { id: "e2", type: "message", message: { role: "toolResult", toolName: "read", toolCallId: "c1", content: [{ type: "image", data: "y", mimeType: "image/png" }] } },
+    { id: "e3", type: "message", message: { role: "user", content: "no images" } },
+    { id: "e4", type: "model_change" },
+  ];
+  const map = collectImageTokens(entries, true);
+  assert.equal(map.get("e1"), IMAGE_TOKEN_COST);
+  assert.equal(map.get("e2"), IMAGE_TOKEN_COST);
+  assert.ok(!map.has("e3"));
+  assert.ok(!map.has("e4"));
+});
+
+test("collectImageTokens is empty for non-vision models", () => {
+  const entries = [imgEntry("e1")];
+  assert.equal(collectImageTokens(entries, false).size, 0);
+});
+
+test("estimateTokens adds image tokens and skips covered ids", () => {
+  const msgs = [
+    { id: "m1", role: "user", contentType: "text", text: "" },
+    { id: "m2", role: "user", contentType: "text", text: "alpha beta gamma" },
+  ];
+  const imageTokens = new Map([["m1", IMAGE_TOKEN_COST]]);
+  assert.equal(estimateTokens(msgs, undefined, imageTokens), IMAGE_TOKEN_COST + 4);
+  assert.equal(estimateTokens(msgs, new Set(["m1"]), imageTokens), 4);
+});
+
+test("images count toward sent-view arbitration (vision model)", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const entries = Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`));
+  const ctx = ctxWithModel(entries, 10_000, ["text", "image"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // 8 × 1600 = 12.8K > 10K window — the nudge must fire even though the
+  // visible text of every message is empty.
+  assert.ok(nudgeCount(r) >= 1, "image tokens must push the sent view past the window");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});
+
+test("identical text-only session stays quiet (same window)", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const entries = Array.from({ length: 8 }, (_, i) => textEntry(`e${i}`, "x"));
+  const ctx = ctxWithModel(entries, 10_000, ["text", "image"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  assert.equal(nudgeCount(r), 0, "eight one-char messages must not trip the nudge");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});
+
+test("images cost nothing for non-vision models", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const entries = Array.from({ length: 8 }, (_, i) => imgEntry(`e${i}`));
+  const ctx = ctxWithModel(entries, 10_000, ["text"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // pi-ai silently drops image blocks for non-vision models — counting them
+  // would fabricate 12.8K of phantom usage.
+  assert.equal(nudgeCount(r), 0, "non-vision model must not count image tokens");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});
+
+test("pi host: image-only user message survives the transform with its ref tag", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const entries = [imgEntry("e1")];
+  const ctx = ctxWithModel(entries, 200_000, ["text", "image"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  assert.ok(r, "handler must not throw on an image-only message");
+  const content = r.messages[0].content;
+  const imageBlocks = content.filter((b: { type?: string }) => b.type === "image");
+  assert.equal(imageBlocks.length, 1, "the image block must survive");
+  assert.equal(imageBlocks[0]!.data, "payload-e1");
+  const textBlock = content.find((b: { type?: string }) => b.type === "text");
+  assert.ok(textBlock, "a ref-tag text block must accompany the image");
+  assert.match(textBlock.text, /m\d{5}/, "ref tag present on the image-only message");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});


### PR DESCRIPTION
Fixes #200 (图片无法被正确处理)

## Root cause

Image blocks were invisible to ACP's sent-view estimate: `extractText()` projects only `type === "text"` blocks into the kernel, so every image contributed **0 tokens** to `sentTokens`. Two concrete failures:

1. **Under-counted usage** — nudge/emergency/truncation arbitration ran on a number that ignored images entirely. An image-heavy session could overflow the provider window before ACP reacted (recovered only via the overflow-selfheal path on the next turn).
2. **Corrupted density calibration** — `density.update(modelId, realUsage.tokens, sentTokens, ...)` compares provider-reported usage (which *includes* image tokens) against the estimate (which did not). The phantom gap pushed density toward the 2.5× clamp, inflating every subsequent estimate and triggering premature compression.

Verified by repro: image-only user messages and image-bearing tool results do survive the transform with correct ref tags — the pipeline never dropped them; only the accounting was wrong.

## Fix

- `countImageBlocks(content)` in `src/messages.ts`
- `IMAGE_TOKEN_COST = 1600` per image in `src/tokens.ts` (~Anthropic screenshot cost; per-model truth converges over time via density calibration — over-counting is safer than under-counting for overflow prevention)
- `modelSupportsImages(model)` — cost is zeroed when the model lacks the `image` input capability, since pi-ai silently drops image blocks for non-vision models (counting them would fabricate phantom usage)
- `estimateTokens(messages, coveredIds?, imageTokensById?)` — optional per-id image token map, wired through `src/index.ts` (sent view + density), `src/status-tool.ts`, `src/compress-tool.ts` (keeps the X→Y panel same-scale), `src/commands.ts` (`/acp` status)

## Tests

New `tests/image-tokens.test.ts` (9 tests): unit coverage for the helpers plus end-to-end cases — 8 images × 1600 > 10K window trips the nudge where identical text-only content stays quiet, non-vision models count 0, and an image-only user message survives the Pi-host transform with its ref tag intact.

Full suite: 55 tests pass. `npm run typecheck && npm test && npm run build` clean.