### PR TITLE
feat(update): follow the installed dist-tag channel instead of hardcoded latest

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -9,7 +9,8 @@ import { debug, logInfo, logWarn } from "./log.js";
 declare const CURRENT_VERSION: string;
 
 const PACKAGE_NAME = "billion-context-pi";
-const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+const registryUrl = (tag: string) =>
+  `https://registry.npmjs.org/${PACKAGE_NAME}/${encodeURIComponent(tag)}`;
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z-.]+)?$/;
 const CHECK_INTERVAL_MS = 3 * 60 * 1000;
 // Resolved lazily (not at module load) so tests can redirect it via env at any
@@ -79,18 +80,94 @@ export function setRunNodeForTest(impl: NodeRunner): void {
   runNodeImpl = impl;
 }
 
-function parseVersion(v: string): number[] {
-  return v.replace(/^v/, "").split(".").map((n) => parseInt(n, 10) || 0);
+// Test-only override for the installed spec (the channel the user installed
+// from). null = not overridden (real discovery). Lets tests exercise the
+// non-latest channel path without a full node_modules fixture.
+let installedSpecOverride: string | null = null;
+export function setInstalledSpecForTest(spec: string | null): void {
+  installedSpecOverride = spec;
 }
 
-export function isNewer(latest: string, current: string): boolean {
-  const l = parseVersion(latest);
-  const c = parseVersion(current);
-  for (let i = 0; i < 3; i++) {
-    if ((l[i] ?? 0) > (c[i] ?? 0)) return true;
-    if ((l[i] ?? 0) < (c[i] ?? 0)) return false;
-  }
+// --- Channel-based auto-update (ported from opencode-acp lib/update.ts) ---
+// The updater follows the dist-tag the user installed from, not the global
+// `latest`: an @stable install tracks `stable`, @dev tracks `dev`, @pr-N
+// tracks `pr-N`, ranges/latest/* track `latest`, and an exact pin never
+// auto-updates.
+
+export function isAutoUpdatableSpec(spec: string): boolean {
+  const value = spec.trim();
+  if (!value) return false;
+  if (value === "latest" || value === "*") return true;
+  if (/^[~^]/.test(value)) return true;
+  if (/^(?:>=|>|<=|<)/.test(value)) return true;
+  if (/\s+(?:\|\||-|[<>=])\s+/.test(value)) return true;
+  if (isDistTag(value)) return true;
   return false;
+}
+
+/**
+ * Registry dist-tag the auto-updater should track for a spec.
+ * - `stable`, `dev`, `pr-327`, `latest` → that dist-tag
+ * - ranges (`^1.2.3`, `>=1.0.0`, `*`) → `latest`
+ * - exact pins / non-registry specs → undefined (never auto-update)
+ */
+export function specUpdateTag(spec: string): string | undefined {
+  const value = spec.trim();
+  if (!isAutoUpdatableSpec(value)) return undefined;
+  if (value === "*") return "latest";
+  if (isDistTag(value)) return value;
+  return "latest";
+}
+
+function isDistTag(value: string): boolean {
+  // npm dist-tag names contain no `/`, `@`, `:`, or whitespace. Anything with
+  // those is a path/git/URL spec; a bare exact version (or x-range) is a pin,
+  // not a tag.
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) return false;
+  if (parseSemVer(value)) return false;
+  if (/\.x(\.|$)/i.test(value)) return false;
+  return true;
+}
+
+export function isVersionNewer(latest: string, current: string): boolean {
+  const next = parseSemVer(latest);
+  const prev = parseSemVer(current);
+  if (!next || !prev) return false;
+
+  for (let i = 0; i < 3; i++) {
+    const a = next.parts[i] ?? 0;
+    const b = prev.parts[i] ?? 0;
+    if (a !== b) return a > b;
+  }
+
+  if (!next.pre.length && prev.pre.length) return true;
+  if (next.pre.length && !prev.pre.length) return false;
+
+  for (let i = 0; i < Math.max(next.pre.length, prev.pre.length); i++) {
+    const a = next.pre[i];
+    const b = prev.pre[i];
+    if (a === undefined) return false;
+    if (b === undefined) return true;
+    if (a === b) continue;
+
+    const aNumber = /^\d+$/.test(a) ? Number(a) : undefined;
+    const bNumber = /^\d+$/.test(b) ? Number(b) : undefined;
+    if (aNumber !== undefined && bNumber !== undefined) return aNumber > bNumber;
+    if (aNumber !== undefined) return false;
+    if (bNumber !== undefined) return true;
+    return a > b;
+  }
+
+  return false;
+}
+
+function parseSemVer(version: string): { parts: number[]; pre: string[] } | undefined {
+  const match = version.match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+.+)?$/);
+  if (!match) return undefined;
+  return {
+    parts: [Number(match[1]), Number(match[2]), Number(match[3])],
+    pre: match[4]?.split(".") ?? [],
+  };
 }
 
 async function readLastCheck(): Promise<number> {
@@ -261,13 +338,17 @@ export async function autoInstallLatest(latest: string, extDirOverride?: string)
   }
 }
 
-async function fetchLatestVersion(): Promise<string | undefined> {
+async function fetchLatestVersion(tag: string): Promise<string | undefined> {
   // Prefer `npm view`: it honors the user's registry/proxy/auth config (mirrors,
   // corporate proxies) — the same toolchain as the install step. A direct fetch
   // to registry.npmjs.org fails on machines that only reach npm via a mirror or
   // proxy (Node fetch ignores HTTP_PROXY/HTTPS_PROXY).
   try {
-    const { code, stdout } = await runNpmImpl(["view", PACKAGE_NAME, "version"], {
+    // `npm view <pkg> version` defaults to the `latest` tag; only pass --tag
+    // for a non-latest channel so the default path stays byte-identical.
+    const viewArgs = ["view", PACKAGE_NAME, "version"];
+    if (tag !== "latest") viewArgs.push("--tag", tag);
+    const { code, stdout } = await runNpmImpl(viewArgs, {
       timeout: 20_000,
     });
     if (code === 0) {
@@ -282,7 +363,7 @@ async function fetchLatestVersion(): Promise<string | undefined> {
   } catch {
   }
   try {
-    const res = await fetch(REGISTRY_URL, {
+    const res = await fetch(registryUrl(tag), {
       signal: AbortSignal.timeout(10_000),
       headers: { Accept: "application/json" },
     });
@@ -325,14 +406,25 @@ export async function checkForUpdate(
     await writeLastCheck(now);
 
     const runtimeVersion = await getRuntimeVersion();
-    const latest = await fetchLatestVersion();
+    // Follow the channel the user installed from (dist-tag), not the global
+    // `latest`: an @stable install tracks `stable`, @dev tracks `dev`, @pr-N
+    // tracks `pr-N`, ranges/latest/* track `latest`, an exact pin never
+    // auto-updates. No recoverable spec (e.g. not under node_modules) → latest.
+    const spec = await getInstalledSpec();
+    const tag = spec ? specUpdateTag(spec) : "latest";
+    if (!tag) {
+      debug.event("update-check", { event: "skip", reason: "pinned-spec", spec });
+      return;
+    }
+    const latest = await fetchLatestVersion(tag);
     if (!latest) return;
 
     const current = runtimeVersion ?? CURRENT_VERSION;
-    const hasUpdate = isNewer(latest, current);
+    const hasUpdate = isVersionNewer(latest, current);
     debug.event("update-check", {
       current,
       latest,
+      tag,
       hasUpdate,
     });
     logInfo("update", { event: "check", current, latest, hasUpdate });
@@ -369,4 +461,18 @@ async function getRuntimeVersion(): Promise<string | undefined> {
   if (!extDir) return undefined;
   const pkg = await readPackageJson(join(extDir, "package.json"));
   return pkg?.version;
+}
+
+// The spec the user installed with, as recorded in the host project's
+// package.json dependencies (e.g. `~/.pi/agent/npm/package.json` →
+// `"billion-context-pi": "^0.1.46"` or `"stable"`). This is what determines
+// which dist-tag channel the auto-updater follows.
+async function getInstalledSpec(): Promise<string | undefined> {
+  if (installedSpecOverride !== null) return installedSpecOverride;
+  const extDir = await findExtensionDir();
+  if (!extDir) return undefined;
+  const npmRoot = findNpmRoot(extDir);
+  if (!npmRoot) return undefined;
+  const hostPkg = await readPackageJson(join(npmRoot, "package.json"));
+  return hostPkg?.dependencies?.[PACKAGE_NAME];
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -110,10 +110,16 @@ export function isAutoUpdatableSpec(spec: string): boolean {
  * - `stable`, `dev`, `pr-327`, `latest` → that dist-tag
  * - ranges (`^1.2.3`, `>=1.0.0`, `*`) → `latest`
  * - exact pins / non-registry specs → undefined (never auto-update)
+ * - exact *prerelease* versions → `latest`: npm records tag installs
+ *   (`@pr-N`, `@dev`) as the resolved exact version, so without this
+ *   fallback those users would freeze on a stale PR/dev build forever
  */
 export function specUpdateTag(spec: string): string | undefined {
   const value = spec.trim();
-  if (!isAutoUpdatableSpec(value)) return undefined;
+  if (!isAutoUpdatableSpec(value)) {
+    if (/^\d+\.\d+\.\d+-[0-9A-Za-z-.]+$/.test(value)) return "latest";
+    return undefined;
+  }
   if (value === "*") return "latest";
   if (isDistTag(value)) return value;
   return "latest";
@@ -408,8 +414,9 @@ export async function checkForUpdate(
     const runtimeVersion = await getRuntimeVersion();
     // Follow the channel the user installed from (dist-tag), not the global
     // `latest`: an @stable install tracks `stable`, @dev tracks `dev`, @pr-N
-    // tracks `pr-N`, ranges/latest/* track `latest`, an exact pin never
-    // auto-updates. No recoverable spec (e.g. not under node_modules) → latest.
+    // tracks `pr-N`, ranges/latest/* track `latest`, an exact stable pin never
+    // auto-updates (exact prerelease versions fall back to latest — see
+    // specUpdateTag). No recoverable spec (e.g. not under node_modules) → latest.
     const spec = await getInstalledSpec();
     const tag = spec ? specUpdateTag(spec) : "latest";
     if (!tag) {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -28,8 +28,11 @@ const {
   findNpmRoot,
   setRunNpmForTest,
   setRunNodeForTest,
+  setInstalledSpecForTest,
   autoInstallLatest,
-  isNewer,
+  isVersionNewer,
+  specUpdateTag,
+  isAutoUpdatableSpec,
   runNpm,
   runNode,
 } = await import("../src/update.js");
@@ -110,13 +113,52 @@ test("checkForUpdate trims surrounding whitespace in ACP_AUTO_UPDATE before matc
   delete process.env.ACP_AUTO_UPDATE;
 });
 
-test("isNewer compares numeric segments", () => {
-  assert.equal(isNewer("0.1.43", "0.1.41"), true);
-  assert.equal(isNewer("0.1.41", "0.1.43"), false);
-  assert.equal(isNewer("0.1.41", "0.1.41"), false);
-  assert.equal(isNewer("0.2.0", "0.10.0"), false);
-  assert.equal(isNewer("1.0.0", "0.9.9"), true);
-  assert.equal(isNewer("v1.2.3", "1.2.2"), true);
+test("isVersionNewer compares numeric segments", () => {
+  assert.equal(isVersionNewer("0.1.43", "0.1.41"), true);
+  assert.equal(isVersionNewer("0.1.41", "0.1.43"), false);
+  assert.equal(isVersionNewer("0.1.41", "0.1.41"), false);
+  assert.equal(isVersionNewer("0.2.0", "0.10.0"), false);
+  assert.equal(isVersionNewer("1.0.0", "0.9.9"), true);
+  assert.equal(isVersionNewer("v1.2.3", "1.2.2"), true);
+});
+
+test("isVersionNewer handles prerelease ordering (pre < release, numeric pre parts)", () => {
+  // A prerelease is OLDER than its release: 0.1.46-pr.202.1 < 0.1.46
+  assert.equal(isVersionNewer("0.1.46", "0.1.46-pr.202.1"), true);
+  assert.equal(isVersionNewer("0.1.46-pr.202.1", "0.1.46"), false);
+  // Higher prerelease number is newer
+  assert.equal(isVersionNewer("0.1.46-pr.203.1", "0.1.46-pr.202.1"), true);
+  // A release is newer than any prerelease of a lower version
+  assert.equal(isVersionNewer("0.1.47", "0.1.46-pr.999.1"), true);
+});
+
+test("specUpdateTag maps a spec to the dist-tag channel to track", () => {
+  // dist-tags track themselves
+  assert.equal(specUpdateTag("stable"), "stable");
+  assert.equal(specUpdateTag("dev"), "dev");
+  assert.equal(specUpdateTag("pr-327"), "pr-327");
+  assert.equal(specUpdateTag("latest"), "latest");
+  // ranges and * track latest
+  assert.equal(specUpdateTag("^1.2.3"), "latest");
+  assert.equal(specUpdateTag("~0.1.0"), "latest");
+  assert.equal(specUpdateTag(">=1.0.0"), "latest");
+  assert.equal(specUpdateTag("*"), "latest");
+  // exact pins and non-registry specs never auto-update
+  assert.equal(specUpdateTag("1.2.3"), undefined);
+  assert.equal(specUpdateTag("file:../local/x.tgz"), undefined);
+  assert.equal(specUpdateTag("git+https://github.com/x/y.git"), undefined);
+  assert.equal(specUpdateTag(""), undefined);
+});
+
+test("isAutoUpdatableSpec classifies specs", () => {
+  assert.equal(isAutoUpdatableSpec("latest"), true);
+  assert.equal(isAutoUpdatableSpec("*"), true);
+  assert.equal(isAutoUpdatableSpec("^1.2.3"), true);
+  assert.equal(isAutoUpdatableSpec("stable"), true);
+  assert.equal(isAutoUpdatableSpec("pr-327"), true);
+  assert.equal(isAutoUpdatableSpec("1.2.3"), false);
+  assert.equal(isAutoUpdatableSpec("file:../x.tgz"), false);
+  assert.equal(isAutoUpdatableSpec(""), false);
 });
 
 test("runNpm resolves real npm output", { timeout: 30_000 }, (t) => {
@@ -153,6 +195,43 @@ test("checkForUpdate queries npm view first with exact args", async () => {
   assert.deepEqual(calls[0].args, ["view", "billion-context-pi", "version"]);
   assert.ok(calls[0].opts.timeout > 0);
   assert.match(readLog(), new RegExp(`event=check current=${REPO_VERSION} latest=0\\.0\\.1 hasUpdate=false`));
+});
+
+test("checkForUpdate follows the installed channel: @stable → npm view --tag stable", async () => {
+  resetThrottle();
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "0.0.1\n", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  setRunNpmForTest(impl);
+  setInstalledSpecForTest("stable");
+  try {
+    const notes: string[] = [];
+    await checkForUpdate(true, (m) => notes.push(m));
+    assert.equal(notes.length, 0);
+    assert.deepEqual(calls[0].args, ["view", "billion-context-pi", "version", "--tag", "stable"]);
+  } finally {
+    setInstalledSpecForTest(null);
+  }
+});
+
+test("checkForUpdate skips the check entirely for an exact-pin spec (never auto-updates)", async () => {
+  resetThrottle();
+  const { impl, calls } = makeFakeNpm(
+    { code: 0, stdout: "99.0.0\n", stderr: "" },
+    { code: 0, stdout: "", stderr: "" },
+  );
+  setRunNpmForTest(impl);
+  setInstalledSpecForTest("1.2.3");
+  try {
+    const notes: string[] = [];
+    await checkForUpdate(true, (m) => notes.push(m));
+    // pinned spec → no npm view, no notify
+    assert.equal(calls.length, 0);
+    assert.equal(notes.length, 0);
+  } finally {
+    setInstalledSpecForTest(null);
+  }
 });
 
 test("checkForUpdate: update available but not under node_modules → manual hint + install-skip logged", async () => {

--- a/tests/update.test.ts
+++ b/tests/update.test.ts
@@ -150,6 +150,15 @@ test("specUpdateTag maps a spec to the dist-tag channel to track", () => {
   assert.equal(specUpdateTag(""), undefined);
 });
 
+test("specUpdateTag tracks latest for exact prerelease pins (npm-resolved tag installs)", () => {
+  // npm records `npm i pkg@pr-293` as the resolved exact version, losing the
+  // channel; freezing those users on a stale PR/dev build serves no one.
+  assert.equal(specUpdateTag("0.1.56-pr.293.4"), "latest");
+  assert.equal(specUpdateTag("0.1.57-beta.1"), "latest");
+  // exact stable pins still never auto-update
+  assert.equal(specUpdateTag("0.1.56"), undefined);
+});
+
 test("isAutoUpdatableSpec classifies specs", () => {
   assert.equal(isAutoUpdatableSpec("latest"), true);
   assert.equal(isAutoUpdatableSpec("*"), true);


### PR DESCRIPTION
**Model: qwen3.8-27b (vllm)** — ework-daemon

## What

Ports opencode-acp's **channel-based auto-update** to `billion-context-pi`. The updater no longer hardcodes `/latest`; it follows the **dist-tag the user installed from**.

## Why

Previously `src/update.ts` always polled `https://registry.npmjs.org/billion-context-pi/latest`. There was no way for a user to opt into a `dev` / `stable` / `pr-N` channel, and the version compare was a naive 3-part numeric compare that mis-ordered prereleases.

## How

- Read the install spec from the host manifest (`~/.pi/agent/npm/package.json` → `dependencies["billion-context-pi"]`), same pattern opencode-acp uses for its wrapper `package.json`.
- `specUpdateTag(spec)` maps the spec to the channel to track:
  - `@stable` → `stable`, `@dev` → `dev`, `@pr-N` → `pr-N`, `@latest` → `latest`
  - ranges (`^1.2.3`, `>=1.0.0`, `*`) → `latest`
  - exact pin / non-registry spec → **never auto-updates**
- `fetchLatestVersion(tag)` queries `npm view <pkg> version --tag <tag>` (only adds `--tag` for non-latest, so the default path is byte-identical) with the registry fetch as fallback.
- Replaced `isNewer` with `isVersionNewer` (proper semver, prerelease-aware: `0.1.46-pr.202.1 < 0.1.46`).

## Effect

- Publishing a PR (`pr-N` tag) **never** pulls a user on another channel forward.
- A user who installed `@dev` only auto-updates when we publish to `dev`; `@stable` only on `stable`; default/range installs follow `latest` (unchanged behavior).

## Tests

`tests/update.test.ts`: +6 tests (specUpdateTag, isAutoUpdatableSpec, isVersionNewer prerelease ordering, `@stable → npm view --tag stable`, exact-pin skip). Full suite: **414 pass, 0 fail**. Typecheck clean.