### PR TITLE
fix(status): recommend ranges view in acp_status prompt snippet

### DIFF
--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -24,7 +24,7 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
     label: "ACP Status",
     description:
       "Context status: overview, compressed blocks, or uncompressed ranges/messages. No args = overview + totals + compressible ranges. scope:'uncompressed' + view:'messages' for per-message listing. scope:'compressed' for block drilldown.",
-    promptSnippet: 'acp_status({}) or acp_status({ scope: "uncompressed", view: "messages" })',
+    promptSnippet: 'acp_status({}) or acp_status({ scope: "uncompressed" })',
     promptGuidelines: [
       "Call with no args for a quick overview of context usage.",
       "Use scope:'uncompressed' to find the largest compressible ranges.",


### PR DESCRIPTION
## Problem

`acp_status` promptSnippet suggested `scope:"uncompressed" + view:"messages"`, steering models to the per-message firehose. Combined with the kernel's ranges view collapsing dense refs into one giant range, the tool's output was not actionable by range - see #193.

## Fix

promptSnippet now recommends `acp_status({ scope: "uncompressed" })` (the ranges view), which acp-kernel PR ranxianglei/acp-kernel#165 makes actionable: ranges grouped by conversation turn, sorted by size.

One-line change in src/status-tool.ts. typecheck + 428 tests + build all pass.