### PR TITLE
fix(compress): repair missing closing brace on last content entry

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -74,13 +74,44 @@ type RangeEntry = Static<typeof RangeSpec>;
 // the failure cap (a returned string would land as isError:false and count
 // as neutral). An empty array passes through (the call site returns "No
 // ranges provided.").
-function normalizeRanges(args: CompressArgs): RangeEntry[] | string {
-  const { ranges, diagnostics } = parseCompressArgs(args);
+export function normalizeRanges(args: CompressArgs): RangeEntry[] | string {
+  const effective = repairContentTail(args);
+  const { ranges, diagnostics } = parseCompressArgs(effective);
   if (ranges.length === 0) {
-    if (Array.isArray(args.content) && args.content.length === 0) return [];
-    return describeDiagnostics(diagnostics, args.content);
+    if (Array.isArray(effective.content) && effective.content.length === 0) return [];
+    return describeDiagnostics(diagnostics, effective.content);
   }
   return ranges.map((r) => ({ startId: r.startRef, endId: r.endRef, summary: r.summary, topic: r.topic }));
+}
+
+// Qwen-family models in non-strict tool-call mode sometimes emit the `content`
+// array as a JSON-encoded string whose LAST entry object is missing its closing
+// `}` (tail `"]` instead of `"}]`). The kernel's lenient parser then drops that
+// last range — or every range, when it is the only one — and reports a
+// misleading "truncated"/"no-valid-ranges" diagnostic. Repair the brace before
+// delegating so the whole array parses. Args are returned unchanged when the
+// repair does not apply.
+function repairContentTail(args: CompressArgs): CompressArgs {
+  if (typeof args.content !== "string") return args;
+  const repaired = tailRepair(args.content);
+  return repaired === undefined ? args : { ...args, content: repaired };
+}
+
+// Deterministic tail-repair: if the trimmed string ends with `"]` and the char
+// before it is a closing `"`, retry the parse with `"}]` appended. A valid JSON
+// array never still parses after appending `}`, so this has no false positives.
+export function tailRepair(s: string): string | undefined {
+  const t = s.trimEnd();
+  if (!t.endsWith("]")) return undefined;
+  const body = t.slice(0, -1).trimEnd();
+  if (!body.endsWith('"')) return undefined;
+  const candidate = body + "}]";
+  try {
+    if (Array.isArray(JSON.parse(candidate))) return candidate;
+  } catch {
+    // not the missing-brace case
+  }
+  return undefined;
 }
 
 function describeDiagnostics(diagnostics: CompressParseDiagnostics, content: CompressArgs["content"]): string {
@@ -94,7 +125,26 @@ function describeDiagnostics(diagnostics: CompressParseDiagnostics, content: Com
   if (diagnostics.invalidItems > 0) {
     return `${base}; ${diagnostics.invalidItems} entr${diagnostics.invalidItems === 1 ? "y was" : "ies were"} dropped as invalid. Each range must be an object with string fields startId, endId, summary.`;
   }
+  const parseErr = jsonParseError(content);
+  if (parseErr !== undefined) {
+    return `${base}; the JSON failed to parse: ${parseErr}. Fix the malformed JSON (e.g. a missing closing brace or quote) and retry.`;
+  }
   return `${base}. content must be an ARRAY of {startId, endId, summary} objects.`;
+}
+
+// Short diagnostic for why a JSON-shaped string fails to parse, or undefined
+// when it parses fine or is not JSON-shaped. Gives the model a retryable signal
+// (the parser's own position) instead of the misleading "must be an ARRAY".
+function jsonParseError(content: CompressArgs["content"]): string | undefined {
+  if (typeof content !== "string") return undefined;
+  const t = content.trim();
+  if (!t.startsWith("{") && !t.startsWith("[")) return undefined;
+  try {
+    JSON.parse(t);
+    return undefined;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
 }
 
 /** Panel block count ("… (~N reclaimed, B blocks)"), or -1 for non-panels. */

--- a/tests/compress-tail-repair.test.ts
+++ b/tests/compress-tail-repair.test.ts
@@ -1,0 +1,159 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+import { normalizeRanges, tailRepair } from "../src/compress-tool.js";
+
+// issue #253: Qwen-family non-strict tool calls drop the last entry's closing
+// `}` (tail `"]` instead of `"}]`). The kernel parser then drops the last range
+// (or every range, when it is the only one) and reports a misleading
+// "truncated"/"no-valid-ranges" + "must be an ARRAY" diagnostic. The adapter
+// repairs the brace before delegating and, when the input is array-shaped but
+// still unparseable, reports the parser's own diagnostic instead.
+
+// Build a content-array string, then drop the last entry's closing `}`.
+function dropLastBrace(arr: unknown[]): string {
+  const s = JSON.stringify(arr);
+  return s.slice(0, s.length - 2) + "]";
+}
+
+// ─── unit: tailRepair (the deterministic repair) ────────────────────────────
+
+test("tailRepair recovers a single entry missing its closing `}`", () => {
+  const broken = dropLastBrace([{ startId: "m00001", endId: "m00010", summary: "s" }]);
+  assert.ok(broken.endsWith('"]') && !broken.endsWith('"}]'), "precondition: tail is `\"]`");
+  const repaired = tailRepair(broken);
+  assert.equal(repaired, JSON.stringify([{ startId: "m00001", endId: "m00010", summary: "s" }]));
+});
+
+test("tailRepair recovers a multi-entry array whose LAST entry is missing `}`", () => {
+  const arr = [
+    { startId: "m00001", endId: "m00010", summary: "a" },
+    { startId: "m00011", endId: "m00020", summary: "b" },
+    { startId: "m00021", endId: "m00030", summary: "c" },
+  ];
+  const repaired = tailRepair(dropLastBrace(arr));
+  assert.deepEqual(JSON.parse(repaired!), arr);
+});
+
+test("tailRepair has no false positives on well-formed inputs", () => {
+  // A valid object array ends in `}]` → body ends in `}`, not `"`.
+  assert.equal(tailRepair('[{"startId":"m1","endId":"m2","summary":"x"}]'), undefined);
+  // A valid string array: appending `}` yields invalid JSON.
+  assert.equal(tailRepair('["a"]'), undefined);
+  // Empty array: body `[` does not end in `"`.
+  assert.equal(tailRepair("[]"), undefined);
+  // Not array-shaped at all.
+  assert.equal(tailRepair('{"content": []}'), undefined);
+  assert.equal(tailRepair("not json"), undefined);
+  // A genuine mid-array defect (missing brace between entries) is NOT the tail
+  // case — left untouched for the accurate error path to report.
+  assert.equal(tailRepair('[{"startId":"m1","endId":"m2","summary":"a"{"startId":"m3","endId":"m4","summary":"b"}]'), undefined);
+});
+
+test("tailRepair tolerates trailing whitespace after the `]`", () => {
+  const broken = dropLastBrace([{ startId: "m1", endId: "m2", summary: "s" }]) + "  \n";
+  assert.equal(tailRepair(broken), JSON.stringify([{ startId: "m1", endId: "m2", summary: "s" }]));
+});
+
+// ─── unit: normalizeRanges (repair wired in + accurate errors) ──────────────
+
+test("normalizeRanges repairs a single-entry missing-`}` payload (the #253 failure)", () => {
+  const summary = "Auth exploration: src/auth/login.ts:12, src/auth/token.ts:45. Chose JWT over session because stateless. saved at /home/dog/tmp/comments_early.json.";
+  const broken = dropLastBrace([{ startId: "m00001", endId: "m00010", summary }]);
+  const out = normalizeRanges({ content: broken });
+  assert.ok(Array.isArray(out), `expected ranges, got error: ${out}`);
+  assert.equal(out.length, 1);
+  assert.deepEqual(out[0], { startId: "m00001", endId: "m00010", summary, topic: undefined });
+});
+
+test("normalizeRanges recovers ALL ranges when the last entry is missing `}`", () => {
+  const broken = dropLastBrace([
+    { startId: "m00001", endId: "m00010", summary: "first" },
+    { startId: "m00011", endId: "m00020", summary: "second" },
+    { startId: "m00021", endId: "m00030", summary: "third" },
+  ]);
+  const out = normalizeRanges({ content: broken });
+  assert.ok(Array.isArray(out), `expected ranges, got error: ${out}`);
+  assert.equal(out.length, 3, "the previously-dropped last range is recovered");
+  assert.deepEqual(out.map((r) => `${r.startId}..${r.endId}`), ["m00001..m00010", "m00011..m00020", "m00021..m00030"]);
+});
+
+test("normalizeRanges applies the top-level topic to repaired ranges", () => {
+  const broken = dropLastBrace([{ startId: "m00001", endId: "m00005", summary: "s" }]);
+  const out = normalizeRanges({ topic: "Auth", content: broken });
+  assert.ok(Array.isArray(out));
+  assert.equal(out[0].topic, "Auth");
+});
+
+test("normalizeRanges leaves a well-formed string array untouched", () => {
+  const s = JSON.stringify([{ startId: "m1", endId: "m2", summary: "x" }]);
+  const out = normalizeRanges({ content: s });
+  assert.ok(Array.isArray(out));
+  assert.equal(out.length, 1);
+  assert.equal(out[0].startId, "m1");
+});
+
+test("array-shaped but unparseable (non-tail defect) → parser diagnostic, not 'must be an ARRAY'", () => {
+  const broken = '[{"startId": "m1", "endId": "m2", "summary": "unterminated';
+  const out = normalizeRanges({ content: broken });
+  assert.equal(typeof out, "string", `expected an error string, got: ${JSON.stringify(out)}`);
+  assert.match(out, /failed to parse/);
+  assert.doesNotMatch(out, /must be an ARRAY/);
+});
+
+test("non-array-shaped garbage still reports 'must be an ARRAY' (unchanged)", () => {
+  const out = normalizeRanges({ content: "not json {" });
+  assert.equal(typeof out, "string");
+  assert.match(out, /must be an ARRAY/);
+});
+
+// ─── integration: the repaired payload actually compresses end-to-end ───────
+
+test("compress tool succeeds on a missing-`}` string payload (end-to-end)", async () => {
+  const handlers = new Map<string, ((e: any, ctx: any) => any)[]>();
+  const api: any = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  createAcpExtension({ modelContextLimit: 200_000 })(api);
+  const stateFile = "/tmp/pai-acp-tail-repair-e2e.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+
+  const ZH = "中".repeat(6000);
+  const userMsg = (id: string, text: string) =>
+    ({ type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } });
+  const entries = [userMsg("e1", ZH)];
+  const ctx: any = {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: 200_000, id: "test-model" },
+    getContextUsage: () => null,
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "tail-repair-session",
+      getSessionFile: () => stateFile,
+    },
+  };
+  await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx); // assign refs
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const broken = dropLastBrace([{ startId: "m00001", endId: "m00001", summary: "compressed via tail repair" }]);
+  // Before the fix this REJECTED with "no-valid-ranges ... must be an ARRAY"
+  // (the single entry's missing `}` made the kernel parser drop it). After the
+  // fix the payload parses, so the tool resolves with a panel — never the
+  // misleading parse error.
+  const out = await compressTool.execute("tc1", { content: broken }, undefined, undefined, ctx);
+  const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  assert.match(text, /▣ ACP \|/, `expected a panel (payload accepted), got: ${text}`);
+  assert.doesNotMatch(text, /must be an ARRAY|no-valid-ranges/, `misleading parse error regressed: ${text}`);
+  await rm(`${stateFile}.acp.json`, { force: true });
+});


### PR DESCRIPTION
## Summary

Fixes #253.

With Qwen-family models in non-strict tool-call mode, the `compress` tool's `content` argument arrives as a JSON-encoded array string whose **last entry object is missing its closing `}`** (the tail is `\"` + `]` instead of `\"` + `}]`). `JSON.parse` rejects the whole string, and the tool surfaced a misleading error — `content must be an ARRAY` — even though the input *is* an array. This sent capable models into restructuring the payload instead of fixing the brace.

## Changes (`src/compress-tool.ts` only)

1. **Deterministic tail-repair** — `tailRepair()` / `repairContentTail()`: when `args.content` is a string that fails to parse and its trimmed form ends with `\"]` (preceded by `\"`), re-append `}` before the final `]` and retry. A no-op for well-formed input (a valid array never still parses after appending `}`), so there are no false positives. Wired into `normalizeRanges` before `parseCompressArgs`.
2. **Accurate error message** — `describeDiagnostics()` now detects array/object-shaped-but-unparseable content and reports the parser's own diagnostic (`the JSON failed to parse: Expecting ',' delimiter near char N`) instead of `must be an ARRAY`, giving the model a retryable signal. The `must be an ARRAY` fallback is preserved for genuinely non-array-shaped garbage.

## Why here and not in acp-kernel

The issue suggested the repair in acp-kernel's `parseContentArray`. I placed it in the adapter instead so this is a **self-contained, single-repo fix** — an acp-kernel change would require a cross-repo release (human PR merge + npm publish) before it could ship. The tail-repair could still be upstreamed to acp-kernel later so other hosts (opencode-acp) benefit; happy to open that as a follow-up if you want.

## Verification

- New `tests/compress-tail-repair.test.ts` (11 tests): single & multi-entry recovery, no-false-positive cases, trailing-whitespace tolerance, accurate error message, and an end-to-end tool test reproducing the #253 payload (single ~6 KB entry with the dropped `}`) that previously rejected with `no-valid-ranges … must be an ARRAY` and now resolves successfully.
- `npm run typecheck` clean · `npm test` **439 pass, 0 fail** (no regressions) · `npm run build` clean (dist 521.71 KB, repair present in bundle).

## Notes

- Content commit — no `version` bump (release-branch territory).
- Not merging (human-only).