### PR TITLE
feat(panel): prompt-cache hit rate in /acp status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.43",
+				"acp-kernel": "0.0.44",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.43",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.43.tgz",
-			"integrity": "sha512-w5vSovgdj/IpHiuwwOJvXDNwQfVE6Qe+raucvdPt61b19g7jDV+o6wxhkowe5m69gr+/X5+tE00BCEHSuGtuvw==",
+			"version": "0.0.44",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.44.tgz",
+			"integrity": "sha512-4d8XtAVef8uhfil3M4zKMpD1dSZ4CjlkVWfTDOTsuuGCh1Y+i4XvYjpF+yORp9g+5zycshjJg4b4FjfXDItlPw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.43",
+		"acp-kernel": "0.0.44",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionCommandContext, RegisteredCommand } from "@earendil-works/pi-coding-agent";
+import type { ExtensionCommandContext, RegisteredCommand, SessionEntry } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
@@ -10,6 +10,20 @@ import { ensureSubagentAcpTools } from "./setup-subagent-tools.js";
 declare const CURRENT_VERSION: string;
 
 type CommandOptions = Omit<RegisteredCommand, "name" | "sourceInfo">;
+
+/** Extract per-request prompt-cache usage from assistant messages' provider
+ *  reported usage (footer of each entry). Requests without cache reporting
+ *  stay 0/0 — cacheHitStats excludes them from the average. */
+function cacheUsageSamples(entries: SessionEntry[]): Array<{ input: number; cacheRead: number; cacheWrite: number }> {
+  const out: Array<{ input: number; cacheRead: number; cacheWrite: number }> = [];
+  for (const e of entries) {
+    if (e.type !== "message") continue;
+    const m = e.message as { role?: string; usage?: { input?: number; cacheRead?: number; cacheWrite?: number } };
+    if (m?.role !== "assistant" || !m.usage) continue;
+    out.push({ input: m.usage.input ?? 0, cacheRead: m.usage.cacheRead ?? 0, cacheWrite: m.usage.cacheWrite ?? 0 });
+  }
+  return out;
+}
 
 export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options: CommandOptions }> {
   return [
@@ -99,7 +113,7 @@ export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options
 }
 
 async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): Promise<string> {
-  const { state, coreMessages } = await runtime.stateFor(ctx);
+  const { state, coreMessages, entries } = await runtime.stateFor(ctx);
   const config = runtime.configFor(ctx);
   // Use pi's real context usage (anchored on provider usage) only for the
   // panel's footer-scale display line; see sentTokens below for arbitration.
@@ -134,6 +148,7 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
     nudge: turn.nudge,
     modelContextLimit: config.modelContextLimit,
     unprunedTokens: coreMessages.reduce((sum, m) => sum + defaultCountTokens(m.text ?? ""), 0),
+    cacheUsages: cacheUsageSamples(entries ?? []),
   });
 
   // pi-specific footer: delegate usage is tracked outside the main totals.

--- a/tests/commands-kit-panel.test.ts
+++ b/tests/commands-kit-panel.test.ts
@@ -79,3 +79,57 @@ test("/acp panel Session-only derives on the estimation scale (positive assertio
   assert.match(text, /Session-only \(compressed originals, est\.\): 86k — pruned from every request/, text);
   assert.doesNotMatch(text, /406k/, "cross-scale subtraction must not appear");
 });
+
+test("/acp panel renders prompt cache hit rate from stateFor entries", async () => {
+  const runtime = fakeRuntime();
+  (runtime.stateFor as () => Promise<unknown>) = async () => ({
+    state: { blocks: [], stats: { tokensCompressed: 0 }, messageRefs: { byRaw: {}, byRef: {} } },
+    coreMessages: [],
+    entries: [
+      { type: "message", message: { role: "user", content: [{ type: "text", text: "hi" }] } },
+      // request 1: 1k fresh + 99k cache-served → 99% of 100k billed
+      { type: "message", message: { role: "assistant", content: [], usage: { input: 1_000, output: 50, cacheRead: 99_000, cacheWrite: 0, totalTokens: 100_050 } } },
+      // no cache signal (cache-less provider) → excluded
+      { type: "message", message: { role: "assistant", content: [], usage: { input: 5_000, output: 10, cacheRead: 0, cacheWrite: 0, totalTokens: 5_010 } } },
+      // request 2 (last): 180k served + 20k written → 90% of 200k billed
+      { type: "message", message: { role: "assistant", content: [], usage: { input: 0, output: 80, cacheRead: 180_000, cacheWrite: 20_000, totalTokens: 200_080 } } },
+    ],
+  });
+  const notified: string[] = [];
+  const ctx = {
+    ui: { notify: (t: string) => notified.push(t) },
+    getContextUsage: () => ({ tokens: 430_000 }),
+    model: { contextWindow: 1_000_000 },
+    sessionManager: { getSessionId: () => "s3", getSessionFile: () => "/tmp/s3.json" },
+  } as unknown as ExtensionCommandContext;
+
+  const acp = makeCommands(runtime).find((c) => c.name === "acp")!;
+  await acp.options.handler!("", ctx);
+
+  const text = notified[0] ?? "";
+  // session = (99k + 180k) / (100k + 200k) = 93.0%; last = 180k/200k = 90.0%
+  assert.match(text, /Prompt cache \(provider-reported\): 90\.0% last · 93\.0% session avg — 279k of 300k billed prompt tokens served from cache \(2 req\)/, text);
+});
+
+test("/acp panel omits prompt cache section when entries carry no usage", async () => {
+  const runtime = fakeRuntime();
+  (runtime.stateFor as () => Promise<unknown>) = async () => ({
+    state: { blocks: [], stats: { tokensCompressed: 0 }, messageRefs: { byRaw: {}, byRef: {} } },
+    coreMessages: [],
+    entries: [{ type: "message", message: { role: "assistant", content: [] } }],
+  });
+  const notified: string[] = [];
+  const ctx = {
+    ui: { notify: (t: string) => notified.push(t) },
+    getContextUsage: () => ({ tokens: 430_000 }),
+    model: { contextWindow: 1_000_000 },
+    sessionManager: { getSessionId: () => "s4", getSessionFile: () => "/tmp/s4.json" },
+  } as unknown as ExtensionCommandContext;
+
+  const acp = makeCommands(runtime).find((c) => c.name === "acp")!;
+  await acp.options.handler!("", ctx);
+
+  const text = notified[0] ?? "";
+  assert.ok(text, "panel rendered");
+  assert.doesNotMatch(text, /Prompt cache/, `cache section must be omitted without cache-reported requests:\n${text}`);
+});


### PR DESCRIPTION
> **Model**: Claude Sonnet 4.5

## What
Show prompt-cache hit rate in the /acp status panel — real-time (last request) + session average.

Renders only when the provider reports cache usage, e.g.:
```
Prompt cache (provider-reported): 90.0% last · 93.0% session avg — 279k of 300k billed prompt tokens served from cache (2 req)
```

- acp-kernel 0.0.43 → 0.0.44 (panel `cacheUsages` input — kernel PR ranxianglei/acp-kernel#157, released as v0.0.44 via ranxianglei/acp-kernel#158)
- Host side: `cacheUsageSamples()` collects per-assistant-message provider `usage` from session entries (`runtime.stateFor()` already returns them) and feeds `buildStatusPanel`
- Only requests with `cacheRead + cacheWrite > 0` count (providers without cache reporting never drag the average to a fake 0%); section is omitted entirely when no request qualifies

## Tests
+2 end-to-end panel cases (rates rendered from mocked entries; section omitted without usage). Full suite: 411/411 pass, typecheck clean.