### PR TITLE
fix: self-disable when running under billion-context proxy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ declare const CURRENT_VERSION: string;
 
 export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactory {
   return (pi: ExtensionAPI) => {
+    if (process.env.BILLION_CONTEXT_PROXY) {
+      console.log("[bcp] disabled: BILLION_CONTEXT_PROXY detected — proxy handles compression");
+      return;
+    }
     const runtime = createRuntime(adapter);
     wireCompactionDisable(pi);
     wireSessionLifecycle(pi, runtime);


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Problem

When both billion-context-pi (bcp) and the billion-context proxy plugin are loaded in pi (via `bili pi`), they register **identical tool names** (`compress`, `decompress`, `search_context`, `acp_status`) and the same `/acp` command. bcp's registrations override the proxy's, so:

- `/acp` shows bcp's empty client-side state instead of the proxy's real session data
- Tool calls may be routed to bcp's handlers instead of the proxy

## Fix

Add a 4-line guard at the top of the extension factory: if `BILLION_CONTEXT_PROXY` is set (the launcher sets this env var), bcp prints a notice and returns early — registering nothing. The proxy plugin then owns all ACP tools.

## Result

- `bili pi` → bcp disabled, proxy plugin active
- Standalone `pi` → bcp works normally (client-side compression)
- Both packages can coexist in settings.json without conflict
