### PR TITLE
fix(delegate): injectResult 以 run.status 判定 FAILED — watchdog null-code 有完整输出不再误报 (#244)

### DIFF
--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -149,7 +149,7 @@ const AGENT_NAMES = Object.keys(AGENTS);
 
 // ─── Run registry (module-level, shared across tools) ───────────────────────
 
-type RunStatus = "running" | "completed" | "failed" | "cancelled";
+export type RunStatus = "running" | "completed" | "failed" | "cancelled";
 
 interface DelegateRun {
   runId: string;
@@ -449,7 +449,7 @@ The delegate runs in its own clean pi process — it does NOT see this conversat
   };
 }
 
-function formatRunResult(run: DelegateRun): string {
+export function formatRunResult(run: DelegateRun): string {
   const timeoutNote = run.timedOut ? ` (timed out: ${run.timedOut})` : "";
   const header =
     run.status === "completed"
@@ -874,7 +874,7 @@ async function runDelegate(
           }
           // EOF-watchdog finalize has no exit code; if the output was delivered,
           // treat it as a completed result (the process is killed afterwards).
-          const effectiveCode = code ?? (output || stderrText ? 0 : null);
+          const effectiveCode = effectiveExitCode(code, output, stderrText);
           // Atomically flip status + result together: until this point the run
           // is still "running" to any observer, so a concurrent wait cannot
           // see "finished but result missing".
@@ -897,7 +897,7 @@ async function runDelegate(
             return;
           }
           const mode = delegateDisplayUsage;
-          const injected = injectResult(pi, args.agent, runId, args.task, code, file, run.timedOut, run.usage, mode, run.usageReported, run.status === "failed" ? body : undefined);
+          const injected = injectResult(pi, args.agent, runId, args.task, run.status, code, file, run.timedOut, run.usage, mode, run.usageReported, run.status === "failed" ? body : undefined);
           if (run.usage && !run.usageReported && (mode === "separate" || injected)) {
             run.usageReported = true;
           }
@@ -1074,11 +1074,22 @@ function formatSyncResult(agent: string, runId: string, task: string, r: ChildRe
   return formatPayload(header, file, task, body);
 }
 
+/** Watchdog/EOF finalize arrives with code === null (the child was killed or
+ *  never exited). If a result was delivered (non-empty reply or stderr), the
+ *  run counts as completed (0); otherwise it stays null = genuine failure. */
+export function effectiveExitCode(code: number | null, output: string, stderr: string): number | null {
+  return code ?? (output || stderr ? 0 : null);
+}
+
+/** status (set by finalize from the effective exit code) is the authority for
+ *  the FAILED/completed decision; the raw code is diagnostic display only
+ *  ("exit ?"), so the notification can never disagree with run.status. */
 export function injectResult(
   pi: ExtensionAPI,
   agent: string,
   runId: string,
   task: string,
+  status: RunStatus,
   code: number | null,
   file: string,
   timedOut?: string,
@@ -1093,8 +1104,8 @@ export function injectResult(
     logWarn("delegate", { event: "inject-skipped", runId, reason: "sendUserMessage unavailable" });
     return false;
   }
-  const failed = code !== 0;
-  const status = failed ? "FAILED ⚠️" : "completed";
+  const failed = status === "failed";
+  const statusLabel = failed ? "FAILED ⚠️" : "completed";
   // Tell the model how many other delegates are still running, so it doesn't
   // lose count when many were dispatched in a batch (e.g. launched 5, this is
   // the 2nd to return → "3 still running" → the model knows to keep waiting).
@@ -1141,7 +1152,7 @@ export function injectResult(
   const closing = failed
     ? "This delegate did NOT complete its task — its result is missing from your work. Read the error excerpt (and the result file if present), then decide whether to re-dispatch the task before wrapping up. This is an automated system notification, NOT a user message."
     : "This is an automated system notification, NOT a user message. Read the result file if you need the details, then continue your original task; do not treat this as a new user request.";
-  const header = `[acp_delegate ${status}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine}${usageNote} ${closing}`;
+  const header = `[acp_delegate ${statusLabel}] **${agent}** (runId \`${runId}\`, exit ${code ?? "?"})${timeoutNote}${remainingLine}${usageNote} ${closing}`;
   const { text: recoveryText, covered } = buildRecoveryNotice(Array.from(runs.values()), runId);
   const text = formatPayload(header, file, task, failed ? body : undefined) + (recoveryText ? `\n\n${recoveryText}` : "");
   try {
@@ -1174,6 +1185,7 @@ function notifyTerminalFailure(pi: ExtensionAPI, run: DelegateRun, body: string)
     run.agent,
     run.runId,
     run.task,
+    run.status,
     run.result?.code ?? null,
     run.result?.file ?? "",
     run.timedOut,

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, buildRecoveryNotice, makeDelegateTool } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, effectiveExitCode, formatRunResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, buildRecoveryNotice, makeDelegateTool } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -288,7 +288,7 @@ const USAGE_FIXTURE = { input: 150, output: 80, cacheRead: 0, cacheWrite: 0, tot
 test("injectResult accumulates usage in separate mode when unreported", () => {
   resetDelegateUsage();
   const pi = { sendUserMessage: () => {} };
-  const ok = injectResult(pi as any, "reviewer", "del_x", "test", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "separate", false);
+  const ok = injectResult(pi as any, "reviewer", "del_x", "test", "completed", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "separate", false);
   assert.equal(ok, true, "injection succeeds");
   const total = getDelegateUsage();
   assert.ok(total, "usage accumulated into session total");
@@ -299,7 +299,7 @@ test("injectResult accumulates usage in separate mode when unreported", () => {
 test("injectResult does not double-accumulate when usage already reported", () => {
   resetDelegateUsage();
   const pi = { sendUserMessage: () => {} };
-  const ok = injectResult(pi as any, "reviewer", "del_x", "test", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "separate", true);
+  const ok = injectResult(pi as any, "reviewer", "del_x", "test", "completed", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "separate", true);
   assert.equal(ok, true, "injection succeeds");
   assert.equal(getDelegateUsage(), undefined, "no accumulation when already reported");
 });
@@ -307,7 +307,7 @@ test("injectResult does not double-accumulate when usage already reported", () =
 test("injectResult merged mode injects without accumulating", () => {
   resetDelegateUsage();
   const pi = { sendUserMessage: () => {} };
-  const ok = injectResult(pi as any, "reviewer", "del_x", "test", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "merged", false);
+  const ok = injectResult(pi as any, "reviewer", "del_x", "test", "completed", 0, "/tmp/del_x.out", undefined, USAGE_FIXTURE, "merged", false);
   assert.equal(ok, true, "injection succeeds");
   assert.equal(getDelegateUsage(), undefined, "merged mode never accumulates");
 });
@@ -315,13 +315,13 @@ test("injectResult merged mode injects without accumulating", () => {
 test("injectResult without usage leaves cumulative total undefined", () => {
   resetDelegateUsage();
   const pi = { sendUserMessage: () => {} };
-  const ok = injectResult(pi as any, "reviewer", "del_x", "test", 0, "/tmp/del_x.out", undefined, undefined, "separate", false);
+  const ok = injectResult(pi as any, "reviewer", "del_x", "test", "completed", 0, "/tmp/del_x.out", undefined, undefined, "separate", false);
   assert.equal(ok, true, "injection succeeds");
   assert.equal(getDelegateUsage(), undefined, "no usage, no accumulation");
 });
 
 test("injectResult returns false when sendUserMessage unavailable", () => {
-  const ok = injectResult({} as any, "reviewer", "del_x", "test", 0, "/tmp/del_x.out");
+  const ok = injectResult({} as any, "reviewer", "del_x", "test", "completed", 0, "/tmp/del_x.out");
   assert.equal(ok, false, "no sendUserMessage means no injection");
 });
 
@@ -368,7 +368,7 @@ function capturePi(sent: string[]): { sendUserMessage: (text: string) => void } 
 
 test("injectResult failed run uses a loud FAILED header and carries the error excerpt", () => {
   const sent: string[] = [];
-  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", 1, "/tmp/del_x.out", undefined, undefined, "separate", false, "Error: provider 429");
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", "failed", 1, "/tmp/del_x.out", undefined, undefined, "separate", false, "Error: provider 429");
   assert.equal(ok, true, "injection succeeds");
   const text = sent[0]!;
   assert.ok(text.includes("[acp_delegate FAILED"), "FAILED header");
@@ -380,12 +380,74 @@ test("injectResult failed run uses a loud FAILED header and carries the error ex
 
 test("injectResult completed run keeps the completed header and no body", () => {
   const sent: string[] = [];
-  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", 0, "/tmp/del_x.out", undefined, undefined, "separate", false, "must not appear");
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", "completed", 0, "/tmp/del_x.out", undefined, undefined, "separate", false, "must not appear");
   assert.equal(ok, true, "injection succeeds");
   const text = sent[0]!;
   assert.ok(text.includes("[acp_delegate completed]"), "completed header unchanged");
   assert.ok(!text.includes("FAILED"), "no FAILED marker");
   assert.ok(!text.includes("must not appear"), "completed runs carry no body");
+});
+
+// ─── #244: watchdog null-code finalize must not misreport FAILED ───────────
+// The watchdog/EOF grace kills the child (or it never exits), so close fires
+// with code === null even when the .out result is complete. finalize derives
+// run.status from the effective exit code; the notification must follow
+// run.status, never re-derive failure from the raw null code.
+
+test("effectiveExitCode: null code with delivered output counts as completed", () => {
+  assert.equal(effectiveExitCode(null, "full report", ""), 0, "non-empty output → 0");
+  assert.equal(effectiveExitCode(null, "", "stderr text"), 0, "non-empty stderr → 0");
+  assert.equal(effectiveExitCode(null, "", ""), null, "no output at all → null (genuine failure)");
+  assert.equal(effectiveExitCode(0, "", ""), 0, "real exit 0 untouched");
+  assert.equal(effectiveExitCode(1, "partial", ""), 1, "real non-zero code untouched");
+});
+
+test("injectResult null code + completed status: completed header, exit ?, no missing-result warning", () => {
+  const sent: string[] = [];
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", "completed", null, "/tmp/del_x.out", "output ended but process did not exit", undefined, "separate", false);
+  assert.equal(ok, true, "injection succeeds");
+  const text = sent[0]!;
+  assert.ok(text.includes("[acp_delegate completed]"), "completed header despite null code");
+  assert.ok(text.includes("exit ?"), "raw null code kept as diagnostic");
+  assert.ok(text.includes("output ended but process did not exit"), "watchdog reason kept as diagnostic");
+  assert.ok(!text.includes("FAILED"), "no FAILED marker");
+  assert.ok(!text.includes("did NOT complete"), "no result-missing warning");
+  assert.ok(!text.includes("re-dispatch"), "no re-dispatch pressure");
+});
+
+test("injectResult null code + failed status: still a loud FAILED", () => {
+  const sent: string[] = [];
+  const ok = injectResult(capturePi(sent) as any, "reviewer", "del_x", "review auth", "failed", null, "/tmp/del_x.out", undefined, undefined, "separate", false, "(no output)");
+  assert.equal(ok, true, "injection succeeds");
+  const text = sent[0]!;
+  assert.ok(text.includes("[acp_delegate FAILED"), "FAILED header for genuine failure");
+  assert.ok(text.includes("exit ?"), "null code shown as ?");
+  assert.ok(text.includes("did NOT complete"), "result-missing warning kept for real failures");
+});
+
+test("watchdog null-code completed run: direct, wait, and recovery paths agree", () => {
+  const run = mkRun("del_w", "completed", {
+    exitCode: null,
+    result: { code: null, file: "/tmp/del_w.out", body: "full report" },
+  });
+  // direct notification path
+  const sent: string[] = [];
+  injectResult(capturePi(sent) as any, run.agent, run.runId, run.task, run.status, run.exitCode, run.result.file, "output ended but process did not exit", undefined, "separate", false);
+  const direct = sent[0]!;
+  assert.ok(direct.includes("[acp_delegate completed]"), "direct: completed");
+  assert.ok(!direct.includes("FAILED"), "direct: no FAILED");
+  assert.ok(!direct.includes("did NOT complete"), "direct: no missing-result warning");
+
+  // wait path
+  const waitText = formatRunResult(run);
+  assert.ok(waitText.includes("completed"), "wait: completed");
+  assert.ok(!waitText.includes("FAILED"), "wait: no FAILED");
+
+  // recovery path
+  const { text: recText } = buildRecoveryNotice([run], undefined);
+  assert.ok(recText.includes("completed"), "recovery: completed");
+  assert.ok(!recText.includes("FAILED"), "recovery: no FAILED");
+  assert.ok(!recText.includes("missing"), "recovery: no missing-work warning");
 });
 
 // ─── undelivered recovery (#16) ─────────────────────────────────────────────


### PR DESCRIPTION
## 问题 (#244)

异步 `acp_delegate` 由 EOF/settled watchdog 收尾时 `close` 以 `code === null` 触发，finalize 已用 effective exit code 把「null code + 有效输出」判为 `completed`，但注入通知仍传原始 `code`，而 `injectResult` 用 `code !== 0` 自行推导状态 → `code === null` 时 `failed === true`，主会话收到 `FAILED ⚠️ / exit ? / did NOT complete its task — its result is missing`，尽管 `.out` 结果完整可读。

## 修复

- `injectResult` 新增显式 `status: RunStatus` 参数（来自 `run.status`，由 finalize 依据 effective exit code 设置），不再从 raw exit code 推导 FAILED/completed —— 即 issue 建议方案 2。
- raw `code` 仅作诊断展示（`exit ?`），watchdog reason（`timedOut`）保留在 header 中 —— 即建议方案 3。
- 两个调用点（finalize 注入、`notifyTerminalFailure`）均改传 `run.status`。
- `effectiveExitCode(code, output, stderr)` 从 finalize 提取为导出的纯函数（语义完全不变），便于回归测试。
- `formatRunResult` 导出，wait 路径可测。

## 回归测试（对应 issue 建议的 5 条）

1. `effectiveExitCode`: `close(null)` + 非空 output → 0（completed）；非空 stderr → 0；无任何输出 → null（failed）；真实 code 不受影响。
2. `injectResult` null code + completed → `completed` header、`exit ?` 诊断保留、watchdog reason 保留、无 FAILED、无 "did NOT complete" / "re-dispatch"。
3. `injectResult` null code + failed → 仍为响亮的 FAILED（真实失败不受影响）。
4. watchdog null-code completed run：direct injection / wait (`formatRunResult`) / recovery (`buildRecoveryNotice`) 三路径一致显示 completed。
5. `.out` 非空且 status=completed 时通知不含 "result is missing" 措辞。

## 验证

- `npm run typecheck` ✅
- `npm test` ✅ 432 pass / 0 fail（含 4 个新回归测试）
- `npm run build` ✅

## 备注

- 与 #235 / PR #236 相关但独立：PR #236 给 `injectResult` 追加了尾部参数（activityFile/signal），本 PR 在 `task` 后插入 `status` 参数，合并时该行会有小冲突，按「status 为权威、raw code 仅诊断」的语义保留两者即可。
- 基于 master (v0.1.52)。