### PR TITLE
fix(guardrail): apply documented 200KB toolOutputMaxBytes default when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased (master, since v0.1.38)
+- **fix(guardrail): `toolOutputMaxBytes` 未配置时文档默认值 200000 现在实际生效** — 原接线 `if (max !== undefined && max > 0)` 把「未配置」当成「禁用」，内置 200KB 天花板永远不可达（`capToolOutput` 内部的回退到不了）；pi 只内置 cap bash/read/grep，其余工具可无限注入 context，与 CONFIGURATION.md 承诺的 ACTIVE 默认不符。改为接线层 `?? DEFAULT_TOOL_OUTPUT_MAX_BYTES` 回退，`0`/负数禁用语义不变 (#210)
 
 - **fix(compress): 接受 JSON 字符串形式的 `content` 参数** — 非严格工具 provider（vLLM openai-completions，`supportsStrictTools:false`）会把嵌套数组参数字符串化，pi 的 typebox 校验直接拒掉（`content.0: must be object`）。实测会话 01a00a38 全部唯一一次 compress 调用即死于此，3 小时会话零压缩。schema 改为 `Type.Union([Array, String])`，字符串自动 `JSON.parse` 并校验（错误信息引导模型传数组）
 - **feat(nudge): compress 失败即时重试提示** — 失败的 compress toolResult 不再白白吃掉本轮 nudge 预算：下一次 context 事件立即注入重试提示（引用被截短的错误文本、给出正确调用格式）。仅统计**当前用户轮**的失败（旧轮失败不再复发），封顶按**失败调用次数**计：每轮最多 3 次（`MAX_COMPRESS_ATTEMPTS`），成功重置；中性结果（非错误非面板文本，如 "No ranges provided."）不重置也不递增——混合失败模式无法绕过封顶。参数类错误改为 throw（pi 仅对 throw 的工具错误标 `isError:true`，return 字符串会被当成成功并重置计数）。提示在重试前每次 LLM 调用都重新注入（pi 每次重建上下文，一次性 append 会消失）

--- a/src/tool-guardrails.ts
+++ b/src/tool-guardrails.ts
@@ -126,14 +126,15 @@ export function wireToolGuardrails(pi: ExtensionAPI, runtime: AcpRuntime): void 
       isBash && event.isError ? detectBashTimeout(event.content) : undefined;
 
     let modified: ToolResultEvent["content"] | undefined;
-    const max = runtime.adapter.toolOutputMaxBytes;
-    if (max !== undefined && max > 0) {
-      const next = capToolOutput(event.content, max, fullPath);
-      if (next) {
-        modified = next;
-        debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
-        logWarn("guardrail", { event: "output-cap", max, hadPath: !!fullPath });
-      }
+    // Unset must mean the documented 200KB default (CONFIGURATION.md), not
+    // "no cap"; only an explicit 0/negative disables. capToolOutput applies
+    // the same fallback internally, but resolving it here keeps logs accurate.
+    const max = runtime.adapter.toolOutputMaxBytes ?? DEFAULT_TOOL_OUTPUT_MAX_BYTES;
+    const next = capToolOutput(event.content, max, fullPath);
+    if (next) {
+      modified = next;
+      debug.event("guardrail-output-cap", { max, hadPath: !!fullPath });
+      logWarn("guardrail", { event: "output-cap", max, hadPath: !!fullPath });
     }
 
     if (timeoutSecs !== undefined) {

--- a/tests/tool-guardrails.test.ts
+++ b/tests/tool-guardrails.test.ts
@@ -6,8 +6,10 @@ import {
   detectBashTimeout,
   appendTimeoutNotice,
   isBashToolResult,
+  wireToolGuardrails,
 } from "../src/tool-guardrails.js";
-import type { ToolResultEvent } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ToolResultEvent } from "@earendil-works/pi-coding-agent";
+import type { AcpRuntime } from "../src/runtime.js";
 
 type Content = ToolResultEvent["content"];
 const text = (t: string): Content => [{ type: "text", text: t }];
@@ -132,4 +134,51 @@ test("isBashToolResult narrows by toolName and exposes bash details (vendored gu
   if (isBashToolResult(bash)) {
     assert.equal(bash.details?.fullOutputPath, "/tmp/x");
   }
+});
+
+// --- wiring: the default-application contract (issue #210) ---
+
+function wireFor(adapter: Record<string, unknown>) {
+  const handlers: Record<string, (e: ToolResultEvent) => unknown> = {};
+  const pi = {
+    on: (name: string, fn: (e: never) => unknown) => {
+      handlers[name] = fn as (e: ToolResultEvent) => unknown;
+    },
+  } as unknown as ExtensionAPI;
+  const runtime = { adapter } as AcpRuntime;
+  wireToolGuardrails(pi, runtime);
+  return (event: ToolResultEvent) => handlers["tool_result"]!(event);
+}
+
+const readResult = (t: string) =>
+  ({ toolName: "read", content: text(t), isError: false }) as unknown as ToolResultEvent;
+
+function textOf(part: unknown): string {
+  if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+    return part.text;
+  }
+  throw new Error("expected a text content part");
+}
+
+test("wireToolGuardrails applies the documented 200KB default when toolOutputMaxBytes is unset", () => {
+  const onResult = wireFor({});
+  const ret = onResult(readResult("x".repeat(300 * 1024)));
+  assert.ok(ret && typeof ret === "object" && "content" in ret && Array.isArray(ret.content),
+    "oversized output must be capped even with no explicit config");
+  const t = textOf(ret.content[0]);
+  assert.match(t, /\[ACP guardrail/);
+  assert.ok(Buffer.byteLength(t, "utf8") < 250 * 1024, "payload must be truncated near the 200KB default");
+});
+
+test("wireToolGuardrails keeps an explicit toolOutputMaxBytes: 0 as disable", () => {
+  const onResult = wireFor({ toolOutputMaxBytes: 0 });
+  assert.equal(onResult(readResult("x".repeat(300 * 1024))), undefined);
+});
+
+test("wireToolGuardrails honors an explicit smaller cap", () => {
+  const onResult = wireFor({ toolOutputMaxBytes: 1000 });
+  const ret = onResult(readResult("x".repeat(10_000)));
+  assert.ok(ret && typeof ret === "object" && "content" in ret && Array.isArray(ret.content));
+  const t = textOf(ret.content[0]);
+  assert.ok(Buffer.byteLength(t, "utf8") < 2000, "payload must be truncated to the explicit cap");
 });


### PR DESCRIPTION
> 模型:zhipuai-lb/glm-5.3

Closes #210

## 问题

`toolOutputMaxBytes` 文档声明的默认值 `200000`(`CONFIGURATION.md:100` 🟢 ACTIVE、`src/config.ts` doc comment)实际从不生效:接线层的外层判断把「未配置」当成了「禁用」。

```ts
// src/tool-guardrails.ts (before)
const max = runtime.adapter.toolOutputMaxBytes;
if (max !== undefined && max > 0) {   // unset → 整个 cap 被跳过
```

- 工厂入口 `createAcpExtension(adapter = {})`、`applyUserConfig` 只覆盖用户显式设置的键 → 默认配置下该值恒为 `undefined`
- `DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000` 只存在于 `capToolOutput` 内部回退,接线层判断使其不可达
- pi 只内置 cap bash/read/grep,其余工具可无上限注入 context,而文档承诺的 200KB 天花板不存在
- 同文件 `resolveBashTimeout` 的 60s 默认走函数内回退、默认生效 —— 两个 guardrail 语义不一致

## 修复

接线层直接回退:`const max = runtime.adapter.toolOutputMaxBytes ?? DEFAULT_TOOL_OUTPUT_MAX_BYTES;`

- 未配置 → 200KB 默认生效(与文档一致)
- `0` / 负数 / NaN → 禁用语义不变(`capToolOutput` 内部 guard)
- 在接线层解析而非依赖函数内回退,使 `guardrail-output-cap` 日志记录的 `max` 为实际生效值

## 测试

新增 3 个 wiring 级测试(`tests/tool-guardrails.test.ts`,直接驱动 `wireToolGuardrails` 的 `tool_result` handler):

1. unset + 300KB read 结果 → 截断 + `[ACP guardrail` 通知,载荷 < 250KB
2. 显式 `0` → 不截断(禁用保留)
3. 显式 `1000` → 按显式值截断

验证:`npm test` 412/412 通过(原 409 + 新增 3),`tsc --noEmit` 零错误。
