### PR TITLE
release v0.1.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.48",
+	"version": "0.1.49",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.48",
+			"version": "0.1.49",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.48",
+	"version": "0.1.49",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to 0.1.49 for the #16 delegate-failure-visibility fixes (PR #219):

- async delegate 失败必达：所有终止路径注入 `FAILED ⚠️` 通知 + Recovery notice 补投
- bad cwd 等即时 spawn 失败不再击穿宿主（spawn→handler 全程同步）
- wait/sync 路径失败结果同样使用 FAILED ⚠️ 头

acp-kernel 不变（0.0.45，本次无 kernel 改动）。合并后 CI 自动发布。typecheck/test 420/420/build 全绿。