### PR TITLE
fix(compress): break dead-range compress loops; add enabled master switch (closes #250)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -93,6 +93,7 @@ All keys below are currently **ACTIVE**.
 
 | Key | Type | Default | Status | Description |
 |-----|------|---------|--------|-------------|
+| `enabled` | boolean | `true` | 🟢 ACTIVE | Master switch. `false` turns the whole adapter off (no tools, no system prompt, no context transform) — for models too small to handle ACP. Requires a Pi restart. |
 | `debug` | boolean | `false` | 🟢 ACTIVE | Enable verbose debug-level events in the log. |
 | `autoUpdate` | boolean | `true` | 🟢 ACTIVE | Check npm for a newer version on startup and auto-install it. |
 | `modelContextLimit` | number | *(auto)* | 🟢 ACTIVE | Override the context limit (in tokens). |
@@ -146,6 +147,13 @@ All keys below are currently **ACTIVE**.
 ---
 
 ## General
+
+### `enabled`
+
+- **Type:** `boolean`
+- **Default:** `true`
+- **Status:** 🟢 ACTIVE
+- **Description:** Master switch for the entire adapter. Set to `false` to turn ACP off completely: no `compress`/`decompress`/`search_context`/`acp_status` tools, no ACP system prompt, no context transformation, and no suppression of Pi's built-in auto-compaction — Pi's native context management runs instead. Intended for small local models (e.g. quantized 27B) that cannot reliably drive ACP's compression loop. Checked once at extension load, so it requires restarting Pi after editing `acp.json`. Project-local `acp.json` overrides the global one.
 
 ### `debug`
 

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -5,9 +5,10 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
+import { MAX_COMPRESS_ATTEMPTS } from "./runtime.js";
 import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
-import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages } from "./tokens.js";
-import { defaultCountTokens, parseCompressArgs, type CompressionBlock, type CompressParseDiagnostics } from "acp-kernel";
+import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages, lastUserMessageId } from "./tokens.js";
+import { defaultCountTokens, parseCompressArgs, viableRanges, formatRanges, type CompressionBlock, type CompressionState, type CompressParseDiagnostics, type NudgeDecision } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
 
@@ -121,6 +122,87 @@ export function isCompressNoopText(text: string): boolean {
   return compressPanelBlocks(text) === 0;
 }
 
+// Issue #250 loop breaker: small models repeat an identical compress call with
+// refs that can NEVER resolve (stale/consumed/unknown) — the kernel rejects
+// every time and the model just retries the same dead refs for minutes. A
+// range is "dead" when the kernel's boundary resolver will reject it no matter
+// what summary is written, so repeating the same dead range set is guaranteed
+// to fail. After DEAD_REPEAT_REJECT identical failures we stop running the
+// kernel and return a hard rejection that lists the LIVE compressible ranges
+// (from the nudge decision already computed in this call), so the model gets
+// usable refs without having to call acp_status.
+const DEAD_REPEAT_REJECT = 2;
+
+function paddedRef(n: number): string {
+  return `m${String(n).padStart(5, "0")}`;
+}
+
+function blockHasVisibleAnchor(block: CompressionBlock, visibleIds: Set<string>): boolean {
+  if (visibleIds.has(`acp_summary_${block.blockId}`)) return true;
+  return block.effectiveMessageIds.some((id) => visibleIds.has(id));
+}
+
+function hasActiveOwner(state: CompressionState, ownedIds: string[], visibleIds: Set<string>): boolean {
+  const owned = new Set(ownedIds);
+  for (const block of state.blocks) {
+    if (!block.active) continue;
+    const inheritsOwned = block.directBlockIds.some((childId) => {
+      const child = state.blocks.find((c) => c.blockId === childId);
+      return child !== undefined && child.effectiveMessageIds.some((id) => owned.has(id));
+    });
+    if (inheritsOwned && blockHasVisibleAnchor(block, visibleIds)) return true;
+  }
+  return false;
+}
+
+function refIsDead(ref: string, state: CompressionState, visibleIds: Set<string>): boolean {
+  const trimmed = ref.trim();
+  if (/^b\d+$/i.test(trimmed)) {
+    const block = state.blocks.find((b) => b.blockId.toLowerCase() === trimmed.toLowerCase());
+    if (!block) return true;
+    if (block.active && blockHasVisibleAnchor(block, visibleIds)) return false;
+    return !hasActiveOwner(state, block.effectiveMessageIds, visibleIds);
+  }
+  const m = trimmed.match(/^m(\d+)$/i);
+  if (!m) return true;
+  const rawId = state.messageRefs.byRef[trimmed] ?? state.messageRefs.byRef[paddedRef(Number(m[1]))];
+  if (!rawId) return true;
+  if (visibleIds.has(rawId)) return false;
+  return !hasActiveOwner(state, [rawId], visibleIds);
+}
+
+function compressibleSnapshotText(nudge: NudgeDecision | undefined): string {
+  const ranges = viableRanges(nudge?.compressibleRanges ?? []);
+  if (ranges.length === 0) {
+    return "No compressible ranges remain — the context is already at its minimum; continue the task without compressing.";
+  }
+  return formatRanges(ranges, []);
+}
+
+function deadRepeatRejectionText(spans: string[], count: number, snapshot: string): string {
+  return [
+    "▣ ACP | 0 → 0 tokens (~0 reclaimed, 0 blocks)",
+    `[ACP] REJECTED — this exact compress call has now failed ${count}× (ranges ${spans.join(", ")}). Those refs are stale: they point at content already compressed into an active block, or at refs that no longer exist. Repeating this call cannot succeed — do not retry it.`,
+    "",
+    "Current compressible ranges (use these refs exactly as listed):",
+    snapshot,
+    "",
+    "If none of these fit, call acp_status for the full picture — or continue the task without compressing.",
+  ].join("\n");
+}
+
+function cappedRejectionText(snapshot: string): string {
+  return [
+    "▣ ACP | 0 → 0 tokens (~0 reclaimed, 0 blocks)",
+    `[ACP] PAUSED — ${MAX_COMPRESS_ATTEMPTS} compress attempts already failed this turn; further compress calls are rejected until the next user message.`,
+    "",
+    "Current compressible ranges (use these refs exactly as listed):",
+    snapshot,
+    "",
+    "Continue the task; compress becomes available again on the next user message.",
+  ].join("\n");
+}
+
 function tier3OnlyRewrite(newBlocks: CompressionBlock[], allBlocks: CompressionBlock[]): string[] | null {
   if (newBlocks.length === 0) return null;
   const byId = new Map(allBlocks.map((b) => [b.blockId, b]));
@@ -166,6 +248,18 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   });
   const state = turn.state;
   const messages = turn.messages;
+  const sid = ctx.sessionManager.getSessionId();
+  const turnKey = lastUserMessageId(entries) ?? sid;
+  const snapshot = compressibleSnapshotText(turn.nudge);
+  if (runtime.compressRetryCappedFor(turnKey)) {
+    logWarn("compress", { sid, event: "capped-reject", turnKey });
+    return cappedRejectionText(snapshot);
+  }
+  const visibleIds = new Set(messages.map((m) => m.id));
+  const deadSpans = ranges
+    .filter((r) => refIsDead(r.startId, state, visibleIds) || refIsDead(r.endId, state, visibleIds))
+    .map((r) => `${r.startId}..${r.endId}`);
+  const allDead = deadSpans.length === ranges.length;
   // beforeTokens on the same CJK-aware scale as the kernel's countTokens, so
   // "X → Y (~Z reclaimed)" compares like-for-like.
   const beforeTokens = estimateTokens(messages, collectCoveredMessageIds(state), imageTokens);
@@ -205,6 +299,15 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   }
   await runtime.save(applied.state, ctx);
   const { blocksCreated, tokensCompressed, errors, warnings } = applied.result;
+  if (blocksCreated > 0) {
+    runtime.clearDeadCompress(sid);
+  } else if (allDead) {
+    const count = runtime.noteDeadCompress(sid, ranges.map((r) => `${r.startId}..${r.endId}`).join("|"));
+    if (count >= DEAD_REPEAT_REJECT) {
+      logWarn("compress", { sid, event: "dead-range-reject", count, spans: deadSpans });
+      return deadRepeatRejectionText(deadSpans, count, snapshot);
+    }
+  }
 
   // Re-measure the post-compression sent view on the SAME scale as beforeTokens
   // (post-processTurn view: visible text + every active block's summary anchor

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,12 @@ export interface CompressConfig extends CompressSettings {
  * (live model context window, protected tools, state persistence).
  */
 export interface AdapterConfig {
+  /** Master switch. Default: true. Set `enabled: false` in acp.json (or
+   *  programmatically) to turn the whole adapter off — no tools, no system
+   *  prompt, no context transform — for models too small to handle ACP, where
+   *  Pi's native context management should run instead. Checked at extension
+   *  load; requires a Pi restart to take effect. */
+  enabled?: boolean;
   /** When omitted, the adapter reads `ctx.model.contextWindow` live each turn.
    *  Set explicitly for tests/headless runs. */
   modelContextLimit?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,10 @@ import type {
   ExtensionFactory,
   SessionMessageEntry,
 } from "@earendil-works/pi-coding-agent";
+import { CONFIG_DIR_NAME } from "@earendil-works/pi-coding-agent";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-kernel";
 import { renderNudgeText, resolvePrompts, defaultPrompts, viableRanges } from "acp-kernel";
 import { type AdapterConfig, resolveDelegate } from "./config.js";
@@ -46,6 +50,10 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
       console.log("[bcp] disabled: BILLION_CONTEXT_PROXY detected — proxy handles compression");
       return;
     }
+    if (adapter.enabled === false || userConfigDisabled(process.cwd())) {
+      console.log("[bcp] disabled: enabled=false — ACP tools and system prompt off; Pi's native context management is in control");
+      return;
+    }
     const runtime = createRuntime(adapter);
     wireCompactionDisable(pi, runtime);
     wireSessionLifecycle(pi, runtime);
@@ -65,6 +73,29 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
 }
 
 export default createAcpExtension();
+
+// Sync factory-time read of the `enabled` master switch: the factory runs at
+// extension load, before session_start (where the async loadUserConfig runs),
+// so a disabled adapter must be detected here to register nothing at all —
+// no tools, no system prompt, no context transform, and no compaction-cancel,
+// leaving Pi's native context management in control (issue #250: models too
+// small to handle ACP). Project acp.json overrides global; only a literal
+// enabled:true/false counts; missing/bad files mean "not disabled".
+function userConfigDisabled(cwd: string): boolean {
+  let disabled: boolean | undefined;
+  for (const base of [join(homedir(), CONFIG_DIR_NAME), join(cwd, CONFIG_DIR_NAME)]) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(join(base, "acp.json"), "utf8"));
+      if (parsed && typeof parsed === "object") {
+        const v = (parsed as Record<string, unknown>).enabled;
+        if (v === true || v === false) disabled = v;
+      }
+    } catch {
+      // missing file / bad JSON → not disabled
+    }
+  }
+  return disabled === false;
+}
 
 // ACP owns compression; cancel Pi's built-in auto-compaction entirely (mirrors
 // opencode-acp requiring opencode's compaction.auto = false). On a refused host
@@ -143,7 +174,8 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     // rpc/json/print have hasUI=false and the call is a no-op.
     delegateStatusWidget.setContext(ctx, runningRunsSnapshot);
   });
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (_event, ctx) => {
+    runtime.clearDeadCompress(ctx.sessionManager.getSessionId());
     delegateStatusWidget.dispose();
     closeLogStream();
   });

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -90,6 +90,15 @@ export interface AcpRuntime {
    *  the map entry so a long-lived process cycling through many sessions
    *  doesn't accumulate them. */
   overflowDrop(sid: string): void;
+  /** Record a compress call whose every requested range is dead (refs stale or
+   *  unknown — the kernel cannot create a block from it no matter what summary
+   *  is written). Returns the failure count for this exact range fingerprint
+   *  in this session (issue #250 loop breaker). */
+  noteDeadCompress(sid: string, fingerprint: string): number;
+  /** Drop a session's dead-range repeat tracking (a successful compress
+   *  renumbers refs so old fingerprints are meaningless; session_shutdown for
+   *  memory hygiene). */
+  clearDeadCompress(sid: string): void;
 }
 // omp fires the context event before the current user message is persisted to
 // the session branch, so merge event.messages (exact messages about to be sent,
@@ -254,6 +263,18 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
     overflowEpisodes.delete(sid);
   }
 
+  const deadCompressCounts = new Map<string, Map<string, number>>();
+  function noteDeadCompress(sid: string, fingerprint: string): number {
+    let per = deadCompressCounts.get(sid);
+    if (!per) { per = new Map(); deadCompressCounts.set(sid, per); }
+    const count = (per.get(fingerprint) ?? 0) + 1;
+    per.set(fingerprint, count);
+    return count;
+  }
+  function clearDeadCompress(sid: string): void {
+    deadCompressCounts.delete(sid);
+  }
+
   const throttleEpisodes = new Map<string, ThrottleEpisode>();
   function throttleFor(sid: string): ThrottleEpisode {
     let ep = throttleEpisodes.get(sid);
@@ -384,4 +405,4 @@ export function createRuntime(adapter: AdapterConfig): AcpRuntime {
   }
 
   let refused = false;
-  return { core, store, get refused() { return refused; }, set refused(v: boolean) { refused = v; }, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, throttleFor, throttleDrop };}
+  return { core, store, get refused() { return refused; }, set refused(v: boolean) { refused = v; }, get adapter() { return adapterRef; }, setAdapter: (a) => { adapterRef = a; }, get prompts() { return promptsRef; }, setPrompts: (p) => { promptsRef = p; }, markNudgeShown: (k) => { nudgeShownTurns.add(k); }, nudgeShownFor: (k) => nudgeShownTurns.has(k), clearNudgeTracking: () => { nudgeShownTurns.clear(); }, noteCompressOutcomes, compressRetryCappedFor, clearCompressRetryTracking, liveContextLimit, configFor, reloadConfig, stateFor, save, acquireLock, overflowFor, overflowDrop, noteDeadCompress, clearDeadCompress, throttleFor, throttleDrop };}

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -11,6 +11,7 @@ import { debug, logWarn } from "./log.js";
  *  ~/.<CONFIG_DIR_NAME>/acp.json (global) and <cwd>/.<CONFIG_DIR_NAME>/acp.json
  *  (project-local overrides project-global). Project wins over global. */
 export interface UserAcpConfig {
+  enabled?: boolean;
   debug?: boolean;
   autoUpdate?: boolean;
   modelContextLimit?: number;
@@ -53,7 +54,7 @@ function join(... parts: string[]): string {
 }
 
 const KNOWN = new Set([
-  "debug", "autoUpdate", "modelContextLimit",
+  "enabled", "debug", "autoUpdate", "modelContextLimit",
   "toolBashDefaultTimeout", "toolOutputMaxBytes",
   "delegate", "compress", "displayUsage", "throttleRetry",
   "prompts", "acknowledgePromptsRisk",

--- a/tests/compress-loop-breaker.test.ts
+++ b/tests/compress-loop-breaker.test.ts
@@ -1,0 +1,211 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createAcpExtension } from "../src/index.js";
+import { createRuntime } from "../src/runtime.js";
+import { isCompressSuccessText, isCompressNoopText } from "../src/compress-tool.js";
+
+// Issue #250 loop breaker (small local models, e.g. quantized 27B):
+// the model repeats an identical compress call with refs that can NEVER
+// resolve (stale — consumed by an active block — or unknown). The kernel
+// rejects every time and the model just retries the same dead refs for
+// minutes (issue log: 8 identical failures over 14 min AFTER the nudge cap
+// fired — the cap only suppressed nudge re-injection, not the tool itself,
+// and the kernel's "run acp_status" hint is unexecutable for small models).
+//
+// Behavior under test:
+//  1. noteDeadCompress/clearDeadCompress: per-session, per-fingerprint
+//     dead-range counter; cleared on the next successful compress.
+//  2. After 2 identical all-dead failures the tool returns a hard rejection
+//     (still a 0-block panel, so the per-turn failure counter keeps
+//     advancing) that lists the LIVE compressible ranges — no acp_status
+//     round-trip needed.
+//  3. Once the turn's MAX_COMPRESS_ATTEMPTS cap is burned, EVERY compress
+//     call is rejected until the next user message — even calls with live
+//     refs (the turn is paused, not just the dead range).
+//  4. A new user message resets the cap; a successful compress clears the
+//     dead-range fingerprint (the same range can fail fresh again later).
+//  5. enabled:false (adapter config or acp.json) registers nothing: no
+//     tools, no context transform — Pi's native compaction stays active.
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function roleMsg(id: string, role: string, text: string) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role, content: text, timestamp: Date.now() } };
+}
+
+function toolResultMsg(id: string, toolCallId: string, text: string, isError: boolean) {
+  return {
+    type: "message", id, parentId: null, timestamp: "",
+    message: {
+      role: "toolResult", toolCallId, toolName: "compress",
+      content: [{ type: "text", text }], isError, timestamp: Date.now(),
+    },
+  };
+}
+
+function fakeCtx(getEntries: () => any[], stateFile: string) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000, id: "test-model" },
+    getContextUsage: () => null,
+    sessionManager: {
+      buildContextEntries: () => getEntries(),
+      getSessionId: () => "loop-test-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+}
+
+const fire = (handlers: Map<string, ((e: any, ctx: any) => any)[]>, ctx: any) =>
+  handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
+
+const textOf = (out: any) => (typeof out === "string" ? out : out.content?.[0]?.text ?? String(out));
+
+const ZH = "中".repeat(6000);
+
+// ─── unit: dead-range counter ───────────────────────────────────────────────
+
+test("noteDeadCompress/clearDeadCompress: per-session, per-fingerprint, cleared on success", () => {
+  const rt = createRuntime({});
+  assert.equal(rt.noteDeadCompress("s1", "a"), 1);
+  assert.equal(rt.noteDeadCompress("s1", "a"), 2);
+  assert.equal(rt.noteDeadCompress("s1", "b"), 1, "different fingerprint counts independently");
+  assert.equal(rt.noteDeadCompress("s2", "a"), 1, "different session counts independently");
+  rt.clearDeadCompress("s1");
+  assert.equal(rt.noteDeadCompress("s1", "a"), 1, "cleared fingerprint restarts at 1");
+  assert.equal(rt.noteDeadCompress("s2", "a"), 2, "clearing one session leaves the other untouched");
+});
+
+// ─── integration: the issue #250 loop ───────────────────────────────────────
+
+test("issue #250: dead-range repeat breaker + turn cap + reset on new turn", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-loop-main.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  // 16 alternating messages (last user = e15, recent zone = e12..e16, so
+  // e9..e11 are the live compressible range after t1).
+  let entries: any[] = [];
+  for (let i = 1; i <= 16; i++) entries.push(roleMsg(`e${i}`, i % 2 ? "user" : "assistant", `m${i} ` + ZH));
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx);
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const S = (a: string, b: string) => [{ startId: a, endId: b, summary: "Loop breaker integration test summary covering the compressed range content." }];
+  const run = async (id: string, ranges: any[]) => {
+    const text = textOf(await compressTool.execute(id, { content: ranges }, undefined, undefined, ctx));
+    entries = [...entries, toolResultMsg(`r${id}`, id, text, false)];
+    await fire(handlers, ctx);
+    return text;
+  };
+
+  const t1 = await run("tc1", S("m00001", "m00008"));
+  assert.ok(isCompressSuccessText(t1), `t1 should succeed: ${t1}`);
+
+  const t2 = await run("tc2", S("m00001", "m00008"));
+  assert.ok(isCompressNoopText(t2), `t2 is a 0-block kernel panel: ${t2}`);
+  assert.ok(!t2.includes("REJECTED"), "first dead failure shows the kernel's canonical error");
+
+  const t3 = await run("tc3", S("m00001", "m00008"));
+  assert.ok(t3.includes("REJECTED"), `t3 is the hard rejection: ${t3}`);
+  assert.ok(isCompressNoopText(t3), "rejection stays a 0-block panel (counts toward the cap)");
+  assert.ok(t3.includes("m00009"), `rejection lists the live compressible range: ${t3}`);
+
+  const t4 = await run("tc4", S("m00001", "m00008"));
+  assert.ok(t4.includes("REJECTED"), "t4 still rejected");
+
+  // t2..t4 burned the turn's 3-attempt cap → every compress call is paused
+  const t5 = await run("tc5", S("m00099", "m00100"));
+  assert.ok(t5.includes("PAUSED"), `t5 paused by the turn cap: ${t5}`);
+
+  const t6 = await run("tc6", S("m00009", "m00010"));
+  assert.ok(t6.includes("PAUSED"), "even a LIVE range is paused until the next user message");
+
+  entries = [...entries, roleMsg("e17", "user", "next question")];
+  await fire(handlers, ctx);
+
+  const t7 = await run("tc7", S("m00009", "m00010"));
+  assert.ok(isCompressSuccessText(t7), `t7 succeeds after the new turn: ${t7}`);
+
+  const t8 = await run("tc8", S("m00001", "m00008"));
+  assert.ok(isCompressNoopText(t8), `t8 is a fresh kernel panel: ${t8}`);
+  assert.ok(!t8.includes("REJECTED"), "fingerprint cleared by t7's success — no hard rejection yet");
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+test("issue #250: unknown-ref dead ranges get the hard rejection with a live snapshot", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+  const stateFile = "/tmp/pai-acp-loop-unknown.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  let entries: any[] = [];
+  for (let i = 1; i <= 8; i++) entries.push(roleMsg(`e${i}`, i % 2 ? "user" : "assistant", `m${i} ` + ZH));
+  const ctx = fakeCtx(() => entries, stateFile);
+  await fire(handlers, ctx);
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const S = () => [{ startId: "m00099", endId: "m00100", summary: "unknown refs" }];
+  const run = async (id: string) => {
+    const text = textOf(await compressTool.execute(id, { content: S() }, undefined, undefined, ctx));
+    entries = [...entries, toolResultMsg(`r${id}`, id, text, false)];
+    await fire(handlers, ctx);
+    return text;
+  };
+
+  const u1 = await run("uc1");
+  assert.ok(isCompressNoopText(u1), `u1 is a 0-block kernel panel: ${u1}`);
+  assert.ok(u1.includes("does not exist"), "kernel reports unknown refs");
+
+  const u2 = await run("uc2");
+  assert.ok(u2.includes("REJECTED"), `u2 is the hard rejection: ${u2}`);
+  assert.ok(u2.includes("m00001"), `rejection lists the live compressible range: ${u2}`);
+  await rm(`${stateFile}.acp.json`, { force: true });
+});
+
+// ─── enabled:false master switch ────────────────────────────────────────────
+
+test("enabled:false (adapter config) registers nothing — Pi native compaction stays active", () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000, enabled: false })(api as any);
+  assert.equal(api.tools.length, 0, "no tools registered");
+  assert.equal(handlers.size, 0, "no event handlers wired");
+});
+
+test("enabled:false in project acp.json disables the adapter", () => {
+  const dir = mkdtempSync(join(tmpdir(), "bcp-loop-disabled-"));
+  mkdirSync(join(dir, ".pi"));
+  writeFileSync(join(dir, ".pi", "acp.json"), JSON.stringify({ enabled: false }));
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension({ modelContextLimit: 200_000 })(api as any);
+    assert.equal(api.tools.length, 0, "no tools registered");
+    assert.equal(handlers.size, 0, "no event handlers wired");
+  } finally {
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #250.

## Problem

Small local models (e.g. quantized 27B) loop on `compress`: they call it with the same stale/hallucinated refs, it fails, and they retry with identical parameters. In the issue log, 8 identical failures ran for 14 minutes AFTER the nudge circuit breaker fired — the existing per-turn cap only suppressed **nudge re-injection**, not the model's own compress calls. The kernel's "run acp_status" hint is unexecutable for small models.

## Changes

1. **Dead-range repeat breaker** (`src/compress-tool.ts`, `src/runtime.ts`)
   - The compress tool pre-checks each requested range against the kernel's boundary-resolver semantics (unknown ref, or consumed-without-active-owner = "dead").
   - After **2 identical all-dead failures** (session-scoped fingerprint), the tool returns a hard rejection listing the **LIVE compressible ranges** (from the nudge decision computed in the same call) — no acp_status round-trip needed.
   - The rejection keeps the 0-block panel shape (`▣ ACP | 0 → 0 tokens … 0 blocks`) so it is still classified as a no-op failure and keeps advancing the per-turn cap counter.
   - The fingerprint clears on the next successful compress and on session shutdown.
2. **Turn-cap tool enforcement** (`src/compress-tool.ts`)
   - Once `MAX_COMPRESS_ATTEMPTS` (3) failed/no-op outcomes burn in one user turn, every further compress call for that turn is rejected (`PAUSED`) until the next user message — including calls with live refs.
3. **`enabled: false` master switch** (`src/index.ts`, `src/config.ts`, `src/user-config.ts`, `CONFIGURATION.md`)
   - `{"enabled": false}` in `~/.pi/acp.json` or `<cwd>/.pi/acp.json` (project wins) disables the entire adapter at load time: no tools, no system prompt, no context transform, no compaction-cancel — Pi's native context management stays in control. For models too small to drive ACP.

No kernel changes — acp-kernel stays pinned at 0.0.46.

## Tests

New `tests/compress-loop-breaker.test.ts` (5 tests): dead-counter unit; full loop integration (success → stale kernel panel → REJECTED with live snapshot → cap burned → PAUSED even for live ranges → new user turn → success → fresh fingerprint); unknown-ref dead class; `enabled:false` via adapter config and via project acp.json.

`npm run typecheck && npm test && npm run build` — all green (433 tests).
