### PR TITLE
fix(delegate): 并发多 agent 失败必达，不再静默 (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased (master, since v0.1.38)
-- **fix(delegate): 并发多 agent 时失败必达，不再静默 (#16)** — async delegate 此前有三条失败路径完全不通知主模型(spawn error、结果持久化 error、`sendUserMessage` 注入丢失)，模型未挂在 `acp_delegate_wait` 上时失败被吞，直到收尾汇总才发现少了结果。现在：所有终止路径 best-effort 注入 `⚠️ FAILED` 通知(带错误摘录，与 sync 路径对齐，明确提示"该任务结果缺失、收尾前决定是否重派")；注入失败的 run 进入未送达集，随**下一个** delegate 通知或任何 delegate 工具结果(`acp_delegate`/`wait`/`cancel`)捎带 Recovery notice 补投；system prompt 补充 FAILED/Recovery 通知说明
+- **fix(delegate): 并发多 agent 时失败必达，不再静默 (#16)** — async delegate 此前有三条失败路径完全不通知主模型(spawn error、结果持久化 error、`sendUserMessage` 注入丢失)，模型未挂在 `acp_delegate_wait` 上时失败被吞，直到收尾汇总才发现少了结果。现在：所有终止路径 best-effort 注入 `FAILED ⚠️` 通知(带错误摘录，与 sync 路径对齐，明确提示"该任务结果缺失、收尾前决定是否重派")；注入失败的 run 进入未送达集，随**下一个** delegate 通知或任何 delegate 工具结果(`acp_delegate`/`wait`/`cancel`)捎带 Recovery notice 补投；Recovery notice 的 delivered 标记改为 carrier 发送成功后才提交（发送抛错不再永久吞掉其他 run 的结果）；system prompt 补充 FAILED/Recovery 通知说明
+- **fix(delegate): bad cwd 等即时 spawn 失败不再击穿宿主 (#16)** — `OUT_DIR` 的 `mkdir` 原本夹在 `spawn()` 与 `child.on("error")` 注册之间：不存在的工作目录使 spawn 立即 ENOENT，错误事件先于监听器注册到达 → uncaughtException → 整个 pi 会话被杀。现在 mkdir 提前到 spawn 之前，spawn 到 close/error 处理器注册全程同步，tmux 实测原崩溃场景稳定注入 FAILED ⚠️ 且宿主存活
 - **fix(guardrail): `toolOutputMaxBytes` 未配置时文档默认值 200000 现在实际生效** — 原接线 `if (max !== undefined && max > 0)` 把「未配置」当成「禁用」，内置 200KB 天花板永远不可达（`capToolOutput` 内部的回退到不了）；pi 只内置 cap bash/read/grep，其余工具可无限注入 context，与 CONFIGURATION.md 承诺的 ACTIVE 默认不符。改为接线层 `?? DEFAULT_TOOL_OUTPUT_MAX_BYTES` 回退，`0`/负数禁用语义不变 (#210)
 
 - **fix(compress): 接受 JSON 字符串形式的 `content` 参数** — 非严格工具 provider（vLLM openai-completions，`supportsStrictTools:false`）会把嵌套数组参数字符串化，pi 的 typebox 校验直接拒掉（`content.0: must be object`）。实测会话 01a00a38 全部唯一一次 compress 调用即死于此，3 小时会话零压缩。schema 改为 `Type.Union([Array, String])`，字符串自动 `JSON.parse` 并校验（错误信息引导模型传数组）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased (master, since v0.1.38)
+- **fix(delegate): 并发多 agent 时失败必达，不再静默 (#16)** — async delegate 此前有三条失败路径完全不通知主模型(spawn error、结果持久化 error、`sendUserMessage` 注入丢失)，模型未挂在 `acp_delegate_wait` 上时失败被吞，直到收尾汇总才发现少了结果。现在：所有终止路径 best-effort 注入 `⚠️ FAILED` 通知(带错误摘录，与 sync 路径对齐，明确提示"该任务结果缺失、收尾前决定是否重派")；注入失败的 run 进入未送达集，随**下一个** delegate 通知或任何 delegate 工具结果(`acp_delegate`/`wait`/`cancel`)捎带 Recovery notice 补投；system prompt 补充 FAILED/Recovery 通知说明
 - **fix(guardrail): `toolOutputMaxBytes` 未配置时文档默认值 200000 现在实际生效** — 原接线 `if (max !== undefined && max > 0)` 把「未配置」当成「禁用」，内置 200KB 天花板永远不可达（`capToolOutput` 内部的回退到不了）；pi 只内置 cap bash/read/grep，其余工具可无限注入 context，与 CONFIGURATION.md 承诺的 ACTIVE 默认不符。改为接线层 `?? DEFAULT_TOOL_OUTPUT_MAX_BYTES` 回退，`0`/负数禁用语义不变 (#210)
 
 - **fix(compress): 接受 JSON 字符串形式的 `content` 参数** — 非严格工具 provider（vLLM openai-completions，`supportsStrictTools:false`）会把嵌套数组参数字符串化，pi 的 typebox 校验直接拒掉（`content.0: must be object`）。实测会话 01a00a38 全部唯一一次 compress 调用即死于此，3 小时会话零压缩。schema 改为 `Type.Union([Array, String])`，字符串自动 `JSON.parse` 并校验（错误信息引导模型传数组）

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The full delegate result is saved to a file (`/tmp/acp-delegate/<runId>.out`); t
 
 - **Interactive (TUI) & RPC modes**: `async:true` (default) runs the child in the background; a short completion notification is injected into the chat when it finishes.
 - **Print / JSON modes** (`pi -p`, SDK): `async:true` auto-downgrades to **synchronous** — the result returns as the tool result in the same turn (the parent exits after one turn, so background injection would be lost).
-- **Failures are loud, never silent.** A run that fails (nonzero exit, spawn error, watchdog timeout) injects a `⚠️ FAILED` notification carrying a short error excerpt, so a failed delegate cannot hide among sibling completions. If a notification cannot be delivered at all, a recovery notice is attached to the next delegate notification or the next `acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel` tool result — a dispatched run's failure always reaches the model before it wraps up.
+- **Failures are loud, never silent.** A run that fails (nonzero exit, spawn error, watchdog timeout) injects a `FAILED ⚠️` notification carrying a short error excerpt, so a failed delegate cannot hide among sibling completions. If a notification cannot be delivered at all, a recovery notice is attached to the next delegate notification or the next `acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel` tool result — a dispatched run's failure always reaches the model before it wraps up.
 
 In the **interactive TUI**, async runs also show a live status widget below the editor (agent, elapsed seconds, task preview), so you always know what's running and for how long. Disabled automatically in RPC/print/JSON.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The full delegate result is saved to a file (`/tmp/acp-delegate/<runId>.out`); t
 
 - **Interactive (TUI) & RPC modes**: `async:true` (default) runs the child in the background; a short completion notification is injected into the chat when it finishes.
 - **Print / JSON modes** (`pi -p`, SDK): `async:true` auto-downgrades to **synchronous** — the result returns as the tool result in the same turn (the parent exits after one turn, so background injection would be lost).
+- **Failures are loud, never silent.** A run that fails (nonzero exit, spawn error, watchdog timeout) injects a `⚠️ FAILED` notification carrying a short error excerpt, so a failed delegate cannot hide among sibling completions. If a notification cannot be delivered at all, a recovery notice is attached to the next delegate notification or the next `acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel` tool result — a dispatched run's failure always reaches the model before it wraps up.
 
 In the **interactive TUI**, async runs also show a live status widget below the editor (agent, elapsed seconds, task preview), so you always know what's running and for how long. Disabled automatically in RPC/print/JSON.
 

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -731,6 +731,11 @@ async function runDelegate(
   debug.event("delegate-spawn", { agent: args.agent, runId, cwd, async: isAsync, useJsonStream, cliArgs });
   logInfo("delegate", { event: "spawn", agent: args.agent, runId, cwd, async: isAsync, useJsonStream, mode: ctx.mode, parentDepth });
 
+  // Prepared before spawn: everything from spawn() to the child event handlers
+  // must stay synchronous — an await in between lets a fast spawn failure
+  // (ENOENT from a missing cwd) fire 'error' before any listener attaches,
+  // which escalates to an uncaughtException and kills the host process.
+  await mkdir(OUT_DIR, { recursive: true });
   const child = spawn(
     process.execPath,
     [resolvePiCliEntry(process.argv[1] ?? "", process.env, isPiHost(ctx.sessionManager)), ...cliArgs],
@@ -773,7 +778,6 @@ async function runDelegate(
     // reply and there is no tool activity to stream, so no .activity file.
     const replyFile = join(OUT_DIR, `${runId}.out`);
     const activityFile = join(OUT_DIR, `${runId}.activity`);
-    await mkdir(OUT_DIR, { recursive: true });
     const replyStream = createWriteStream(replyFile, { flags: "a" });
     const activityStream = useJsonStream ? createWriteStream(activityFile, { flags: "a" }) : null;
     const endStream = (s: WriteStream | null): Promise<void> =>

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -454,7 +454,7 @@ function formatRunResult(run: DelegateRun): string {
   const header =
     run.status === "completed"
       ? `Delegate **${run.agent}** (runId \`${run.runId}\`) completed (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`
-      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status} (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`;
+      : `Delegate **${run.agent}** (runId \`${run.runId}\`) ${run.status === "failed" ? "FAILED ⚠️" : run.status} (exit ${run.exitCode ?? "?"})${timeoutNote}${remainingLineForWait(run.runId)}`;
   return formatPayload(header, run.result?.file ?? "", run.task, run.result?.body);
 }
 
@@ -1050,7 +1050,7 @@ function waitForChild(child: ChildProcess, signal: AbortSignal | undefined): Pro
 }
 
 function formatSyncResult(agent: string, runId: string, task: string, r: ChildResult, file: string): string {
-  const status = r.timedOut ? "timed out" : r.code === 0 ? "completed" : "failed";
+  const status = r.timedOut ? "timed out" : r.code === 0 ? "completed" : "FAILED ⚠️";
   const header = `Delegate **${agent}** ${status} (runId \`${runId}\`, exit ${r.code ?? "?"}).`;
   if (r.code === 0 && !r.timedOut) {
     return formatPayload(header, file, task);

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -435,12 +435,15 @@ The delegate runs in its own clean pi process — it does NOT see this conversat
       "Delegate to get a focused result in a clean context, or to parallelize independent work.",
       "The sub-agent has NO access to this conversation — write a fully self-contained task.",
       "Prefer async=true and launch several; results arrive back automatically when each finishes.",
+      "A FAILED notification (⚠️) means that task produced no usable result — decide whether to re-dispatch it before wrapping up.",
       "For changes you must apply yourself, delegate read-only investigation (reviewer/researcher/oracle) and keep the main context as the sole writer.",
     ],
     parameters: DelegateParams,
     async execute(toolCallId, params, signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
       const args = params as DelegateArgs;
-      const outcome = await runDelegate(pi, args, ctx, signal);
+      let outcome = await runDelegate(pi, args, ctx, signal);
+      const notice = undeliveredNotice();
+      if (notice) outcome = `${notice}\n\n${outcome}`;
       return { details: undefined, content: [{ type: "text", text: outcome }] };
     },
   };
@@ -459,6 +462,47 @@ function formatRunResult(run: DelegateRun): string {
 function remainingLineForWait(selfRunId: string): string {
   const remaining = Array.from(runs.values()).filter((r) => r.status === "running" && r.runId !== selfRunId).length;
   return remaining > 0 ? ` ${remaining} delegate${remaining === 1 ? " is" : "s are"} still running.` : "";
+}
+
+/** Runs that reached a terminal state but whose result never reached the
+ *  model: no parked waiter, not consumed by a tool result, and never injected
+ *  as a notification. The model was promised a notification ("do NOT keep
+ *  waiting"), so these must eventually be recovered, or a failed delegate
+ *  stays invisible until the very end of the task. */
+export function findUndeliveredRuns(all: DelegateRun[], excludeRunId?: string): DelegateRun[] {
+  return all.filter(
+    (r) =>
+      r.runId !== excludeRunId &&
+      (r.status === "completed" || r.status === "failed") &&
+      !r.waiter &&
+      !r.consumed &&
+      !r.injected,
+  );
+}
+
+/** Build a recovery notice for undelivered runs. Marks each covered run
+ *  injected=true (this notice IS its delivery) so it is never re-notified and
+ *  a later wait dedups instead of re-delivering the payload. */
+export function undeliveredNoticeFrom(all: DelegateRun[], excludeRunId?: string): string {
+  const pending = findUndeliveredRuns(all, excludeRunId);
+  if (pending.length === 0) return "";
+  for (const r of pending) r.injected = true;
+  const anyFailed = pending.some((r) => r.status === "failed");
+  const header = `⚠️ Recovery notice: ${pending.length} earlier delegate result${pending.length === 1 ? "" : "s"} never reached you (notification delivery failed).${anyFailed ? " At least one FAILED — that task's work is missing; read its result below and decide whether to re-dispatch before concluding." : ""}`;
+  return [header, ...pending.map((r) => formatRunResult(r))].join("\n");
+}
+
+function undeliveredNotice(excludeRunId?: string): string {
+  return undeliveredNoticeFrom(Array.from(runs.values()), excludeRunId);
+}
+
+/** Attach the recovery notice (if any) to a delegate tool result, so a lost
+ *  notification resurfaces at the next delegate interaction. */
+function withUndeliveredNotice(result: AgentToolResult<unknown>): AgentToolResult<unknown> {
+  const notice = undeliveredNotice();
+  const first = result.content[0];
+  if (notice && first && first.type === "text") first.text = `${notice}\n\n${first.text}`;
+  return result;
 }
 
 /** If the delegate already delivered its result via a system notification
@@ -525,8 +569,80 @@ export function buildCancelResult(
 }
 
 export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof WaitParams> {
-  return {
-    name: "acp_delegate_wait",
+  const exec = async (args: { runId: string; timeout?: number }, signal?: AbortSignal): Promise<AgentToolResult<unknown>> => {
+  const run = runs.get(args.runId);
+    if (!run) {
+      return { details: undefined, content: [{ type: "text" as const, text: `No delegate run with runId \`${args.runId}\`. It may have already been reported or never existed.` }] };
+    }
+    // Already finished (e.g. the model calls wait after the injected
+    // notification, or the run was cancelled).
+    const displayMode = delegateDisplayUsage;
+    if (run.status === "cancelled") {
+      run.consumed = true;
+      return buildWaitResult(run, `Delegate \`${args.runId}\` was cancelled (no result).${remainingLineForWait(args.runId)}`, displayMode);
+    }
+    if (run.status !== "running") {
+      // The delegate already finished. If the close handler already injected
+      // its result as a system notification (it fired before this wait was
+      // called), don't re-deliver the full payload — point at the file
+      // instead, so the model never sees the same result twice.
+      const dedup = injectedWaitMessage(run, args.runId, remainingLineForWait(args.runId));
+      if (dedup) {
+        run.consumed = true;
+        return buildWaitResult(run, dedup, displayMode);
+      }
+      // status is only flipped together with result (see close handler), so
+      // a non-running, non-cancelled run always has a result. Guard anyway.
+      run.consumed = true;
+      if (!run.result) {
+        return buildWaitResult(run, `Delegate \`${args.runId}\` finished but no result is available (persist error).`, displayMode);
+      }
+      return buildWaitResult(run, formatRunResult(run), displayMode);
+    }
+    const timeoutMs = resolveWaitTimeoutMs(args.timeout);
+    // Refuse to park a second waiter on the same run: a second wait would
+    // overwrite run.waiter and orphan the first wait's listener/timer.
+    if (run.waiter) {
+      return { details: undefined, content: [{ type: "text", text: `Delegate \`${args.runId}\` already has a wait in progress; do not wait on it twice.` }] };
+    }
+    // Park a waiter; the close handler resolves it (and the result is owned
+    // by this tool, so no injection duplicates it).
+    return new Promise((resolve) => {
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = (result: { details: undefined; content: { type: "text"; text: string }[]; usage?: AgentToolResult<unknown>["usage"] }) => {
+        if (settled) return;
+        settled = true;
+        run.waiter = undefined;
+        if (timer) clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+        resolve(result);
+      };
+      const onAbort = () => {
+        finish({ details: undefined, content: [{ type: "text", text: `Aborted; delegate \`${args.runId}\` is still running in the background. A notification will be injected when it finishes.` }] });
+      };
+      run.waiter = () => {
+        run.consumed = true; // we own the result; suppress injection
+        if (run.status === "cancelled") {
+          // Same message as the cancel-then-wait early-return path, for consistency.
+          // Don't go through formatRunResult — cancelled runs have no result, and
+          // formatPayload would render a misleading "could not be persisted" line.
+          // Partial usage (if any) is accumulated per displayMode like the
+          // early-return path.
+          finish(buildWaitResult(run, `Delegate \`${run.runId}\` was cancelled (no result).${remainingLineForWait(run.runId)}`, displayMode));
+          return;
+        }
+        finish(buildWaitResult(run, formatRunResult(run), displayMode));
+      };
+      signal?.addEventListener("abort", onAbort);
+      timer = setTimeout(
+        () => finish({ details: undefined, content: [{ type: "text", text: `Failed: delegate \`${args.runId}\` result not ready after ${Math.round(timeoutMs / 1000)}s. Do NOT keep waiting or retry — go do other work now. The run continues in the background and a completion notification (with the result file path) will be injected into the chat when it finishes.` }] }),
+        timeoutMs,
+      );
+    });
+  };
+return {
+  name: "acp_delegate_wait",
     label: "ACP Delegate Wait",
     description:
       "Block until an acp_delegate async run finishes, then return its result (status + file path). This is the ONLY way to fetch a delegate's result — there is no non-blocking status tool, so you cannot poll. Default timeout is 10s (max 300s). If the delegate finishes within the timeout, its result is returned here (same format as a sync delegate). If it times out, the run keeps going in the background and you should STOP waiting — do not retry in a loop; go do other work, and a completion notification will still be injected into the chat when it finishes.",
@@ -537,82 +653,33 @@ export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof W
     ],
     parameters: WaitParams,
     async execute(_toolCallId, params, signal): Promise<AgentToolResult<unknown>> {
-      const args = params as { runId: string; timeout?: number };
-      const run = runs.get(args.runId);
-      if (!run) {
-        return { details: undefined, content: [{ type: "text" as const, text: `No delegate run with runId \`${args.runId}\`. It may have already been reported or never existed.` }] };
-      }
-      // Already finished (e.g. the model calls wait after the injected
-      // notification, or the run was cancelled).
-      const displayMode = delegateDisplayUsage;
-      if (run.status === "cancelled") {
-        run.consumed = true;
-        return buildWaitResult(run, `Delegate \`${args.runId}\` was cancelled (no result).${remainingLineForWait(args.runId)}`, displayMode);
-      }
-      if (run.status !== "running") {
-        // The delegate already finished. If the close handler already injected
-        // its result as a system notification (it fired before this wait was
-        // called), don't re-deliver the full payload — point at the file
-        // instead, so the model never sees the same result twice.
-        const dedup = injectedWaitMessage(run, args.runId, remainingLineForWait(args.runId));
-        if (dedup) {
-          run.consumed = true;
-          return buildWaitResult(run, dedup, displayMode);
-        }
-        // status is only flipped together with result (see close handler), so
-        // a non-running, non-cancelled run always has a result. Guard anyway.
-        run.consumed = true;
-        if (!run.result) {
-          return buildWaitResult(run, `Delegate \`${args.runId}\` finished but no result is available (persist error).`, displayMode);
-        }
-        return buildWaitResult(run, formatRunResult(run), displayMode);
-      }
-      const timeoutMs = resolveWaitTimeoutMs(args.timeout);
-      // Refuse to park a second waiter on the same run: a second wait would
-      // overwrite run.waiter and orphan the first wait's listener/timer.
-      if (run.waiter) {
-        return { details: undefined, content: [{ type: "text", text: `Delegate \`${args.runId}\` already has a wait in progress; do not wait on it twice.` }] };
-      }
-      // Park a waiter; the close handler resolves it (and the result is owned
-      // by this tool, so no injection duplicates it).
-      return new Promise((resolve) => {
-        let settled = false;
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const finish = (result: { details: undefined; content: { type: "text"; text: string }[]; usage?: AgentToolResult<unknown>["usage"] }) => {
-          if (settled) return;
-          settled = true;
-          run.waiter = undefined;
-          if (timer) clearTimeout(timer);
-          signal?.removeEventListener("abort", onAbort);
-          resolve(result);
-        };
-        const onAbort = () => {
-          finish({ details: undefined, content: [{ type: "text", text: `Aborted; delegate \`${args.runId}\` is still running in the background. A notification will be injected when it finishes.` }] });
-        };
-        run.waiter = () => {
-          run.consumed = true; // we own the result; suppress injection
-          if (run.status === "cancelled") {
-            // Same message as the cancel-then-wait early-return path, for consistency.
-            // Don't go through formatRunResult — cancelled runs have no result, and
-            // formatPayload would render a misleading "could not be persisted" line.
-            // Partial usage (if any) is accumulated per displayMode like the
-            // early-return path.
-            finish(buildWaitResult(run, `Delegate \`${run.runId}\` was cancelled (no result).${remainingLineForWait(run.runId)}`, displayMode));
-            return;
-          }
-          finish(buildWaitResult(run, formatRunResult(run), displayMode));
-        };
-        signal?.addEventListener("abort", onAbort);
-        timer = setTimeout(
-          () => finish({ details: undefined, content: [{ type: "text", text: `Failed: delegate \`${args.runId}\` result not ready after ${Math.round(timeoutMs / 1000)}s. Do NOT keep waiting or retry — go do other work now. The run continues in the background and a completion notification (with the result file path) will be injected into the chat when it finishes.` }] }),
-          timeoutMs,
-        );
-      });
+      return withUndeliveredNotice(await exec(params as { runId: string; timeout?: number }, signal));
     },
   };
 }
 
 export function makeDelegateCancelTool(_pi: ExtensionAPI): ToolDefinition<typeof CancelParams> {
+  const exec = async (params: Static<typeof CancelParams>): Promise<AgentToolResult<unknown>> => {
+    const { runId } = params;
+    const run = runs.get(runId);
+    if (!run) {
+      return { details: undefined, content: [{ type: "text", text: `Unknown runId "${runId}".` }] };
+    }
+    if (run.status !== "running") {
+      return buildCancelResult(run, `Run ${runId} already ${run.status} (no action).`);
+    }
+    run.status = "cancelled";
+    run.consumed = true; // suppress injection; the waiter (if any) gets cancelled status
+    try {
+      run.child?.kill("SIGTERM");
+    } catch (err) {
+      debug.event("delegate-cancel-kill-error", { runId, error: String(err) });
+      logError("delegate", { event: "cancel-kill-error", runId, error: String(err) });
+    }
+    delegateStatusWidget.poke();
+    const displayMode = delegateDisplayUsage;
+    return buildCancelResult(run, `Cancelled ${runId} (${run.agent}).`, displayMode);
+  };
   return {
     name: "acp_delegate_cancel",
     label: "ACP Delegate Cancel",
@@ -622,25 +689,7 @@ export function makeDelegateCancelTool(_pi: ExtensionAPI): ToolDefinition<typeof
     promptGuidelines: [],
     parameters: CancelParams,
     async execute(toolCallId, params): Promise<AgentToolResult<unknown>> {
-      const { runId } = params as Static<typeof CancelParams>;
-      const run = runs.get(runId);
-      if (!run) {
-        return { details: undefined, content: [{ type: "text", text: `Unknown runId "${runId}".` }] };
-      }
-      if (run.status !== "running") {
-        return buildCancelResult(run, `Run ${runId} already ${run.status} (no action).`);
-      }
-      run.status = "cancelled";
-      run.consumed = true; // suppress injection; the waiter (if any) gets cancelled status
-      try {
-        run.child?.kill("SIGTERM");
-      } catch (err) {
-        debug.event("delegate-cancel-kill-error", { runId, error: String(err) });
-        logError("delegate", { event: "cancel-kill-error", runId, error: String(err) });
-      }
-      delegateStatusWidget.poke();
-      const displayMode = delegateDisplayUsage;
-      return buildCancelResult(run, `Cancelled ${runId} (${run.agent}).`, displayMode);
+      return withUndeliveredNotice(await exec(params as Static<typeof CancelParams>));
     },
   };
 }
@@ -833,7 +882,7 @@ async function runDelegate(
             return;
           }
           const mode = delegateDisplayUsage;
-          const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut, run.usage, mode, run.usageReported);
+          const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut, run.usage, mode, run.usageReported, run.status === "failed" ? body : undefined);
           if (run.usage && !run.usageReported && (mode === "separate" || injected)) {
             run.usageReported = true;
           }
@@ -846,7 +895,7 @@ async function runDelegate(
           run.finishedAt = Date.now();
           debug.event("delegate-done-error", { runId, error: String(err) });
           logError("delegate", { event: "done-error", runId, agent: args.agent, error: String(err) });
-          run.waiter?.();
+          notifyTerminalFailure(pi, run, `result persistence error: ${String(err)}`);
           delegateStatusWidget.poke();
         }
       })();
@@ -873,7 +922,8 @@ async function runDelegate(
         run.result = { code: null, file: "", body: `spawn error: ${String(err)}` };
         debug.event("delegate-spawn-error", { runId, error: String(err) });
         logError("delegate", { event: "spawn-error", runId, agent: args.agent, error: String(err) });
-        run.waiter?.();
+        if (run.status === "failed") notifyTerminalFailure(pi, run, `spawn error: ${String(err)}`);
+        else run.waiter?.();
         delegateStatusWidget.poke();
       }
     });
@@ -1020,6 +1070,7 @@ export function injectResult(
   usage?: Usage,
   mode: "merged" | "separate" = "separate",
   usageAlreadyReported?: boolean,
+  body?: string,
 ): boolean {
   const send = pi.sendUserMessage;
   if (typeof send !== "function") {
@@ -1027,7 +1078,8 @@ export function injectResult(
     logWarn("delegate", { event: "inject-skipped", runId, reason: "sendUserMessage unavailable" });
     return false;
   }
-  const status = code === 0 ? "completed" : "failed";
+  const failed = code !== 0;
+  const status = failed ? "FAILED ⚠️" : "completed";
   // Tell the model how many other delegates are still running, so it doesn't
   // lose count when many were dispatched in a batch (e.g. launched 5, this is
   // the 2nd to return → "3 still running" → the model knows to keep waiting).
@@ -1071,8 +1123,12 @@ export function injectResult(
     if (lines.length) usageNote = ` Usage: ${lines.join(", ")}.`;
   }
   
-  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine}${usageNote} This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.`;
-  const text = formatPayload(header, file, task);
+  const closing = failed
+    ? "This delegate did NOT complete its task — its result is missing from your work. Read the error excerpt (and the result file if present), then decide whether to re-dispatch the task before wrapping up. This is an automated system notification, NOT a user message."
+    : "This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.";
+  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine}${usageNote} ${closing}`;
+  const recovery = undeliveredNotice(runId);
+  const text = formatPayload(header, file, task, failed ? body : undefined) + (recovery ? `\n\n${recovery}` : "");
   try {
     // sendUserMessage is fire-and-forget (returns void): it enqueues a
     // follow-up turn. Interactive/rpc sessions consume it via their main loop;
@@ -1084,6 +1140,34 @@ export function injectResult(
     logError("delegate", { event: "inject-error", runId, agent, error: String(err) });
     return false;
   }
+}
+
+/** Deliver a terminal failure that occurred OUTSIDE normal finalize (spawn
+ *  error, result persistence error). A parked waiter owns the result; with no
+ *  waiter the model must still learn the run failed — inject best-effort, and
+ *  runs whose injection also fails land in the undelivered set for recovery. */
+function notifyTerminalFailure(pi: ExtensionAPI, run: DelegateRun, body: string): void {
+  const hadWaiter = run.waiter !== undefined;
+  run.waiter?.();
+  if (hadWaiter || run.consumed) return;
+  const mode = delegateDisplayUsage;
+  const injected = injectResult(
+    pi,
+    run.agent,
+    run.runId,
+    run.task,
+    run.result?.code ?? null,
+    run.result?.file ?? "",
+    run.timedOut,
+    run.usage,
+    mode,
+    run.usageReported,
+    body,
+  );
+  if (run.usage && !run.usageReported && (mode === "separate" || injected)) {
+    run.usageReported = true;
+  }
+  run.injected = injected;
 }
 
 // Build the lightweight payload: a header, the task title (so the model

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -480,16 +480,27 @@ export function findUndeliveredRuns(all: DelegateRun[], excludeRunId?: string): 
   );
 }
 
-/** Build a recovery notice for undelivered runs. Marks each covered run
- *  injected=true (this notice IS its delivery) so it is never re-notified and
- *  a later wait dedups instead of re-delivering the payload. */
-export function undeliveredNoticeFrom(all: DelegateRun[], excludeRunId?: string): string {
+/** Compute the recovery notice for undelivered runs WITHOUT marking them
+ *  delivered. The caller commits the marking (covered[].injected = true) only
+ *  after the carrier message is actually sent: if the send throws, the runs
+ *  must stay undelivered so a later carrier can recover them. */
+export function buildRecoveryNotice(all: DelegateRun[], excludeRunId?: string): { text: string; covered: DelegateRun[] } {
   const pending = findUndeliveredRuns(all, excludeRunId);
-  if (pending.length === 0) return "";
-  for (const r of pending) r.injected = true;
+  if (pending.length === 0) return { text: "", covered: [] };
   const anyFailed = pending.some((r) => r.status === "failed");
   const header = `⚠️ Recovery notice: ${pending.length} earlier delegate result${pending.length === 1 ? "" : "s"} never reached you (notification delivery failed).${anyFailed ? " At least one FAILED — that task's work is missing; read its result below and decide whether to re-dispatch before concluding." : ""}`;
-  return [header, ...pending.map((r) => formatRunResult(r))].join("\n");
+  return { text: [header, ...pending.map((r) => formatRunResult(r))].join("\n"), covered: pending };
+}
+
+/** Build a recovery notice for undelivered runs and mark each covered run
+ *  injected=true (this notice IS its delivery) so it is never re-notified and
+ *  a later wait dedups instead of re-delivering the payload. For carriers the
+ *  host owns (delegate tool results); injectResult commits the marking itself
+ *  only after its send succeeds (see buildRecoveryNotice). */
+export function undeliveredNoticeFrom(all: DelegateRun[], excludeRunId?: string): string {
+  const { text, covered } = buildRecoveryNotice(all, excludeRunId);
+  for (const r of covered) r.injected = true;
+  return text;
 }
 
 function undeliveredNotice(excludeRunId?: string): string {
@@ -519,7 +530,7 @@ export function injectedWaitMessage(
   if (!run.injected) return null;
   const file = run.result?.file;
   const fileLine = file ? ` If you need details, read the result file: \`${file}\`.` : "";
-  return `Delegate \`${runId}\` already delivered its result via a system notification when it finished — no need to wait on it again.${remainingLine}${fileLine}`;
+  return `Delegate \`${runId}\` already delivered its result (system notification or recovery notice) when it finished — no need to wait on it again.${remainingLine}${fileLine}`;
 }
 
 /** Build usage-aware return payload. Sets usageReported=true so subsequent
@@ -570,7 +581,7 @@ export function buildCancelResult(
 
 export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof WaitParams> {
   const exec = async (args: { runId: string; timeout?: number }, signal?: AbortSignal): Promise<AgentToolResult<unknown>> => {
-  const run = runs.get(args.runId);
+    const run = runs.get(args.runId);
     if (!run) {
       return { details: undefined, content: [{ type: "text" as const, text: `No delegate run with runId \`${args.runId}\`. It may have already been reported or never existed.` }] };
     }
@@ -641,8 +652,8 @@ export function makeDelegateWaitTool(_pi: ExtensionAPI): ToolDefinition<typeof W
       );
     });
   };
-return {
-  name: "acp_delegate_wait",
+  return {
+    name: "acp_delegate_wait",
     label: "ACP Delegate Wait",
     description:
       "Block until an acp_delegate async run finishes, then return its result (status + file path). This is the ONLY way to fetch a delegate's result — there is no non-blocking status tool, so you cannot poll. Default timeout is 10s (max 300s). If the delegate finishes within the timeout, its result is returned here (same format as a sync delegate). If it times out, the run keeps going in the background and you should STOP waiting — do not retry in a loop; go do other work, and a completion notification will still be injected into the chat when it finishes.",
@@ -1131,13 +1142,16 @@ export function injectResult(
     ? "This delegate did NOT complete its task — its result is missing from your work. Read the error excerpt (and the result file if present), then decide whether to re-dispatch the task before wrapping up. This is an automated system notification, NOT a user message."
     : "This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.";
   const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine}${usageNote} ${closing}`;
-  const recovery = undeliveredNotice(runId);
-  const text = formatPayload(header, file, task, failed ? body : undefined) + (recovery ? `\n\n${recovery}` : "");
+  const { text: recoveryText, covered } = buildRecoveryNotice(Array.from(runs.values()), runId);
+  const text = formatPayload(header, file, task, failed ? body : undefined) + (recoveryText ? `\n\n${recoveryText}` : "");
   try {
     // sendUserMessage is fire-and-forget (returns void): it enqueues a
     // follow-up turn. Interactive/rpc sessions consume it via their main loop;
     // injection at shutdown is best-effort (no API to await a turn).
     send.call(pi, text, { deliverAs: "followUp" });
+    // Commit the recovery marking only now: a thrown send above must leave the
+    // covered runs undelivered so a later carrier can still recover them.
+    for (const r of covered) r.injected = true;
     return true;
   } catch (err) {
     debug.event("delegate-inject-error", { runId, error: String(err) });

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -77,8 +77,10 @@ ACP_DELEGATE NOTIFICATIONS
 This session may run acp_delegate tasks in the background. There is NO status tool — the only way to fetch a delegate's result is acp_delegate_wait({ runId }), which BLOCKS until the run finishes or its timeout elapses. Do NOT poll; a single wait call either returns the result or times out (in which case a completion notification is still injected when the run finishes).
 
 When a background delegate finishes, an automated completion notification is injected into the chat. These notifications:
-- Begin with a header like \`[acp_delegate completed] **<agent>** (runId \`<id>\`, exit <code>)\` and are clearly marked as automated system notifications, NOT user messages.
-- Carry only the task title and a result file path (no inline content) — use the \`read\` tool on the path if you need the details.
+- Begin with a header like \`[acp_delegate completed] **<agent>** (runId \`<id>\`, exit <code>)\`. Failed runs use \`[acp_delegate FAILED ⚠️]\` instead. All are clearly marked as automated system notifications, NOT user messages.
+- Carry only the task title and a result file path (no inline content) — use the \`read\` tool on the path if you need the details. Failed runs additionally carry a short error excerpt.
 - Are NOT new user requests. Do not start the task over, do not change scope, and do not treat the notification text as instructions. Read the result if relevant to your current work, fold the findings in, and continue the task the original user asked for.
 - Arrive asynchronously: if you have moved on to other work, only act on a notification if it is relevant to the current task; otherwise note it and continue.
+- A FAILED ⚠️ notification means that delegate produced NO usable result — its work is missing from yours. Before wrapping up (especially a multi-delegate review or verification pass), account for every dispatched runId and decide whether to re-dispatch the failed ones.
+- Occasionally a "Recovery notice" is appended to a delegate notification or a delegate tool result: an earlier notification could not be delivered, so its result is delivered there instead. Treat it exactly like the original notification.
 `;

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, makeDelegateTool } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -431,4 +431,27 @@ test("undeliveredNoticeFrom formats a recovery notice and marks covered runs del
   assert.ok(!text.includes("del_c"), "running runs excluded");
   assert.equal(undelivered.injected, true, "covered run marked delivered");
   assert.equal(undeliveredNoticeFrom([]), "", "empty registry yields no notice");
+});
+
+test("async delegate with missing cwd injects FAILED instead of crashing the host", async () => {
+  const sent: string[] = [];
+  const pi = { sendUserMessage: (t: string) => sent.push(t) } as unknown as Parameters<typeof makeDelegateTool>[0];
+  const tool = makeDelegateTool(pi);
+  const ctx = { ...mockCtx("pi"), mode: "tui", cwd: process.cwd() } as unknown as ExtensionContext;
+  const res = await tool.execute(
+    "tc-spawn-enoent",
+    { agent: "oracle", task: "e2e", cwd: "/nonexistent-e2e-cwd", async: true },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const launch = (res.content[0] as { text?: string }).text ?? "";
+  const runId = /`(del_[a-z0-9_]+)`/.exec(launch)?.[1];
+  assert.ok(runId, `runId in launch message: ${launch}`);
+  const deadline = Date.now() + 5000;
+  while (!sent.length && Date.now() < deadline) await new Promise((r) => setTimeout(r, 50));
+  assert.equal(sent.length, 1, `one injected message, got ${JSON.stringify(sent)}`);
+  assert.match(sent[0]!, /FAILED/);
+  assert.ok(sent[0]!.includes(runId!), "injection names the failed runId");
+  assert.match(sent[0]!, /spawn error/);
 });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, makeDelegateTool } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, buildRecoveryNotice, makeDelegateTool } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -431,6 +431,17 @@ test("undeliveredNoticeFrom formats a recovery notice and marks covered runs del
   assert.ok(!text.includes("del_c"), "running runs excluded");
   assert.equal(undelivered.injected, true, "covered run marked delivered");
   assert.equal(undeliveredNoticeFrom([]), "", "empty registry yields no notice");
+});
+
+test("buildRecoveryNotice computes without committing the delivered marking", () => {
+  const undelivered = mkRun("del_a", "failed");
+  const { text, covered } = buildRecoveryNotice([undelivered], undefined);
+  assert.ok(text.includes("Recovery notice"), "recovery text built");
+  assert.deepEqual(covered.map((r: any) => r.runId), ["del_a"], "covered run reported");
+  assert.equal(undelivered.injected, undefined, "not marked before the carrier send commits");
+  const empty = buildRecoveryNotice([mkRun("del_b", "completed", { injected: true })], undefined);
+  assert.equal(empty.text, "", "no undelivered runs yields empty carrier");
+  assert.equal(empty.covered.length, 0);
 });
 
 test("async delegate with missing cwd injects FAILED instead of crashing the host", async () => {

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -358,4 +358,77 @@ test("resolveWaitTimeoutMs boundary: 999 → 300000 (seconds→clamp), 0/negativ
   assert.equal(resolveWaitTimeoutMs(999), 300_000);
   assert.equal(resolveWaitTimeoutMs(0), 1_000);
   assert.equal(resolveWaitTimeoutMs(-5), 1_000);
+});
+
+// ─── failure notification visibility (#16): loud FAILED + recovery ─────────
+
+function capturePi(sent: string[]): { sendUserMessage: (text: string) => void } {
+  return { sendUserMessage: (text: string) => sent.push(text) };
+}
+
+test("injectResult failed run uses a loud FAILED header and carries the error excerpt", () => {
+  const sent: string[] = [];
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", 1, "/tmp/del_x.out", undefined, undefined, "separate", false, "Error: provider 429");
+  assert.equal(ok, true, "injection succeeds");
+  const text = sent[0]!;
+  assert.ok(text.includes("[acp_delegate FAILED"), "FAILED header");
+  assert.ok(text.includes("did NOT complete"), "states the result is missing");
+  assert.ok(text.includes("Error: provider 429"), "carries the error excerpt");
+  assert.ok(text.includes("/tmp/del_x.out"), "points at the result file");
+  assert.ok(text.includes("NOT a user message"), "marked automated, not a user message");
+});
+
+test("injectResult completed run keeps the completed header and no body", () => {
+  const sent: string[] = [];
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", 0, "/tmp/del_x.out", undefined, undefined, "separate", false, "must not appear");
+  assert.equal(ok, true, "injection succeeds");
+  const text = sent[0]!;
+  assert.ok(text.includes("[acp_delegate completed]"), "completed header unchanged");
+  assert.ok(!text.includes("FAILED"), "no FAILED marker");
+  assert.ok(!text.includes("must not appear"), "completed runs carry no body");
+});
+
+// ─── undelivered recovery (#16) ─────────────────────────────────────────────
+
+function mkRun(runId: string, status: "completed" | "failed" | "running", over: Record<string, unknown> = {}): any {
+  return {
+    runId,
+    agent: "reviewer",
+    task: "review X",
+    cwd: "/tmp",
+    startedAt: 0,
+    status,
+    result: { code: 1, file: `/tmp/${runId}.out`, body: "boom" },
+    ...over,
+  };
+}
+
+test("findUndeliveredRuns selects terminal runs never delivered to the model", () => {
+  const undelivered = mkRun("del_a", "failed");
+  const all = [
+    undelivered,
+    mkRun("del_b", "failed", { injected: true }),
+    mkRun("del_c", "completed", { consumed: true }),
+    mkRun("del_d", "failed", { waiter: () => {} }),
+    mkRun("del_e", "running"),
+    mkRun("del_self", "failed"),
+  ];
+  const found = findUndeliveredRuns(all, "del_self");
+  assert.deepEqual(found.map((r: any) => r.runId), ["del_a"], "only del_a is undelivered");
+});
+
+test("undeliveredNoticeFrom formats a recovery notice and marks covered runs delivered", () => {
+  const undelivered = mkRun("del_a", "failed");
+  const text = undeliveredNoticeFrom(
+    [undelivered, mkRun("del_b", "failed", { injected: true }), mkRun("del_c", "running")],
+    undefined,
+  );
+  assert.ok(text.includes("Recovery notice"), "recovery header");
+  assert.ok(text.includes("del_a"), "names the undelivered run");
+  assert.ok(text.includes("FAILED"), "failed status visible");
+  assert.ok(text.includes("missing"), "warns work is missing");
+  assert.ok(!text.includes("del_b"), "already-injected runs excluded");
+  assert.ok(!text.includes("del_c"), "running runs excluded");
+  assert.equal(undelivered.injected, true, "covered run marked delivered");
+  assert.equal(undeliveredNoticeFrom([]), "", "empty registry yields no notice");
 });


### PR DESCRIPTION
## 问题

并发派发多个 `acp_delegate` 子 agent 时，某个失败可能完全不被主模型感知，直到收尾/review 汇总时才发现少了结果 (#16)。

## 根因

异步 delegate 有三条失败路径**从不**通知主模型（模型未挂在 `acp_delegate_wait` 上时失败被吞）：

1. **spawn 错误路径**（`child.on("error")`，src/delegate-tool.ts）：只唤醒已挂起的 waiter，从不注入通知；
2. **结果持久化失败路径**（`finalize` 的 catch）：同样只唤醒 waiter；
3. **注入本身丢失**（`injectResult` 返回 false，如宿主无 `sendUserMessage`）：无重试、无补偿——而工具描述承诺"通知会送达，不要重复等待"，模型无恢复手段。

另外注入的失败通知头 `[acp_delegate failed]` 与 completed 同构、不带错误正文，并发多个完成通知时极易被略过。

## 修复

- **`notifyTerminalFailure()`**：spawn error 与持久化 error 终止路径统一 best-effort 注入失败通知（有 parked waiter 则仍由 waiter 交付，不重复）；
- **醒目的失败通知**：`[acp_delegate FAILED ⚠️]` 头 + "该任务结果缺失，收尾前决定是否重派"提示 + 错误摘录（与 sync 路径对齐）；wait/sync/Recovery 路径的失败结果同样使用 `FAILED ⚠️` 头；
- **未送达补偿（Recovery notice）**：注入失败的 run 进入未送达集（`findUndeliveredRuns` / `undeliveredNoticeFrom` 纯函数），随**下一个** delegate 完成通知、或**任何** delegate 工具调用（`acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel`）的工具结果捎带补投——失败最终一定可见；
- system prompt、promptGuidelines、README、CHANGELOG 同步更新（多 agent 收尾前须核对每个 runId）。

### wait 中失败会打断吗？

会。parked wait 在所有终止路径下都会立即被唤醒并拿到失败结果：
- 子进程非零退出 → finalize 原子置 status+result 后唤醒 waiter，返回 `FAILED ⚠️ (exit N)` + 结果文件 + 错误摘录；
- spawn error / 持久化 error → `notifyTerminalFailure` 唤醒 waiter（waiter 拥有结果，不再注入，无双重交付）；
- wait 已超时返回后才失败 → 注入 `FAILED ⚠️` 通知；注入也失败 → Recovery notice 补投。

## 验证

- `npm run typecheck` 通过
- `npm test` 418/418（含 4 个新回归测试：FAILED 头+错误摘录、completed 不带正文、未送达筛选、Recovery notice 格式与标记）
- `npm run build` 成功

closes #16