### PR TITLE
refuse ACP service on OMP hosts (oh-my-pi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The model decides <em>when</em> and <em>what</em> to compress — not a hard lim
 
 ---
 
+> **Host support:** this plugin is for **Pi**. It does **not** support **OMP (oh-my-pi)** — on an OMP host it refuses to run. OMP users: use [billion-context](https://github.com/ranxianglei/billion-context) instead (`bili omp`). Details: [docs/omp.md](./docs/omp.md).
+
 ## Why?
 
 When conversations get long, the model runs out of context. Most tools hard-truncate — silently dropping earlier messages. **billion-context** gives the model a `compress` tool: the LLM decides **when** and **what** to compress into high-fidelity summaries, preserving critical details (file paths, decisions, error strings) while reclaiming context space.
@@ -83,8 +85,10 @@ billion-context-pi is built for the **Pi** coding agent (`@earendil-works/pi-cod
 
   ```bash
   npm install -g billion-context
-  bili omp -- -p "your task"   # run OMP through the proxy
+  bili omp   # run OMP through the proxy
   ```
+
+  Full details: [docs/omp.md](./docs/omp.md).
 
 ## Model-facing tools
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ This has two practical implications:
 
 2. **Even with a single compression plugin, interference is still possible in rare cases.** Load order under Pi is determined by filesystem discovery order (`fs.readdirSync` over `.pi/extensions/` → global → packages), which is not fully deterministic. If another (non-compression) extension also hooks the `context` event and happens to load *after* billion-context-pi, it could modify the compressed output. billion-context-pi rebuilds its working set from the session log rather than the chained input, which makes it robust to handlers that run *before* it — but it cannot defend against a handler that runs *after* it. This is a limitation of Pi's extension model; if you observe unexpected context behavior, check whether other installed extensions intercept the `context` event.
 
+## Host support
+
+billion-context-pi is built for the **Pi** coding agent (`@earendil-works/pi-coding-agent`) and detects the host at session start:
+
+- **Pi** — fully supported.
+- **OMP (`can1357/oh-my-pi`)** — **not supported.** OMP's in-process session API diverges from Pi's, so the compression refs the extension injects can drift out of sync with the session's real refs and `compress` calls fail with `does not exist in this session` (issue [#234](https://github.com/ranxianglei/billion-context-pi/issues/234)). On OMP the extension now **refuses service**: it prints a warning, disables the ACP tools, and leaves the host's own context handling untouched.
+
+  **Use [billion-context](https://github.com/ranxianglei/billion-context) instead** — it runs the same compression pipeline server-side in a proxy, so the refs never diverge:
+
+  ```bash
+  npm install -g billion-context
+  bili omp -- -p "your task"   # run OMP through the proxy
+  ```
+
 ## Model-facing tools
 
 | Tool | What it does |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,8 @@
 
 ---
 
+> **宿主支持:** 本插件面向 **Pi**。它**不支持 OMP(oh-my-pi)** —— 在 OMP 宿主上会拒绝运行。OMP 用户请改用 [billion-context](https://github.com/ranxianglei/billion-context)(`bili omp`)。详细说明:[docs/omp.zh-CN.md](./docs/omp.zh-CN.md)。
+
 ## 为什么选择 billion-context
 
 当对话变长,模型的上下文会耗尽。多数工具采用硬截断 —— 静默丢弃早期消息。**billion-context** 把 `compress` 工具交给模型:由 LLM 决定**何时**压缩、压缩**什么**,将内容压缩成高保真摘要,在回收上下文空间的同时保留关键细节(文件路径、决策、错误字符串)。
@@ -70,6 +72,22 @@ billion-context 通过拦截 Pi 的 `context` 事件接管上下文管理。**Pi
 1. **只保留一个上下文压缩插件。** 如果同时运行两个压缩插件(例如 billion-context-pi 和另一个),它们都会改写消息列表、互相覆盖 —— 已压缩的范围可能被重新展开或破坏。Pi 的内置自动压缩已由 billion-context-pi 自动取消,但任何*第三方*压缩/compaction 扩展都应卸载。
 
 2. **即使只有一个压缩插件,在少数情况下仍可能出现干扰。** Pi 下的加载顺序由文件系统发现顺序(`fs.readdirSync` 遍历 `.pi/extensions/` → 全局 → 包)决定,并不完全确定。如果另一个(非压缩类)扩展也 hook 了 `context` 事件、且恰好加载在 billion-context-pi *之后*,它可能修改压缩后的输出。billion-context-pi 从会话日志重建工作集(而非链式输入),这让它对*排在它之前*的 handler 鲁棒 —— 但无法防御*排在它之后*的 handler。这是 Pi 扩展模型的固有限制;若你观察到上下文行为异常,请检查是否有其他已安装扩展拦截了 `context` 事件。
+
+## 宿主支持
+
+billion-context-pi 面向 **Pi** 编码代理(`@earendil-works/pi-coding-agent`)构建,并在会话开始时检测宿主:
+
+- **Pi** — 完全支持。
+- **OMP(`can1357/oh-my-pi`)** — **不支持。** OMP 的进程内会话 API 与 Pi 不同,扩展注入的压缩引用可能与会话的真实引用漂移失步,导致 `compress` 调用失败,报错 `does not exist in this session`(issue [#234](https://github.com/ranxianglei/billion-context-pi/issues/234))。在 OMP 上,扩展现在会**拒绝服务**:打印警告、禁用 ACP 工具,并保持宿主自身的上下文处理不受影响。
+
+  **请改用 [billion-context](https://github.com/ranxianglei/billion-context)** — 它把同样的压缩流水线运行在服务端代理里,因此引用不会漂移:
+
+  ```bash
+  npm install -g billion-context
+  bili omp   # 让 OMP 通过代理运行
+  ```
+
+  完整说明:[docs/omp.zh-CN.md](./docs/omp.zh-CN.md)。
 
 ## 模型工具
 

--- a/docs/omp.md
+++ b/docs/omp.md
@@ -1,0 +1,53 @@
+[English](./omp.md) | [中文](./omp.zh-CN.md)
+
+# OMP (oh-my-pi) support
+
+> **billion-context-pi does not support OMP.** If you run it on an OMP
+> (`can1357/oh-my-pi`) host, the extension **refuses to run**: it prints a
+> warning once, disables the ACP tools, and leaves the host's own context
+> handling untouched. Use the [billion-context](https://github.com/ranxianglei/billion-context)
+> proxy instead.
+
+## Why OMP is not supported
+
+billion-context-pi is an in-process adapter for the **Pi** coding agent
+(`@earendil-works/pi-coding-agent`). It manages context by injecting invisible
+message refs (`m00001`, `m00002`, …) into the live conversation and letting the
+model drive `compress` / `decompress` / `search_context` against those refs.
+
+OMP exposes a different in-process session API. The refs the extension injects
+can drift out of sync with the session's real refs, so `compress` calls fail
+with `does not exist in this session` and one-shot runs never succeed
+([#234](https://github.com/ranxianglei/billion-context-pi/issues/234)). Keeping
+that in-process integration reliable on OMP is not worth the maintenance cost,
+so OMP is no longer an actively supported host for this plugin.
+
+## What happens on an OMP host
+
+At session start the extension feature-detects the host (Pi exposes
+`sessionManager.buildContextEntries()`; OMP only exposes `getBranch()`). When it
+detects OMP it stands down:
+
+- warns **once per process** (UI notification in TUI/RPC; `console.error` to
+  stderr in headless one-shot mode) pointing at the supported alternative,
+- the four ACP tools (`compress`, `decompress`, `search_context`, `acp_status`)
+  return the guidance message instead of acting,
+- the ACP system-prompt injection is skipped,
+- the `context` transform is a no-op (messages pass through untouched),
+- the host's own auto-compaction is **not** cancelled.
+
+Pi hosts are completely unaffected.
+
+## The alternative: billion-context proxy
+
+[billion-context](https://github.com/ranxianglei/billion-context) runs the same
+compression pipeline **server-side in a proxy**. Because the proxy owns the ref
+coordinate space, the refs never diverge — it works on OMP (and other hosts).
+
+```bash
+npm install -g billion-context
+bili omp
+```
+
+`bili omp` starts a local proxy and launches OMP against it. See
+[billion-context](https://github.com/ranxianglei/billion-context) for options.

--- a/docs/omp.zh-CN.md
+++ b/docs/omp.zh-CN.md
@@ -1,0 +1,50 @@
+[English](./omp.md) | [中文](./omp.zh-CN.md)
+
+# OMP(oh-my-pi)支持
+
+> **billion-context-pi 不支持 OMP。** 在 OMP(`can1357/oh-my-pi`)宿主上运行时,
+> 扩展会**拒绝服务**:打印一次警告、禁用 ACP 工具,并保持宿主自身的上下文处理
+> 不受影响。请改用 [billion-context](https://github.com/ranxianglei/billion-context)
+> 代理。
+
+## 为什么不支持 OMP
+
+billion-context-pi 是面向 **Pi** 编码代理(`@earendil-works/pi-coding-agent`)的
+进程内适配器。它通过向实时对话注入不可见的消息引用(`m00001`、`m00002` …),
+让模型基于这些引用驱动 `compress` / `decompress` / `search_context` 来管理上下文。
+
+OMP 暴露的是另一套进程内会话 API。扩展注入的引用可能与会话的真实引用发生漂移,
+导致 `compress` 调用失败,报错 `does not exist in this session`,一次性运行
+(one-shot)永远无法成功
+([#234](https://github.com/ranxianglei/billion-context-pi/issues/234))。在 OMP 上
+维持这套进程内集成的可靠性并不划算,因此 OMP 不再是本插件主动支持的宿主。
+
+## 在 OMP 宿主上会发生什么
+
+会话开始时,扩展通过特性检测识别宿主(Pi 暴露
+`sessionManager.buildContextEntries()`,OMP 只暴露 `getBranch()`)。检测到 OMP 时,
+扩展会"让位":
+
+- **每个进程只警告一次**(TUI/RPC 下用 UI 通知;headless 一次性模式下用
+  `console.error` 输出到 stderr),并指向受支持的替代方案;
+- 四个 ACP 工具(`compress`、`decompress`、`search_context`、`acp_status`)
+  返回引导信息,而不执行实际操作;
+- 跳过 ACP 系统提示注入;
+- `context` 转换变为空操作(消息原样透传);
+- **不**取消宿主自身的自动压缩。
+
+Pi 宿主完全不受影响。
+
+## 替代方案:billion-context 代理
+
+[billion-context](https://github.com/ranxianglei/billion-context) 把同样的压缩
+流水线**运行在服务端代理**里。由于代理持有引用坐标系,引用不会漂移 —— 因此它
+在 OMP(以及其他宿主)上都能工作。
+
+```bash
+npm install -g billion-context
+bili omp
+```
+
+`bili omp` 会启动一个本地代理,并让 OMP 通过它运行。更多选项见
+[billion-context](https://github.com/ranxianglei/billion-context)。

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -9,6 +9,7 @@ import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
 import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages } from "./tokens.js";
 import { defaultCountTokens, parseCompressArgs, type CompressionBlock, type CompressParseDiagnostics } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
+import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 
 function formatK(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}K` : String(n);
@@ -53,6 +54,7 @@ export function makeCompressTool(runtime: AcpRuntime): ToolDefinition<typeof Com
     ],
     parameters: CompressParams,
     async execute(toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      if (runtime.refused) return { details: undefined, content: [{ type: "text", text: OMP_UNSUPPORTED_MESSAGE }] };
       let result: string;
       try {
         result = await handleCompress(params as CompressArgs, runtime, ctx, toolCallId);

--- a/src/decompress-tool.ts
+++ b/src/decompress-tool.ts
@@ -4,6 +4,7 @@ import type { AcpRuntime } from "./runtime.js";
 import { debug, logError, logInfo, logThrow } from "./log.js";
 import { parseBlockIdArg, collectBlockContent, type CompressionBlock } from "acp-kernel";
 import { entriesToCoreMessages } from "./messages.js";
+import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 import { writeFile, mkdir } from "node:fs/promises";
 import { existsSync, lstatSync, readlinkSync, realpathSync } from "node:fs";
 import { resolve, relative, isAbsolute, join, basename, dirname } from "node:path";
@@ -45,6 +46,7 @@ export function makeDecompressTool(runtime: AcpRuntime): ToolDefinition<typeof D
     ],
     parameters: DecompressParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      if (runtime.refused) return { details: undefined, content: [{ type: "text", text: OMP_UNSUPPORTED_MESSAGE }] };
       let result: string;
       try {
         result = await handleDecompress(params as DecompressArgs, runtime, ctx);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import {
 import { defaultCountTokens } from "acp-kernel";
 import { formatSystemPromptForEvent, getSystemPromptText } from "./compat.js";
 import { inspectOverflowMessage, reserveOutputHeadroom, shouldReserveOutputHeadroom } from "./overflow-selfheal.js";
+import { isOmpHost, OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 
 type AgentMessage = SessionMessageEntry["message"];
 
@@ -46,7 +47,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
       return;
     }
     const runtime = createRuntime(adapter);
-    wireCompactionDisable(pi);
+    wireCompactionDisable(pi, runtime);
     wireSessionLifecycle(pi, runtime);
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
@@ -66,9 +67,13 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
 export default createAcpExtension();
 
 // ACP owns compression; cancel Pi's built-in auto-compaction entirely (mirrors
-// opencode-acp requiring opencode's compaction.auto = false).
-function wireCompactionDisable(pi: ExtensionAPI): void {
-  pi.on("session_before_compact", () => ({ cancel: true }));
+// opencode-acp requiring opencode's compaction.auto = false). On a refused host
+// (OMP) we stand down and let the host compact normally instead.
+function wireCompactionDisable(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  pi.on("session_before_compact", () => {
+    if (runtime.refused) return;
+    return { cancel: true };
+  });
 }
 
 // (acp_delegate injection is best-effort: sendUserMessage is fire-and-forget
@@ -76,7 +81,25 @@ function wireCompactionDisable(pi: ExtensionAPI): void {
 // consumes the follow-up queue naturally — no shutdown drain needed.)
 
 function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
+  let ompWarned = false;
   pi.on("session_start", async (_event, ctx) => {
+    // OMP (oh-my-pi) is not supported: its in-process live-entries integration
+    // diverges the nudge's example refs from the session's real refs, so
+    // compress calls fail with "does not exist in this session". Stand down —
+    // refuse service and point the user at the billion-context proxy. session_start
+    // always precedes the first context/before_agent_start event, so setting
+    // `refused` here reliably gates every downstream handler for the session.
+    if (isOmpHost(ctx.sessionManager)) {
+      runtime.refused = true;
+      if (!ompWarned) {
+        ompWarned = true;
+        const sid = ctx.sessionManager.getSessionId();
+        logWarn("host", { event: "omp-unsupported", sid, action: "refused" });
+        if (ctx.hasUI) ctx.ui.notify(OMP_UNSUPPORTED_MESSAGE, "warning");
+        else console.error(OMP_UNSUPPORTED_MESSAGE);
+      }
+      return;
+    }
     runtime.store.invalidate();
     runtime.clearNudgeTracking();
     runtime.throttleFor(ctx.sessionManager.getSessionId()).reset();
@@ -131,6 +154,10 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
 // nudge decision) and return the transformed AgentMessage[].
 function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("context", async (event, ctx) => {
+    // Refused host (OMP): leave the context completely untouched — no ref tags,
+    // no compression, no nudge. Returning undefined makes pi send the original
+    // messages verbatim.
+    if (runtime.refused) return;
     const sid = ctx.sessionManager.getSessionId();
     const release = await runtime.acquireLock(sid);
     try {
@@ -348,6 +375,9 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
 
 function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
   pi.on("before_agent_start", (event) => {
+    // Refused host (OMP): don't inject the ACP system prompt — the model must
+    // not learn about compress/decompress on a host where they can't work.
+    if (runtime.refused) return;
     const delegate = runtime.adapter.delegate !== false;
     const acp = buildAcpSystemPrompt(runtime.prompts);
     const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;

--- a/src/omp.ts
+++ b/src/omp.ts
@@ -26,6 +26,6 @@ export const OMP_UNSUPPORTED_MESSAGE = [
   "The in-process compression path is unreliable on OMP: the nudge's example refs diverge from the session's real refs, so compress calls fail with \"does not exist in this session\".",
   "Use the billion-context proxy instead — it runs compression server-side and works on OMP:",
   "  npm install -g billion-context",
-  "  bili omp -- -p \"your task\"",
+  "  bili omp",
   "Docs: https://github.com/ranxianglei/billion-context",
 ].join("\n");

--- a/src/omp.ts
+++ b/src/omp.ts
@@ -1,0 +1,31 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { isPiHost } from "./runtime.js";
+
+/**
+ * Positive OMP (oh-my-pi) host detection.
+ *
+ * pi exposes `sessionManager.buildContextEntries()`; omp only exposes
+ * `getBranch()`. `isPiHost` feature-detects the former, so its negation is the
+ * established "omp path" used throughout the adapter (see runtime.stateFor).
+ * We reuse that semantic so the refusal and the (now dormant) best-effort omp
+ * path can never disagree about which host we are on.
+ */
+export function isOmpHost(sm: ExtensionContext["sessionManager"]): boolean {
+  return !isPiHost(sm);
+}
+
+/**
+ * Shown (and logged) when the extension detects an OMP host and stands down.
+ * OMP's in-process live-entries integration is unreliable: the nudge's example
+ * refs diverge from the session's real refs, so compress calls fail with
+ * "does not exist in this session". The billion-context proxy runs compression
+ * server-side (it owns the ref coordinate space) and works on OMP.
+ */
+export const OMP_UNSUPPORTED_MESSAGE = [
+  "[billion-context-pi] This host is OMP (oh-my-pi), which is NOT supported — ACP has been disabled for this session.",
+  "The in-process compression path is unreliable on OMP: the nudge's example refs diverge from the session's real refs, so compress calls fail with \"does not exist in this session\".",
+  "Use the billion-context proxy instead — it runs compression server-side and works on OMP:",
+  "  npm install -g billion-context",
+  "  bili omp -- -p \"your task\"",
+  "Docs: https://github.com/ranxianglei/billion-context",
+].join("\n");

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -40,6 +40,11 @@ export function isPiHost(sm: ExtensionContext["sessionManager"]): boolean {
 
 export interface AcpRuntime {
   core: CompressionCore;
+  /** Set when the host is unsupported (currently: OMP / oh-my-pi). Once true,
+   *  the extension stands down: the context transform, system-prompt injection,
+   *  compaction-cancel and ACP tools all no-op so the host runs untouched.
+   *  Set at session_start (see wireOmpRefusal in src/index.ts). */
+  refused: boolean;
   /** Per-session provider-throttle retry episode (attempt budget + kick
    *  pacing), keyed by session id so concurrent sessions in one extension
    *  instance cannot share an episode. Reset on session_start and on any
@@ -378,4 +383,5 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     await store.save(state, sm.getSessionFile() ?? undefined, sm.getSessionId());
   }
 
-  return { core, store, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}
+  let refused = false;
+  return { core, store, get refused() { return refused; }, set refused(v: boolean) { refused = v; }, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}

--- a/src/search-tool.ts
+++ b/src/search-tool.ts
@@ -4,6 +4,7 @@ import { searchBlocks, type SearchResult } from "acp-kernel";
 import type { AcpRuntime } from "./runtime.js";
 import { buildSearchDocs } from "./search-index.js";
 import { logThrow } from "./log.js";
+import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 
 const SearchParams = Type.Object({
     query: Type.String({ description: "Keywords to locate detail folded into compressed summaries or historical messages." }),
@@ -25,10 +26,11 @@ export function makeSearchTool(runtime: AcpRuntime): ToolDefinition<typeof Searc
             "Message hits link to the owning block — decompress that block to recover surrounding detail.",
         ],
         parameters: SearchParams,
-        async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
-            let result: string;
-            try {
-                result = await handleSearch(params as SearchArgs, runtime, ctx);
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+        if (runtime.refused) return { details: undefined, content: [{ type: "text", text: OMP_UNSUPPORTED_MESSAGE }] };
+        let result: string;
+        try {
+            result = await handleSearch(params as SearchArgs, runtime, ctx);
             } catch (e) {
                 logThrow("search", e, { sid: ctx.sessionManager.getSessionId(), query: (params as SearchArgs).query });
                 throw e;

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -8,6 +8,7 @@ import { getSystemPromptText } from "./compat.js";
 import { logThrow } from "./log.js";
 import { getDelegateUsage } from "./delegate-tool.js";
 import { resolveDelegate } from "./config.js";
+import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 
 const StatusParams = Type.Object({
   scope: Type.Optional(Type.Union([Type.Literal("compressed"), Type.Literal("uncompressed")], { description: '"compressed" = drill into blocks; "uncompressed" = show visible messages/ranges. Default: overview.' })),
@@ -33,6 +34,7 @@ export function makeStatusTool(runtime: AcpRuntime): ToolDefinition<typeof Statu
     ],
     parameters: StatusParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx): Promise<AgentToolResult<unknown>> {
+      if (runtime.refused) return { details: undefined, content: [{ type: "text", text: OMP_UNSUPPORTED_MESSAGE }] };
       let result: string;
       try {
         result = await handleStatus(params as StatusArgs, runtime, ctx);

--- a/tests/omp-refuse.test.ts
+++ b/tests/omp-refuse.test.ts
@@ -1,0 +1,161 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { createAcpExtension } from "../src/index.js";
+import { OMP_UNSUPPORTED_MESSAGE } from "../src/omp.js";
+import { setRunNpmForTest } from "../src/update.js";
+
+// Hermetic session_start: the pi (non-OMP) path runs the auto-update check, so
+// disable it and stub npm (no network) — mirroring integration.test.ts.
+setRunNpmForTest(async (args) => ({ code: 0, stdout: args[0] === "view" ? "0.0.1\n" : "", stderr: "" }));
+process.env.ACP_AUTO_UPDATE = "false";
+delete process.env.BILLION_CONTEXT_PROXY;
+
+// Mock Pi's ExtensionAPI — captures the event handlers + tools the factory wires.
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) {
+      this.tools.push(tool);
+    },
+    registerCommand(name: string, options: any) {
+      this.commands.set(name, options);
+    },
+  };
+  return { api, handlers };
+}
+
+type Notify = (msg: string, type?: string) => void;
+
+// OMP-shaped host: sessionManager exposes getBranch but NOT buildContextEntries.
+function ompCtx(notify: Notify, hasUI: boolean) {
+  return {
+    mode: "rpc",
+    hasUI,
+    cwd: "/tmp",
+    ui: { notify, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      getBranch: () => [],
+      getSessionId: () => "omp-session",
+      getSessionFile: () => "/tmp/omp-refuse.session.json",
+    },
+  };
+}
+
+// pi-shaped host: sessionManager exposes buildContextEntries (the pi signature).
+function piCtx(notify: Notify) {
+  return {
+    mode: "rpc",
+    hasUI: true,
+    cwd: "/tmp",
+    ui: { notify, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000 },
+    sessionManager: {
+      buildContextEntries: () => [],
+      getBranch: () => [],
+      getSessionId: () => "pi-session",
+      getSessionFile: () => "/tmp/pi-refuse.session.json",
+    },
+  };
+}
+
+const startSession = (handlers: any, ctx: any) =>
+  handlers.get("session_start")![0]!({ type: "session_start", reason: "startup" }, ctx);
+
+describe("OMP host refusal (issue #234)", () => {
+  test("detects OMP at session_start, refuses service, warns once via UI", async () => {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+    const notes: Array<{ msg: string; type?: string }> = [];
+    const notify: Notify = (msg, type) => notes.push({ msg, type });
+    const ctx = ompCtx(notify, true);
+
+    await startSession(handlers, ctx);
+
+    assert.equal(notes.length, 1, "warns exactly once");
+    assert.equal(notes[0]!.msg, OMP_UNSUPPORTED_MESSAGE);
+    assert.equal(notes[0]!.type, "warning");
+
+    // Stands down: does not cancel the host's own compaction.
+    assert.equal(handlers.get("session_before_compact")![0]!({}, {}), undefined);
+    // Does not inject the ACP system prompt (model must not learn compress here).
+    assert.equal(handlers.get("before_agent_start")![0]!({ systemPrompt: "BASE" }, {}), undefined);
+    // Leaves the context untouched (no ref tags / nudge) — returns undefined.
+    const ctxResult = await handlers.get("context")![0]!(
+      { type: "context", messages: [{ role: "user", content: "hi" }] },
+      ctx,
+    );
+    assert.equal(ctxResult, undefined, "context untouched on a refused host");
+  });
+
+  test("warns only once across repeated session_start events", async () => {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+    const notes: string[] = [];
+    const notify: Notify = (msg) => notes.push(msg);
+    const ctx = ompCtx(notify, true);
+
+    await startSession(handlers, ctx);
+    await startSession(handlers, ctx);
+
+    assert.equal(notes.length, 1, "second session_start must not re-warn");
+    assert.equal(notes[0], OMP_UNSUPPORTED_MESSAGE);
+  });
+
+  test("all four ACP tools refuse service on OMP", async () => {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+    const ctx = ompCtx(() => {}, true);
+    await startSession(handlers, ctx);
+
+    for (const name of ["compress", "decompress", "search_context", "acp_status"]) {
+      const tool = api.tools.find((t: any) => t.name === name);
+      assert.ok(tool, `${name} tool is registered`);
+      const res = await (tool as any).execute("t1", {}, undefined, undefined, ctx);
+      assert.equal((res.content[0] as any).text, OMP_UNSUPPORTED_MESSAGE, `${name} refuses service`);
+    }
+  });
+
+  test("prints the warning to stderr when there is no UI (headless one-shot)", async () => {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+    const ctx = ompCtx(() => {}, false);
+
+    const orig = console.error;
+    const errs: string[] = [];
+    console.error = (...a: any[]) => {
+      errs.push(a.join(" "));
+    };
+    try {
+      await startSession(handlers, ctx);
+    } finally {
+      console.error = orig;
+    }
+
+    assert.equal(errs.length, 1, "exactly one stderr line");
+    assert.equal(errs[0], OMP_UNSUPPORTED_MESSAGE);
+  });
+
+  test("does NOT refuse on a pi host (buildContextEntries present)", async () => {
+    const { api, handlers } = captureApi();
+    createAcpExtension()(api as any);
+    const notes: string[] = [];
+    const notify: Notify = (msg) => notes.push(msg);
+    const ctx = piCtx(notify);
+
+    await startSession(handlers, ctx);
+
+    assert.equal(notes.filter((m) => m === OMP_UNSUPPORTED_MESSAGE).length, 0, "no OMP warning on a pi host");
+    assert.deepEqual(handlers.get("session_before_compact")![0]!({}, {}), { cancel: true });
+    const sp = handlers.get("before_agent_start")![0]!({ systemPrompt: "BASE" }, {});
+    assert.ok(sp.systemPrompt.startsWith("BASE"));
+    assert.ok(sp.systemPrompt.includes("compress"));
+  });
+});


### PR DESCRIPTION
## Summary

Refuses ACP service on **OMP** (`can1357/oh-my-pi`) hosts. Fixes #234.

## Why

OMP's in-process session API diverges from Pi's. The compression refs billion-context-pi injects can drift out of sync with the session's real refs, so `compress` calls fail with `does not exist in this session` and one-shot runs never succeed. OMP is no longer actively supported on this plugin (maintainer note on #234) — the in-process integration is too complex to keep reliable.

## What changed

- **Host detection** — new `src/omp.ts`: `isOmpHost(sm) = !isPiHost(sm)`, reusing the existing feature-detect (Pi exposes `buildContextEntries`; OMP only `getBranch`).
- **Refuse at `session_start`** — on OMP the extension sets a `refused` flag and, once per process, warns (UI `notify` in TUI/RPC; `console.error` to stderr in headless one-shot; plus a log line) pointing users at the supported alternative.
- **Stand down** — when refused: the 4 ACP tools return the guidance message, the ACP system-prompt injection is skipped, the `context` transform is a no-op (messages pass through untouched), and host auto-compaction is left alone (no `cancel`).
- **Pi hosts are unaffected.**
- **Docs** — README gains a "Host support" section recommending [billion-context](https://github.com/ranxianglei/billion-context) for OMP.

## Alternative for OMP users

```bash
npm install -g billion-context
bili omp -- -p "your task"   # OMP through the proxy — refs never diverge
```

## Tests

- New `tests/omp-refuse.test.ts` (5 cases): single warning, tool refusal, headless stderr path, and Pi-host no-regression.
- `npm test` → **433 pass, 0 fail**. The existing OMP integration tests still pass (they exercise the context handler directly without firing `session_start`).
- `npm run typecheck` clean; `npm run build` succeeds.

No version bump here — that belongs to the release commit.
