### PR TITLE
fix(nudge): cap retry-prompt re-injections per unaddressed failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased (master, since v0.1.38)
+- **fix(nudge): 同一失败的压缩重试提示设注入预算（≤5 次/轮）** — "从不重试"的模型让同一失败永远是最新结果，重试提示每次 context fire 重注入（用户日志 ~400 次/小时、attempt 恒 1、emergency pct 95→127%，billion-context#7）；原 3 次封顶只数不同失败调用，对该模式不可达。新增 `MAX_RETRY_PROMPT_FIRES=5`：烧尽后重试提示与 emergency nudge 一并静默（一次性 `compress-retry-exhausted` 日志 + UI 提示），任何新 compress 结果或新用户轮重置预算 (dog/billion-context#7)
 - **fix(guardrail): `toolOutputMaxBytes` 未配置时文档默认值 200000 现在实际生效** — 原接线 `if (max !== undefined && max > 0)` 把「未配置」当成「禁用」，内置 200KB 天花板永远不可达（`capToolOutput` 内部的回退到不了）；pi 只内置 cap bash/read/grep，其余工具可无限注入 context，与 CONFIGURATION.md 承诺的 ACTIVE 默认不符。改为接线层 `?? DEFAULT_TOOL_OUTPUT_MAX_BYTES` 回退，`0`/负数禁用语义不变 (#210)
 
 - **fix(compress): 接受 JSON 字符串形式的 `content` 参数** — 非严格工具 provider（vLLM openai-completions，`supportsStrictTools:false`）会把嵌套数组参数字符串化，pi 的 typebox 校验直接拒掉（`content.0: must be object`）。实测会话 01a00a38 全部唯一一次 compress 调用即死于此，3 小时会话零压缩。schema 改为 `Type.Union([Array, String])`，字符串自动 `JSON.parse` 并校验（错误信息引导模型传数组）

--- a/devlog/2026-08-24_compress-retry-fire-budget/REQ.md
+++ b/devlog/2026-08-24_compress-retry-fire-budget/REQ.md
@@ -1,0 +1,42 @@
+# REQ: 压缩重试提示无限重注入（issue 重复刷屏）
+
+- Task ID: `2026-08-24_compress-retry-fire-budget`
+- Home Repo: `billion-context-pi`
+- Created: 2026-08-24
+- Status: InProgress
+- Priority: P1
+- Owner: ework-daemon
+- References: issue dog/billion-context#7
+
+## 1. Background & Problem Statement
+
+- **Context**: compress 失败后的重试提示（`compress-retry-inject`）设计为"每次 context 事件重新注入，直到模型重试"（pi 每次重建上下文，一次性 append 会消失）。
+- **Current behavior (symptom)**: 用户日志（billion-context#7，billion-context-pi 0.1.41–0.1.47，本地 GGUF 模型 qwen3.8-27b）显示同一 `toolCallId` 的失败被连续重注入 ~400 次/小时（08-23 10:14–11:15+），`attempt` 恒为 1，`emergency-inject` 的 pct 从 95 爬到 127。模型收到重试提示后**从不重试**（不再产生任何新 compress 调用），同一失败永远是"最新结果"，`retryFor` 每次 fire 都置位 → 无限重注入；封顶（`MAX_COMPRESS_ATTEMPTS=3`）只有出现 3 个**不同**的失败调用才可达。emergency nudge 只受 retry-cap 抑制，不受任何注入预算约束，加剧循环。
+- **Expected behavior**:
+  - 同一未处理的失败最多重注入 `MAX_RETRY_PROMPT_FIRES = 5` 次；预算烧完后静默（日志 `compress-retry-exhausted` 一次性记录 + UI 提示），emergency nudge 同步静默。
+  - 任何**新的** compress 结果（成功/失败/no-op）重置预算并解除静默；下一用户轮照常重置。
+  - 封顶语义（3 个不同失败）不变；turnKey 作用域不变。
+- **Impact**: 修复后最坏情况从无限重注入降为 5 次；正常重试路径（模型每次产生新调用）行为不变。
+
+## 2. Reproduction
+
+- **Environment**: win32、本地 openai-completions provider（非严格工具）、小模型不重试 compress。
+- **Minimal reproduction steps**:
+  1) 注入大上下文触发 compress nudge；
+  2) 模型发起一次失败的 compress 调用（如 content 传 JSON 字符串）；
+  3) 模型之后**忽略**所有重试提示（无新调用）；
+  4) 每次 LLM 调用 context fire 都再注入一条重试提示 → 刷屏 + usage 虚高。
+- 集成测试 `emergency nudge quiets once the fire budget is burned by an ignored failure` 复现该路径。
+
+## 3. Constraints & Non-Goals
+
+- **Constraints**: 不引入新依赖；不改变重试提示文案语义（attempt N of M 不变）；不改变 3 次封顶与 per-turn 重置。
+- **Non-Goals**: 不解决"模型为什么失败"（stale refs / JSON 字符串参数已有各自修复）；不做指数退避（固定预算足够）。
+
+## 4. Acceptance Criteria (must be testable)
+
+1. 单元：同一 `toolCallId` 失败重复 fire，`retryFor` 非空次数 = `MAX_RETRY_PROMPT_FIRES`，之后为 null 且 `compressRetryExhaustedFor(turnKey)` 为 true（per-turn）。
+2. 单元：预算耗尽后出现**新**失败 → count 递增、预算重置、exhausted 解除。
+3. 集成：一条失败 + N>预算次 fire → 重试提示恰好出现 MAX 次，之后静默；新失败恢复 attempt 2。
+4. 集成：emergency nudge 在预算烧完后不再重注入；新 compress 结果（即使 no-op）恢复 guidance。
+5. 全量 `npm test` 通过（417+ tests）、`npm run typecheck`、`npm run build` 通过。

--- a/devlog/2026-08-24_compress-retry-fire-budget/WORKLOG.md
+++ b/devlog/2026-08-24_compress-retry-fire-budget/WORKLOG.md
@@ -1,0 +1,38 @@
+# WORKLOG: 压缩重试提示无限重注入（issue 重复刷屏）
+
+- Task ID: `2026-08-24_compress-retry-fire-budget`
+- Home Repo: `billion-context-pi`
+- Status: InProgress
+- Updated: 2026-08-24
+
+## 1. Summary
+
+- **What was done**: 新增 `MAX_RETRY_PROMPT_FIRES = 5` 注入预算——同一未处理失败的 `retryFor` 在预算烧尽后不再置位；`noteCompressOutcomes` 返回新增 `fires`/`exhaustedNow`；新接口 `compressRetryExhaustedFor(turnKey)` 把 exhausted 并入 emergency/nudge 的 alreadyShown 抑制；一次性日志 `compress-retry-exhausted` + UI notify；任何新 compress 结果或新用户轮重置预算。
+- **Why**: billion-context#7 用户日志（0.1.41–0.1.47）显示"从不重试"的模型会让同一失败永远保持最新结果，重试提示每次 context fire 重注入（~400 次/小时，attempt 恒 1，usage 95→127%）。原 3 次封顶只数**不同**失败调用，对"零重试"模型不可达；emergency nudge 无任何预算约束。
+- **Behavior / compatibility changes**: Yes——同一失败的重试提示从无限次降为 ≤5 次/轮；emergency nudge 在预算耗尽后同样静默（此前仅 retry-cap 抑制）。正常重试路径（每次新调用）不受影响。
+- **Risk level**: Low
+
+## 2. Change Log
+
+### Commits
+
+| Commit | Description |
+|--------|-------------|
+| (本分支) | fix(nudge): cap retry-prompt re-injections per unaddressed failure (fire budget) |
+
+### Key files
+
+- `src/runtime.ts` — `MAX_RETRY_PROMPT_FIRES`、`retryPromptFires`/`retryExhaustedNotified` 状态、`noteCompressOutcomes` 返回 `{count, retryFor, cappedNow, exhaustedNow, fires}`、`compressRetryExhaustedFor()`。
+- `src/index.ts` — nudge 门控并入 exhausted 抑制（含 emergency 分支）；`compress-retry-inject` 日志带 `fires`/`fireMax`；`compress-retry-exhausted` 事件 + UI notify。
+- `tests/compress-retry.test.ts` — 新增 3 个测试（unit 预算计数 / 集成 5 次封顶+新失败恢复 / issue #7 emergency 静默+恢复）。
+
+## 3. Verification
+
+- `npm run typecheck` ✅
+- `npm test`：417 tests pass（含新增 3 项）✅
+- `npm run build` ✅
+- 复现路径回归：`emergency nudge quiets once the fire budget is burned by an ignored failure (issue #7 loop breaker)` ✅
+
+## 4. Follow-ups
+
+- 发版走 `*_release-v*` + CI（不手动 publish）；发版后在 billion-context#7 回访用户确认日志不再出现重复注入。

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import type {
 import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-kernel";
 import { renderNudgeText, resolvePrompts, defaultPrompts, viableRanges } from "acp-kernel";
 import { type AdapterConfig, resolveDelegate } from "./config.js";
-import { createRuntime, type AcpRuntime, MAX_COMPRESS_ATTEMPTS } from "./runtime.js";
+import { createRuntime, type AcpRuntime, MAX_COMPRESS_ATTEMPTS, MAX_RETRY_PROMPT_FIRES } from "./runtime.js";
 import { makeCompressTool, isCompressSuccessText, isCompressNoopText } from "./compress-tool.js";
 import { makeDecompressTool } from "./decompress-tool.js";
 import { makeSearchTool } from "./search-tool.js";
@@ -322,8 +322,13 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       // keeps usage pinned at emergency). Once this turn burned
       // MAX_COMPRESS_ATTEMPTS attempts, stop re-injecting the nudge — the
       // kernel's emergency truncation still shrinks context mechanically.
+      // The fire-budget exhaustion (billion-context issue #7: a model that
+      // NEVER retries keeps the same failure newest forever) gets the same
+      // suppression — without it the runaway was ~400 retry re-injections
+      // per hour with usage climbing 95%→127%.
       const retryCapped = runtime.compressRetryCappedFor(turnKey);
-      const alreadyShown = retryCapped || (!emergency && runtime.nudgeShownFor(turnKey));
+      const retryQuiet = retryCapped || runtime.compressRetryExhaustedFor(turnKey);
+      const alreadyShown = retryQuiet || (!emergency && runtime.nudgeShownFor(turnKey));
       if (!alreadyShown) {
         rebuilt.push(nudgeMessage(turn.nudge, turn.state.blocks.filter((b) => b.active), runtime.prompts));
         const rendered = renderNudgeText(turn.nudge, runtime.prompts);
@@ -346,13 +351,19 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const failed = outcome.retryFor !== null ? compressOutcomes.find((o) => o.toolCallId === outcome.retryFor) : undefined;
       if (failed) {
         rebuilt.push(compressRetryMessage(failed.text, outcome.count, MAX_COMPRESS_ATTEMPTS));
-        logWarn("nudge", { sid, event: "compress-retry-inject", attempt: outcome.count, max: MAX_COMPRESS_ATTEMPTS, toolCallId: failed.toolCallId });
+        logWarn("nudge", { sid, event: "compress-retry-inject", attempt: outcome.count, max: MAX_COMPRESS_ATTEMPTS, fires: outcome.fires, fireMax: MAX_RETRY_PROMPT_FIRES, toolCallId: failed.toolCallId });
         debug.event("compress-retry-injected", { sid, turnKey, attempt: outcome.count, toolCallId: failed.toolCallId, text: failed.text.slice(0, 200) });
       } else if (outcome.cappedNow) {
         logWarn("nudge", { sid, event: "compress-retry-capped", failures: outcome.count });
         debug.event("compress-retry-capped", { sid, turnKey, failures: outcome.count });
         if (ctx.hasUI) {
           ctx.ui.notify(`[ACP] compress failed ${outcome.count}× this turn — retry prompts disabled until the next user message.`);
+        }
+      } else if (outcome.exhaustedNow) {
+        logWarn("nudge", { sid, event: "compress-retry-exhausted", failures: outcome.count, fires: outcome.fires, fireMax: MAX_RETRY_PROMPT_FIRES });
+        debug.event("compress-retry-exhausted", { sid, turnKey, failures: outcome.count });
+        if (ctx.hasUI) {
+          ctx.ui.notify(`[ACP] compress retry prompt ignored ${MAX_RETRY_PROMPT_FIRES}× this turn — retry prompts paused until a new compress attempt or the next user message.`);
         }
       }
     }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -74,12 +74,20 @@ export interface AcpRuntime {
    *  failure (count++), success panel (>= 1 block) → reset, other non-error
    *  text → neutral (count unchanged). Returns the failure count, the
    *  toolCallId of the newest failure that still needs a retry prompt (null
-   *  when none, capped, or count 0), and whether the cap was just reached. */
-  noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean };
+   *  when none, capped, count 0, or the per-failure fire budget burned), the
+   *  number of fires the current failure already consumed, and one-shot
+   *  cappedNow/exhaustedNow crossing flags. */
+  noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean; exhaustedNow: boolean; fires: number };
   /** True when this turn already burned MAX_COMPRESS_ATTEMPTS failed/no-op
    *  compress calls — used to stop re-injecting the (dedup-exempt) emergency
    *  nudge that would otherwise keep looping no-op compressions (issue #6). */
   compressRetryCappedFor(turnKey: string): boolean;
+  /** True when this turn has an unaddressed failure below the call cap whose
+   *  retry-prompt fire budget is burned — same emergency-nudge suppression as
+   *  the cap (a model that ignores MAX_RETRY_PROMPT_FIRES prompts in a row
+   *  would otherwise be nagged on every LLM call forever: billion-context
+   *  issue #7, ~400 re-injections/hour, usage 95%→127%). */
+  compressRetryExhaustedFor(turnKey: string): boolean;
   clearNudgeTracking(): void;
   clearCompressRetryTracking(): void;
   liveContextLimit(ctx: ExtensionContext): number;
@@ -237,6 +245,11 @@ function pruneOrphanRefs(state: CompressionState, messages: ReturnType<typeof en
 }
 /** Max FAILED compress calls that get a retry prompt per user turn. */
 export const MAX_COMPRESS_ATTEMPTS = 3;
+/** Max LLM-call re-injections of the retry prompt for one unaddressed
+ *  failure. Without it a model that never retries is nagged on every fire
+ *  forever (billion-context issue #7: ~400 re-injections in one hour, usage
+ *  95%→127%). A NEW outcome (any class) resets the budget. */
+export const MAX_RETRY_PROMPT_FIRES = 5;
 
 export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   const density = new DensityEstimator();
@@ -279,26 +292,34 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   // Failure-triggered compress retry state (see wireContextTransform): a
   // failed compress call consumed the turn's nudge budget while nothing got
   // compressed — re-prompt immediately, capped at MAX_COMPRESS_ATTEMPTS FAILED
-  // CALLS per user turn (prompt frequency within a turn is not capped: the
-  // prompt re-injects on every fire until the model retries — pi rebuilds
-  // context per LLM call, a one-shot append would vanish). The caller feeds
-  // only CURRENT-turn outcomes, so stale failures never re-prompt and the cap
-  // is always reachable; success resets the counter, neutral outcomes
-  // (non-error text that is not a success panel) leave it frozen so mixed
-  // failure modes cannot bypass the cap.
+  // CALLS per user turn. The prompt re-injects per LLM call (pi rebuilds
+  // context each fire, a one-shot append would vanish) but only for
+  // MAX_RETRY_PROMPT_FIRES consecutive fires per failure: a model that never
+  // retries must not be nagged forever (billion-context issue #7). Any NEW
+  // outcome resets the fire budget. The caller feeds only CURRENT-turn
+  // outcomes, so stale failures never re-prompt and the caps are always
+  // reachable; success resets the counter, neutral outcomes (non-error text
+  // that is not a success panel) leave it frozen so mixed failure modes
+  // cannot bypass the cap.
   const compressOutcomeSeen = new Set<string>();
   let compressFailTurnKey: string | null = null;
   let compressFailCount = 0;
+  let retryPromptFires = 0;
+  let retryExhaustedNotified = false;
 
-  function noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean } {
+  function noteCompressOutcomes(turnKey: string, outcomes: ReadonlyArray<{ toolCallId: string; isError: boolean; success: boolean; noop?: boolean }>): { count: number; retryFor: string | null; cappedNow: boolean; exhaustedNow: boolean; fires: number } {
     if (compressFailTurnKey !== turnKey) {
       compressFailTurnKey = turnKey;
       compressFailCount = 0;
+      retryPromptFires = 0;
+      retryExhaustedNotified = false;
     }
     const prevCount = compressFailCount;
+    let sawNewOutcome = false;
     for (const o of outcomes) {
       if (compressOutcomeSeen.has(o.toolCallId)) continue;
       compressOutcomeSeen.add(o.toolCallId);
+      sawNewOutcome = true;
       if (o.isError || o.noop === true) {
         compressFailCount += 1;
       } else if (o.success) {
@@ -306,23 +327,37 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
       }
       // neutral: counter untouched
     }
+    if (sawNewOutcome) {
+      retryPromptFires = 0;
+      retryExhaustedNotified = false;
+    }
     const latest = outcomes.length > 0 ? outcomes[outcomes.length - 1] : undefined;
+    const latestFailed = latest !== undefined && (latest.isError || latest.noop === true);
     // count >= 1 guards against a deduped stale failure sliding in with a
     // reset-to-0 counter (defense in depth; the caller's turn scoping already
     // prevents it — an "attempt 0 of 3" prompt must be impossible).
-    const retryFor = latest && (latest.isError || latest.noop === true) && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS ? latest.toolCallId : null;
+    const retryFor = latestFailed && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS && retryPromptFires < MAX_RETRY_PROMPT_FIRES ? latest!.toolCallId : null;
+    if (retryFor !== null) retryPromptFires += 1;
     const cappedNow = compressFailCount >= MAX_COMPRESS_ATTEMPTS && prevCount < MAX_COMPRESS_ATTEMPTS;
-    return { count: compressFailCount, retryFor, cappedNow };
+    const exhaustedNow = retryFor === null && latestFailed && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS && retryPromptFires >= MAX_RETRY_PROMPT_FIRES && !retryExhaustedNotified;
+    if (exhaustedNow) retryExhaustedNotified = true;
+    return { count: compressFailCount, retryFor, cappedNow, exhaustedNow, fires: retryPromptFires };
   }
 
   function compressRetryCappedFor(turnKey: string): boolean {
     return compressFailTurnKey === turnKey && compressFailCount >= MAX_COMPRESS_ATTEMPTS;
   }
 
+  function compressRetryExhaustedFor(turnKey: string): boolean {
+    return compressFailTurnKey === turnKey && compressFailCount >= 1 && compressFailCount < MAX_COMPRESS_ATTEMPTS && retryPromptFires >= MAX_RETRY_PROMPT_FIRES;
+  }
+
   function clearCompressRetryTracking(): void {
     compressOutcomeSeen.clear();
     compressFailTurnKey = null;
     compressFailCount = 0;
+    retryPromptFires = 0;
+    retryExhaustedNotified = false;
   }
 
   async function acquireLock(sid: string): Promise<() => void> {
@@ -410,4 +445,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     lastActiveBlockIds.delete(sid);
   }
 
-  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}
+  return { core, store, density, setCountModel: (m) => { countModelId = m; }, noteActiveBlocks, clearSessionTracking, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, compressRetryExhaustedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}

--- a/tests/compress-retry.test.ts
+++ b/tests/compress-retry.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { rm } from "node:fs/promises";
 import { createAcpExtension } from "../src/index.js";
-import { createRuntime, MAX_COMPRESS_ATTEMPTS } from "../src/runtime.js";
+import { createRuntime, MAX_COMPRESS_ATTEMPTS, MAX_RETRY_PROMPT_FIRES } from "../src/runtime.js";
 import { isCompressSuccessText, isCompressNoopText } from "../src/compress-tool.js";
 
 // Failure-triggered compress retry (session 01a00a38 post-mortem): the model's
@@ -152,6 +152,33 @@ test("noteCompressOutcomes: counts, caps, resets on success, resets per turn, ne
   assert.equal(r.retryFor, null, "no prompt without a counted failure in this turn");
 });
 
+test("noteCompressOutcomes: one unaddressed failure re-prompts at most MAX_RETRY_PROMPT_FIRES fires", () => {
+  const rt = createRuntime({});
+  const fail = (id: string) => ({ toolCallId: id, isError: true, success: false });
+
+  let prompts = 0;
+  let sawExhausted = false;
+  let last = rt.noteCompressOutcomes("u1", [fail("t0")]);
+  for (let i = 0; i < 11; i++) {
+    last = rt.noteCompressOutcomes("u1", [fail("t0")]);
+    if (last.retryFor !== null) prompts++;
+    if (last.exhaustedNow) sawExhausted = true;
+  }
+  assert.equal(prompts, MAX_RETRY_PROMPT_FIRES - 1, "first call above plus exactly MAX-1 more re-fires prompt");
+  assert.ok(sawExhausted, "exhaustion crossing is reported exactly once");
+  assert.equal(last.retryFor, null, "budget burned: no more prompt for the stale failure");
+  assert.equal(last.count, 1, "same toolCallId stays deduped");
+  assert.equal(rt.compressRetryExhaustedFor("u1"), true);
+  assert.equal(rt.compressRetryExhaustedFor("u2"), false, "exhaustion is per-turn");
+
+  // a NEW failure after exhaustion: attempt advances and the budget resets
+  const r2 = rt.noteCompressOutcomes("u1", [fail("t0"), fail("t1")]);
+  assert.equal(r2.count, 2);
+  assert.equal(r2.retryFor, "t1", "fresh budget for the new failure");
+  assert.equal(r2.fires, 1);
+  assert.equal(rt.compressRetryExhaustedFor("u1"), false, "new outcome lifts exhaustion");
+});
+
 // ─── unit: normalizeRanges via the tool ─────────────────────────────────────
 
 test("compress tool accepts JSON-encoded string content (non-strict-tool providers)", async () => {
@@ -234,6 +261,33 @@ test("failed compress toolResult triggers an immediate retry nudge that quotes t
   entries = [...entries, toolResultMsg("e4", "call_3", VALIDATION_ERR, true)];
   const r4 = await fire(handlers, ctx);
   assert.equal(retryMsgs(r4).length, 0, "cap reached → no retry nudge");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+test("retry nudge stops re-injecting once the fire budget is burned; a new failure gets a fresh budget", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-budget.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  let entries: any[] = [userMsg("e1", ZH)];
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx);
+
+  entries = [...entries, toolResultMsg("e2", "call_1", VALIDATION_ERR, true)];
+  let prompts = 0;
+  for (let i = 0; i < MAX_RETRY_PROMPT_FIRES + 3; i++) {
+    const r = await fire(handlers, ctx);
+    if (retryMsgs(r).length > 0) prompts++;
+  }
+  assert.equal(prompts, MAX_RETRY_PROMPT_FIRES, "one unaddressed failure prompts at most MAX_RETRY_PROMPT_FIRES fires");
+  const rQuiet = await fire(handlers, ctx);
+  assert.equal(retryMsgs(rQuiet).length, 0, "budget burned → silence for the stale failure");
+
+  entries = [...entries, toolResultMsg("e3", "call_2", VALIDATION_ERR, true)];
+  const rRe = await fire(handlers, ctx);
+  assert.equal(retryMsgs(rRe).length, 1, "new failure → fresh budget");
+  assert.match(retryText(rRe), /attempt 2 of 3/);
   await rm(`${stateFile}.acp.json`, { force: true });
 });
 
@@ -424,5 +478,42 @@ test("emergency nudge stops re-injecting once the turn's retry cap is burned (is
   entries = [...entries, toolResultMsg("ec4", "call_4", SUCCESS_PANEL, false)];
   const rRe = await fire(handlers, ctx);
   assert.ok(nudgeCount(rRe) >= 1, "after a successful compress the emergency nudge may resume");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+test("emergency nudge quiets once the fire budget is burned by an ignored failure (issue #7 loop breaker)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 180_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-retry-emerg7.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  const MID = "lorem ".repeat(3000);
+  const roleMsg = (id: string, role: string, text: string) => ({
+    type: "message", id, parentId: null, timestamp: "",
+    message: { role, content: text, timestamp: Date.now() },
+  });
+  let entries: any[] = [roleMsg("e0", "user", "start " + MID)];
+  for (let i = 1; i <= 59; i++) entries.push(roleMsg(`e${i}`, i % 2 ? "assistant" : "user", `f${i} ` + MID));
+  const ctx = fakeCtx(() => entries, stateFile);
+  const nudgeCount = (r: any) =>
+    (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached/.test(JSON.stringify(m.content))).length;
+
+  const r0 = await fire(handlers, ctx);
+  assert.ok(nudgeCount(r0) >= 1, "emergency nudge fires on real overflow");
+
+  // model answers once with a no-op compress, then ignores every retry
+  // prompt (no new outcomes — the failure stays newest forever)
+  entries = [...entries, toolResultMsg("ec1", "call_1", NOOP_PANEL, false)];
+  for (let i = 0; i < MAX_RETRY_PROMPT_FIRES + 2; i++) await fire(handlers, ctx);
+  const rQuiet = await fire(handlers, ctx);
+  assert.equal(nudgeCount(rQuiet), 0, "fire budget burned → emergency nudge no longer re-injects");
+  assert.equal(retryMsgs(rQuiet).length, 0, "retry prompts also quiet");
+
+  // a fresh compress attempt (even another no-op) resets the budget →
+  // guidance resumes so the model gets another chance
+  entries = [...entries, toolResultMsg("ec2", "call_2", NOOP_PANEL, false)];
+  const rRe = await fire(handlers, ctx);
+  assert.ok(nudgeCount(rRe) >= 1, "after a new compress attempt the emergency nudge may resume");
+  assert.equal(retryMsgs(rRe).length, 1, "fresh failure re-prompts at attempt 2");
   await rm(`${stateFile}.acp.json`, { force: true });
 });


### PR DESCRIPTION
## 问题（dog/billion-context#7）

用户日志（billion-context-pi 0.1.41–0.1.47，本地 GGUF 模型）显示同一失败的 compress 调用被无限重注入重试提示：

- 08-23 10:14–11:15+ 同一 `toolCallId` 连续 `compress-retry-inject` ~400 次/小时，`attempt` 恒为 1
- `emergency-inject` pct 95 → 127，每 ~9s 一条
- 08-24 0.1.47 上仍复现（attempt=1 / attempt=2 两个 toolCallId）

## 根因

模型收到重试提示后**从不重试**（不再产生任何新 compress 调用），同一失败永远是"最新结果"，`retryFor` 每次 context fire 都置位 → 无限重注入。原 3 次封顶（`MAX_COMPRESS_ATTEMPTS`）只数**不同**失败调用，对该模式不可达；emergency nudge 只受 retry-cap 抑制、无任何注入预算约束。

## 修复

新增 `MAX_RETRY_PROMPT_FIRES = 5` 注入预算（per turnKey + per 未处理失败）：

- 同一失败的 `retryFor` 最多置位 5 次；烧尽后重试提示与 emergency nudge **一并静默**（一次性 `compress-retry-exhausted` 日志 + UI notify）
- 任何**新的** compress 结果（成功/失败/no-op）重置预算并解除静默；下一用户轮照常重置
- `noteCompressOutcomes` 返回新增 `fires` / `exhaustedNow`；新接口 `compressRetryExhaustedFor(turnKey)` 并入 alreadyShown 门控

最坏情况从无限重注入降为 5 次/轮；正常重试路径（模型每次产生新调用）行为不变。

## 测试

- 新增 3 个测试：unit 预算计数、集成 5 次封顶 + 新失败恢复、issue #7 emergency 静默 + 恢复
- `npm test`：417 tests pass；`npm run typecheck` ✅；`npm run build` ✅

Refs dog/billion-context#7