### PR TITLE
release v0.1.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.46",
+	"version": "0.1.47",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.46",
+			"version": "0.1.47",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.44",
+				"acp-kernel": "0.0.45",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.44",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.44.tgz",
-			"integrity": "sha512-4d8XtAVef8uhfil3M4zKMpD1dSZ4CjlkVWfTDOTsuuGCh1Y+i4XvYjpF+yORp9g+5zycshjJg4b4FjfXDItlPw==",
+			"version": "0.0.45",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.45.tgz",
+			"integrity": "sha512-WrRALDcfnNxcdc4ARBOA5gHm5a+Ip1eKXbIHZ3GtWTmWD7hI42zw1pp+mCl3QzwBovciTdKvGSFpFNl2LsaaNQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.46",
+	"version": "0.1.47",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.44",
+		"acp-kernel": "0.0.45",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
> **Model: qwen3.8-27b (vllm)**

## Release v0.1.47

Ships 13 commits since v0.1.46 (all merged to master):

**Features**
- #211 self-disable when `BILLION_CONTEXT_PROXY` is set (co-exists with the bili proxy launcher)
- #213 /acp panel wires prompt-cache hit rate
- #205 CI: per-PR npm preview builds (pr-artifact workflow)
- absorb groundwork via acp-kernel bump

**Fixes**
- #212 guardrail applies documented 200KB `toolOutputMaxBytes` default when unset (#210)
- #209 compress normalizeRanges switches to kernel `parseCompressArgs`
- acp-kernel bumped 0.0.36→…→**0.0.45** (size-aware truncation #133, salvage #109, rejection-loop guard #103, absorb tool #139)

**Release changes** (per repo convention, same as v0.1.46):
- `package.json`: version 0.1.46 → 0.1.47, acp-kernel 0.0.44 → 0.0.45 (0.0.45 is live on npm)
- lockfile refreshed

**Pre-flight** (local, with acp-kernel 0.0.45): typecheck ✅ · 414/414 tests ✅ · build ✅

Merge → release.yml publishes `latest` automatically. Verify with `npm view billion-context-pi version` → 0.1.47.