### PR TITLE
feat(compress): switch normalizeRanges to kernel parseCompressArgs (de-JSON)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.41",
+				"acp-kernel": "0.0.43",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.41",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.41.tgz",
-			"integrity": "sha512-TFIxqoPkDVmakxDJGkkKitz1gGVjFlOrkRyHG24r3q49Sc2JWkf1YxcnA3KNRbZzoG9R0hsgOMzU078cY3pnJA==",
+			"version": "0.0.43",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.43.tgz",
+			"integrity": "sha512-w5vSovgdj/IpHiuwwOJvXDNwQfVE6Qe+raucvdPt61b19g7jDV+o6wxhkowe5m69gr+/X5+tE00BCEHSuGtuvw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.41",
+		"acp-kernel": "0.0.43",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -7,7 +7,7 @@ import type {
 import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds, calibrateTokens } from "./tokens.js";
-import { defaultCountTokens, type CompressionBlock } from "acp-kernel";
+import { defaultCountTokens, parseCompressArgs, type CompressionBlock, type CompressParseDiagnostics } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 
 function formatK(n: number): string {
@@ -67,30 +67,34 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
 
 type RangeEntry = Static<typeof RangeSpec>;
 
-// Normalize the content argument: array passes through; a JSON-encoded string
-// (non-strict-tool providers) is parsed. Returns an error string on bad input —
-// handleCompress THROWS it so pi marks the toolResult isError:true and the
-// retry nudge (src/index.ts) can quote it back (returning it normally would
-// produce isError:false, which both skips the nudge and resets the counter).
-function normalizeRanges(content: CompressArgs["content"]): RangeEntry[] | string {
-  let ranges: unknown = content ?? [];
-  if (typeof ranges === "string") {
-    try {
-      ranges = JSON.parse(ranges);
-    } catch (e) {
-      return `Invalid content: not valid JSON (${e instanceof Error ? e.message : String(e)}). content must be an ARRAY of {startId, endId, summary} objects — pass the array directly, not a string.`;
-    }
+// Normalize the compress args via the kernel's lenient parser (fenced /
+// trailing-comma / raw-newline / double-stringified / truncated-salvage).
+// Returns an error string on bad input — handleCompress THROWS it so pi marks
+// the toolResult isError:true and the retry nudge (src/index.ts) can quote it
+// back (returning it normally would produce isError:false, which both skips
+// the nudge and resets the counter). An empty array passes through (the call
+// site returns "No ranges provided.").
+function normalizeRanges(args: CompressArgs): RangeEntry[] | string {
+  const { ranges, diagnostics } = parseCompressArgs(args);
+  if (ranges.length === 0) {
+    if (Array.isArray(args.content) && args.content.length === 0) return [];
+    return describeDiagnostics(diagnostics, args.content);
   }
-  if (!Array.isArray(ranges)) {
-    return `Invalid content: expected an array of ranges, got ${ranges === null ? "null" : typeof ranges}.`;
+  return ranges.map((r) => ({ startId: r.startRef, endId: r.endRef, summary: r.summary, topic: r.topic }));
+}
+
+function describeDiagnostics(diagnostics: CompressParseDiagnostics, content: CompressArgs["content"]): string {
+  const shape = typeof content === "string"
+    ? "a JSON-encoded string (non-strict-tool providers stringify array arguments)"
+    : content === null ? "null" : `a ${typeof content}`;
+  const base = `Invalid compress content (${diagnostics.kind}): got ${shape}`;
+  if (diagnostics.kind === "truncated") {
+    return `${base}; the input was truncated and no complete ranges could be recovered. Shorten the summary or split into smaller ranges.`;
   }
-  for (const [i, r] of ranges.entries()) {
-    const o = r as Record<string, unknown>;
-    if (!o || typeof o !== "object" || typeof o.startId !== "string" || typeof o.endId !== "string" || typeof o.summary !== "string") {
-      return `Invalid content[${i}]: each range must be an object with string fields startId, endId, summary.`;
-    }
+  if (diagnostics.invalidItems > 0) {
+    return `${base}; ${diagnostics.invalidItems} entr${diagnostics.invalidItems === 1 ? "y was" : "ies were"} dropped as invalid. Each range must be an object with string fields startId, endId, summary.`;
   }
-  return ranges as RangeEntry[];
+  return `${base}. content must be an ARRAY of {startId, endId, summary} objects.`;
 }
 
 /** Panel block count ("… (~N reclaimed, B blocks)"), or -1 for non-panels. */
@@ -135,7 +139,7 @@ function tier3OnlyRewrite(newBlocks: CompressionBlock[], allBlocks: CompressionB
 }
 
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {
-  const maybeRanges = normalizeRanges(args.content);
+  const maybeRanges = normalizeRanges(args);
   // Argument errors throw (not return): pi-agent-core only sets isError:true
   // on THROWN tool errors, and the retry nudge keys off isError. A returned
   // string would land as isError:false — no nudge, and the counter resets.

--- a/tests/compress-retry.test.ts
+++ b/tests/compress-retry.test.ts
@@ -190,7 +190,7 @@ test("compress tool THROWS on garbage string content (isError:true → retry nud
   // finding 2 on 7ddd2c6), so the tool must reject.
   await assert.rejects(
     () => compressTool.execute("tc1", { content: "not json {" }, undefined, undefined, ctx),
-    /Invalid content: not valid JSON[\s\S]*ARRAY/,
+    /Invalid compress content[\s\S]*ARRAY/,
   );
   await rm(`${stateFile}.acp.json`, { force: true });
 });


### PR DESCRIPTION
> **Model**: qwen3.8-27b (vllm)

## What
Replace pi's strict `normalizeRanges` (JSON.parse, no salvage) with the kernel's lenient `parseCompressArgs` (fenced / trailing-comma / raw-newline / double-stringified / truncated-salvage). Keeps the throw contract (pi isError depends on throw). Adds `describeDiagnostics` for actionable error messages.

## Dependency
**Depends on acp-kernel#111** (`parseCompressArgs`) being merged + published. Until then this branch is RED (import fails on old kernel 0.0.41). After #111 publishes: bump acp-kernel version + refresh lockfile + re-run CI.

## Tests
409/409 pass, typecheck clean (validated against local kernel overlay of #111).