### PR TITLE
release v0.1.51

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.50",
+	"version": "0.1.51",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.50",
+			"version": "0.1.51",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.50",
+	"version": "0.1.51",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.51 — ships the #223 fix (transient compress-retry prompt removal, #225).

## Contents since v0.1.50
- **fix(nudge): 移除瞬态 compress 重试提示注入 (closes #223)** — PR #225 (commits 3ec5441 + 5f17e73): compress 失败后不再每次 LLM 调用追加 `compressRetryMessage`（对从不重试的模型即 #223 的无限追加）；失败 toolResult 仍持久可自我纠正；issue #6 nudge 断路器保留；双 agent review 确认零回归、前缀缓存安全

## Changes in this PR
- `package.json` 0.1.50 → 0.1.51
- `package-lock.json` version fields refreshed
- acp-kernel unchanged (pinned 0.0.45, no kernel change in this release)

## Pre-flight
- `npm run typecheck` ✓ · `npm test` 428/428 ✓ · `npm run build` ✓

CI auto-publishes on merge. Supersedes/closes #217 (closed).

🤖 Generated by ework-daemon (agent) — merge decision is human-only.