### PR TITLE
release v0.1.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.47",
+	"version": "0.1.48",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.47",
+			"version": "0.1.48",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.47",
+	"version": "0.1.48",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.48

Clean version-bump release — master has no code changes since v0.1.47 (PR #216).

**Release changes** (per repo convention):
- `package.json`: version 0.1.47 → 0.1.48
- `acp-kernel`: stays **0.0.45** (latest on npm, already pinned — no kernel release pending)
- lockfile refreshed (version fields only)

**Pre-flight** (local): typecheck ✅ · 414/414 tests ✅ · build ✅ (dist 516.87 KB)

**Note on pending PRs** — not included in this cut: #217 (nudge retry cap), #215 (overflow no-body arm), #214 (arbitration real usage), #208 (absorb tool), #206 (update channel), #201, #196, #194. To ship any of them in this release, merge them to master first and refresh this branch (I can do it on request); otherwise merge as-is for a clean bump.

Merge → release.yml publishes `latest` automatically. Verify with `npm view billion-context-pi version` → 0.1.48.

Closes #15