### PR TITLE
chore: acp-kernel 0.0.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.40",
+				"acp-kernel": "0.0.41",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.40",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.40.tgz",
-			"integrity": "sha512-ofKAhtGsQ/aD3Na2lUxg6Xc/P9k8ie8dXKZyEWkHpVd5/37E8+WlcpWqJypOohP5LrSsFVZaPRqVC/5NOdJfgA==",
+			"version": "0.0.41",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.41.tgz",
+			"integrity": "sha512-TFIxqoPkDVmakxDJGkkKitz1gGVjFlOrkRyHG24r3q49Sc2JWkf1YxcnA3KNRbZzoG9R0hsgOMzU078cY3pnJA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.40",
+		"acp-kernel": "0.0.41",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Kernel pin 0.0.40 → 0.0.41.

Brings the `acp-kernel/persist` subpath (StateStore mechanism, #126) and its 0.0.41 additions (legacy record adoption + loadSync path hint, #130). No pi code consumes the persist subpath yet — pi still folds per-request on the wire (no restart fingerprint problem by design), this is pin hygiene.

0.0.41 vs 0.0.40 delta is persist-only (hooks, no codec changes): 409/409 tests green, tsc clean, build clean. MERGE BY OWNER ONLY.