### PR TITLE
fix(arbitration): prefer provider-anchored usage over calibrated estimate

### DIFF
--- a/src/arbitration.ts
+++ b/src/arbitration.ts
@@ -1,0 +1,72 @@
+/**
+ * Provider-anchored context arbitration.
+ *
+ * chars/4×density estimates of the sent view can run far below the provider's
+ * real token count (CJK + minified code under-report by 4×+; incident session
+ * 01a02d90: estimated 57K = 51.8% while the provider was already rejecting a
+ * 134.5K prompt). pi's `getContextUsage().tokens` anchors on the provider-
+ * reported usage of the last assistant message (plus an estimated trailing
+ * tail), so when that anchor is trustworthy it beats the local estimate
+ * outright for nudge/emergency arbitration.
+ *
+ * The anchor is NOT trustworthy in two regimes, both observed in the wild:
+ *
+ * 1. Transient post-compression turn: the anchor assistant predates the
+ *    compress, so its usage still reflects the pre-compression (much larger)
+ *    sent view. Consuming it would fire false EMERGENCY nudges right after a
+ *    successful compress (omp issue #18 family). Density's postCompression
+ *    skip (density.ts) uses the same guard.
+ *
+ * 2. Provider-never-reports-usage regime: when no assistant message ever
+ *    carried usage, pi falls back to summing the whole session tree
+ *    (originals included, never shrinks) — after compression that number can
+ *    exceed the window many times over while the real sent view is a few
+ *    percent, producing permanent false EMERGENCY nudges (omp issue #18).
+ *    Detect it the same way pi's compaction does (compaction.ts
+ *    getAssistantUsage): an assistant entry only counts as provider-backed
+ *    when it carries a non-zero usage record.
+ */
+
+export interface UsageLike {
+  tokens: number | null;
+}
+
+export interface EntryLike {
+  type?: string;
+  message?: {
+    role?: string;
+    usage?: {
+      input?: number;
+      totalTokens?: number;
+    };
+  };
+}
+
+/**
+ * Resolve the provider-anchored token count for arbitration, or null when the
+ * anchor must not be consumed this turn.
+ *
+ * Returns `realUsage.tokens` when ALL hold:
+ *  a) it is a positive finite number (pi yields null when it cannot anchor,
+ *     e.g. right after a pi-side compaction with no post-compaction usage);
+ *  b) this is not a post-compression transient turn (guard 1 above);
+ *  c) at least one assistant entry in the merged session view carries a
+ *     non-zero provider usage record (guard 2 above) — mirroring how pi
+ *     decides between usage-anchoring and tree-summing.
+ */
+export function providerAnchoredTokens(
+  realUsage: UsageLike | undefined,
+  entries: readonly EntryLike[],
+  postCompression: boolean,
+): number | null {
+  const tokens = realUsage?.tokens;
+  if (typeof tokens !== "number" || !Number.isFinite(tokens) || tokens <= 0) return null;
+  if (postCompression) return null;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const message = entries[i]?.message;
+    if (message?.role !== "assistant") continue;
+    const usage = message.usage;
+    if ((usage?.totalTokens ?? 0) > 0 || (usage?.input ?? 0) > 0) return tokens;
+  }
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, calibrateTokens } from "./tokens.js";
+import { providerAnchoredTokens } from "./arbitration.js";
 import { checkForUpdate } from "./update.js";
 import {
   THROTTLE_RETRY_ERROR_MESSAGE,
@@ -195,6 +196,30 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // below is fed the RAW sentTokens — its samples must stay on the
       // raw basis or density would chase its own calibration.
       let tokenCount = calibrateTokens(sentTokens, runtime.density.densityFor(modelId));
+      // A compress happened since the previous context round: blocks are
+      // created out-of-band by the compress tool, so detect new active
+      // blocks on the LOADED state vs. the previous round (comparing a
+      // single processTurn's input/output can never see them). Hoisted ABOVE
+      // the provider-anchored arbitration below: post-compression turns must
+      // not consume pi's usage anchor (it predates the shrink — see
+      // arbitration.ts).
+      const postCompression = runtime.noteActiveBlocks(
+        sid,
+        state.blocks.filter((b) => b.active).map((b) => b.blockId),
+      );
+      // Provider-anchored arbitration (incident 01a02d90): when pi's usage
+      // anchor is trustworthy it beats the calibrated estimate outright —
+      // that session arbitrated on 57K (51.8%) while the provider was already
+      // rejecting a 134.5K prompt (4.5× underestimate; density was clamped at
+      // its 2.5 ceiling and could never catch up). Take the LARGER of the
+      // two so a stale-low estimate can never mask a real overflow; the
+      // anchored number already includes pi's estimated trailing tail.
+      // Guarded against post-compression transients and the
+      // provider-never-reports-usage tree-sum regime (omp #18).
+      const anchoredTokens = providerAnchoredTokens(realUsage, entries, postCompression);
+      if (anchoredTokens !== null && anchoredTokens > tokenCount) {
+        tokenCount = anchoredTokens;
+      }
       // Self-heal (armed): after an overflow, force this turn's usage to >=95%
       // so the kernel's emergency nudge + tool-result truncate fire immediately,
       // even if the density-calibrated estimate under-reports the sent view.
@@ -208,14 +233,6 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
           logWarn("overflow-selfheal", { sid, event: "armed-emergency", tokenCount, limit: config.modelContextLimit });
         }
       }
-      // A compress happened since the previous context round: blocks are
-      // created out-of-band by the compress tool, so detect new active
-      // blocks on the LOADED state vs. the previous round (comparing a
-      // single processTurn's input/output can never see them).
-      const postCompression = runtime.noteActiveBlocks(
-        sid,
-        state.blocks.filter((b) => b.active).map((b) => b.blockId),
-      );
 
       debug.event("context-in", {
         sid,
@@ -226,6 +243,7 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         coreMsgs: coreMessages.length,
         tokenCount,
         sessionTokens: realUsage?.tokens ?? null,
+        anchoredTokens,
         limit: config.modelContextLimit,
         blocksBefore: state.blocks.length,
         activeBefore: state.blocks.filter((b) => b.active).length,

--- a/tests/arbitration.test.ts
+++ b/tests/arbitration.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { providerAnchoredTokens } from "../src/arbitration.js";
+
+function assistantEntry(usage?: { input?: number; totalTokens?: number }) {
+  return { type: "message", id: "a1", message: { role: "assistant", usage } };
+}
+function userEntry() {
+  return { type: "message", id: "u1", message: { role: "user" } };
+}
+
+test("providerAnchoredTokens: returns anchored tokens when last assistant carries usage", () => {
+  const entries = [userEntry(), assistantEntry({ input: 8858, totalTokens: 8875 }), userEntry()];
+  assert.equal(providerAnchoredTokens({ tokens: 134569 }, entries, false), 134569);
+});
+
+test("providerAnchoredTokens: skips non-assistant entries in the back-scan", () => {
+  const entries = [assistantEntry({ input: 100 }), userEntry(), userEntry(), { type: "message", id: "t1", message: { role: "toolResult" } }];
+  assert.equal(providerAnchoredTokens({ tokens: 5000 }, entries, false), 5000);
+});
+
+test("providerAnchoredTokens: usage-less assistant tail falls through to an earlier provider-backed assistant", () => {
+  // Tail assistant aborted/error (no usage record) — pi anchors on the earlier
+  // good one, so the number is still provider-backed.
+  const entries = [assistantEntry({ input: 100 }), userEntry(), assistantEntry(undefined), userEntry()];
+  assert.equal(providerAnchoredTokens({ tokens: 45000 }, entries, false), 45000);
+});
+
+test("providerAnchoredTokens: omp #18 — no assistant ever reported usage → distrust (tree-sum regime)", () => {
+  const entries = [assistantEntry(undefined), userEntry(), assistantEntry({ input: 0 }), userEntry()];
+  assert.equal(providerAnchoredTokens({ tokens: 999999 }, entries, false), null);
+});
+
+test("providerAnchoredTokens: empty entries → null", () => {
+  assert.equal(providerAnchoredTokens({ tokens: 1000 }, [], false), null);
+});
+
+test("providerAnchoredTokens: post-compression transient turn → null regardless of anchor", () => {
+  const entries = [assistantEntry({ input: 100 }), userEntry()];
+  assert.equal(providerAnchoredTokens({ tokens: 134569 }, entries, true), null);
+});
+
+test("providerAnchoredTokens: null/zero/non-finite tokens → null (pi cannot anchor)", () => {
+  const entries = [assistantEntry({ input: 100 })];
+  assert.equal(providerAnchoredTokens(undefined, entries, false), null);
+  assert.equal(providerAnchoredTokens({ tokens: null }, entries, false), null);
+  assert.equal(providerAnchoredTokens({ tokens: 0 }, entries, false), null);
+  assert.equal(providerAnchoredTokens({ tokens: Number.NaN }, entries, false), null);
+});
+
+test("providerAnchoredTokens: totalTokens alone counts as provider-backed (OpenAI-style usage)", () => {
+  const entries = [assistantEntry({ totalTokens: 8875 })];
+  assert.equal(providerAnchoredTokens({ tokens: 8875 }, entries, false), 8875);
+});
+
+test("providerAnchoredTokens: all-zero usage record does not count as provider-backed", () => {
+  const entries = [assistantEntry({ input: 0, totalTokens: 0 })];
+  assert.equal(providerAnchoredTokens({ tokens: 70000 }, entries, false), null);
+});


### PR DESCRIPTION
# fix(arbitration): prefer provider-anchored usage over calibrated estimate

> Model: **GLM-5.3** (zhipuai-lb, via pi coding agent) — per AGENTS.md rule 2.
> Branch: `2026-08-23_arbitration-real-usage` (based on `origin/master`) · Commit: `26d83f2`

## Problem

Same incident family as #204, but the deepest layer: the arbitration number itself was fiction.

Session `01a02d90` (2026-08-23) dead-looped on `400 (no body)` from sglang. Autopsy of the session jsonl:

- **953/953 assistant turns carried real provider usage** (pi requests `stream_options.include_usage`, parses it, persists it). The final pre-crash turn reported `{input: 169, cacheRead: 134400}` = **134,569 real context tokens** — already past the effective input limit (`262,144 − 131,072 maxTokens` reserve).
- Yet the per-turn log arbitrated on `tokens=57463 pct=51.8` — a chars/4×density estimate of the sent view, **4.5× below reality**.
- The DensityEstimator was doing its job — acp.log shows `density=2.5` on **831 turns**, i.e. pinned at its ceiling — but the true ratio was ~4.5, so calibration could never catch up and every threshold (75% nudge, 95% emergency) stayed closed while the provider rejected every request.

The correct number was **already in the host**: pi's `getContextUsage().tokens` anchors on the last assistant's provider-reported usage (plus estimated trailing tokens; `calculateContextTokens` includes `cacheRead`). On the very turn the loop started it read >100%. The extension fed it only to `density.update()`, never to arbitration.

## Fix

Arbitrate on `max(calibrated estimate, provider anchor)` — new `src/arbitration.ts`:

```ts
tokenCount = calibrateTokens(sentTokens, densityFor(modelId));
const anchored = providerAnchoredTokens(realUsage, entries, postCompression);
if (anchored !== null && anchored > tokenCount) tokenCount = anchored;
```

The anchor is consumed **only** when trustworthy (`providerAnchoredTokens`, all three guards required):

1. **`realUsage.tokens > 0`** — pi yields `null` when it cannot anchor (e.g. right after a pi-side compaction with no post-compaction usage).
2. **Not a post-compression transient turn** — the anchor assistant predates an ACP compress; consuming it would false-EMERGENCY right after a successful shrink (omp #18 family; same guard as density's `postCompressionSkip`). To enable this, `noteActiveBlocks()` is hoisted above arbitration (was below the self-heal block; called once per context event, unchanged semantics).
3. **Provider-usage regime confirmed** — at least one assistant entry in the merged session view carries a non-zero usage record (same rule pi's compaction `getAssistantUsage` uses). Without it, pi's number is a whole-tree sum that never shrinks — the permanent false-EMERGENCY regime of omp issue #18.

Taking `max()` means a stale-low estimate can never mask a real overflow; the anchored number already includes pi's estimated trailing tail, so it never under-counts what is about to be sent.

Overflow self-heal's armed ≥95% floor still applies **after** arbitration (unchanged).

### Files changed

| File | Change |
|---|---|
| `src/arbitration.ts` (new) | `providerAnchoredTokens(realUsage, entries, postCompression)` + the three-guard rationale. |
| `src/index.ts` | import; hoist `noteActiveBlocks` above arbitration; `anchoredTokens` max-merge; `anchoredTokens` added to the `context-in` debug event. |
| `tests/arbitration.test.ts` (new) | 9 tests. |

## Tests

`npm run typecheck` ✅ · `npm run build` ✅ · `npm test` ✅ **421 pass / 0 fail**:

- anchored tokens returned when last assistant carries usage; back-scan skips user/tool entries
- usage-less assistant tail (aborted/error) falls through to an earlier provider-backed assistant
- omp #18: no assistant ever reported usage → `null` (tree-sum regime distrusted)
- post-compression transient → `null`; empty entries → `null`
- `null`/`0`/`NaN` tokens → `null`; `totalTokens`-only usage counts; all-zero record does not

## Relation to other work

- **`2026-08-23_overflow-nobody-arm`** (no-body 4xx arm): that PR recovers the loop *after* it starts; this PR prevents it from starting — with anchored arbitration the 95% emergency fires on the first genuinely oversized turn.
- **acp-kernel `2026-08-23_toolresult-token-cap`**: hard per-message cap, usage-agnostic. Orthogonal belt-and-braces.
- Closes the root-cause half of **#204**.
