### PR TITLE
release v0.1.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.51",
+	"version": "0.1.52",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.51",
+			"version": "0.1.52",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.45",
+				"acp-kernel": "0.0.46",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.45",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.45.tgz",
-			"integrity": "sha512-WrRALDcfnNxcdc4ARBOA5gHm5a+Ip1eKXbIHZ3GtWTmWD7hI42zw1pp+mCl3QzwBovciTdKvGSFpFNl2LsaaNQ==",
+			"version": "0.0.46",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.46.tgz",
+			"integrity": "sha512-LE0qif1XmfGHVF39vNIIaRVzi+W/ZPaxmIo+rtGxgT//U03dJhgI8CfzF9thUlHVqM8NSw5uRrTYwWrAgDVcoQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.51",
+	"version": "0.1.52",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.45",
+		"acp-kernel": "0.0.46",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Release v0.1.52 — bumps `acp-kernel` 0.0.45 → **0.0.46** (exact pin), shipping the tier-2/3 count-trigger fix for #224 ("T2 永不触发", fixed by ranxianglei/acp-kernel#162, released as acp-kernel#164).

## What changes for users
Tier-2 distillation nudges now fire once ≥ 5 active tier-1 blocks exist (block COUNT), instead of the practically-unreachable summary-token-mass gate. Previously T2 essentially never triggered.

## Pre-flight
- `npm install` refreshed lockfile (kernel 0.0.46 from npm, no overlay) ✅
- `npm run typecheck` ✅
- `npm test` ✅ 428/428
- `npm run build` ✅
- Functional smoke against installed 0.0.46: 6 active T1 blocks + raw pending below T1 threshold → `tier: 2, inject: true`, reason `T2 distill ready: 6 tier-1 blocks >= tier2Trigger 5 (6000 tokens), usage 5%` — the #224 scenario now nudges correctly ✅

Merge → CI publishes `billion-context-pi@0.1.52`.