### PR TITLE
Show /acp and /acp-status as persistent custom messages (#255)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,6 @@
-import type { ExtensionCommandContext, RegisteredCommand, SessionEntry } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, RegisteredCommand, SessionEntry } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
+import { ACP_STATUS_CUSTOM_TYPE } from "./messages.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 import { collectCoveredMessageIds, estimateTokens, calibrateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
@@ -25,20 +26,31 @@ function cacheUsageSamples(entries: SessionEntry[]): Array<{ input: number; cach
   return out;
 }
 
-export function makeCommands(runtime: AcpRuntime): Array<{ name: string; options: CommandOptions }> {
+export function makeCommands(runtime: AcpRuntime, pi?: ExtensionAPI): Array<{ name: string; options: CommandOptions }> {
+  // Persistent transcript output (rendered by TUI and web hosts like pi-web);
+  // notify() is a transient toast and only the fallback for hosts without
+  // sendMessage (issue #255).
+  const statusHandler = async (_args: string, ctx: ExtensionCommandContext) => {
+    const text = await statusReport(runtime, ctx);
+    if (typeof pi?.sendMessage === "function") {
+      pi.sendMessage({ customType: ACP_STATUS_CUSTOM_TYPE, content: text, display: true });
+      return;
+    }
+    ctx.ui.notify(text);
+  };
   return [
     {
       name: "acp",
       options: {
         description: "Show ACP context usage, token breakdown, and compression status.",
-        handler: async (_args, ctx) => ctx.ui.notify(await statusReport(runtime, ctx)),
+        handler: statusHandler,
       },
     },
     {
       name: "acp-status",
       options: {
         description: "Detailed ACP status (block tiers, token breakdown, delegate usage).",
-        handler: async (_args, ctx) => ctx.ui.notify(await statusReport(runtime, ctx)),
+        handler: statusHandler,
       },
     },
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     pi.registerTool(makeDecompressTool(runtime));
     pi.registerTool(makeSearchTool(runtime));
     pi.registerTool(makeStatusTool(runtime));
-    for (const { name, options } of makeCommands(runtime)) {
+    for (const { name, options } of makeCommands(runtime, pi)) {
       pi.registerCommand(name, options);
     }
   };

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,13 +18,17 @@ const REF_TAG_SOURCE = "(?:\x3cacp\\s[^>]*\x3em\\d{5}\x3c/acp\x3e|\\[m\\d{1,5}\\
 const REF_TAG = new RegExp(`^${REF_TAG_SOURCE}\\s?\\n?`);
 const TRAILING_REF_TAG = new RegExp(`\\n*${REF_TAG_SOURCE}\\s*$`);
 
+// /acp panels are UI-only transcript output (issue #255): persistent in the
+// session, but never projected into the sent view.
+export const ACP_STATUS_CUSTOM_TYPE = "acp-status";
+
 export function entriesToCoreMessages(entries: SessionEntry[]): CoreMessage[] {
   const out: CoreMessage[] = [];
   for (const entry of entries) {
     if (entry.type !== "message") {
       // custom_message participates in LLM context per Pi native semantics
       // (session-manager.d.ts) — project it as a user message.
-      if (entry.type === "custom_message") {
+      if (entry.type === "custom_message" && entry.customType !== ACP_STATUS_CUSTOM_TYPE) {
         const text = extractText(entry.content);
         if (text.length > 0) {
           out.push({ id: entry.id, role: "user", contentType: "text", text });

--- a/tests/commands-kit-panel.test.ts
+++ b/tests/commands-kit-panel.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { AcpRuntime } from "../src/runtime.js";
-import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 
 // tsup defines CURRENT_VERSION at build time; under the node test runner it
 // is bare, so stub it before the module graph reads it.
@@ -132,4 +132,46 @@ test("/acp panel omits prompt cache section when entries carry no usage", async 
   const text = notified[0] ?? "";
   assert.ok(text, "panel rendered");
   assert.doesNotMatch(text, /Prompt cache/, `cache section must be omitted without cache-reported requests:\n${text}`);
+});
+
+test("/acp and /acp-status emit a persistent custom message via pi.sendMessage (issue #255)", async () => {
+  const sent: Array<{ customType: string; content: string; display: boolean }> = [];
+  const pi = { sendMessage: (m: { customType: string; content: string; display: boolean }) => sent.push(m) } as unknown as ExtensionAPI;
+  const notified: string[] = [];
+  const ctx = {
+    ui: { notify: (t: string) => notified.push(t) },
+    getContextUsage: () => ({ tokens: 430_000 }),
+    model: { contextWindow: 1_000_000 },
+    sessionManager: { getSessionId: () => "s5", getSessionFile: () => "/tmp/s5.json" },
+  } as unknown as ExtensionCommandContext;
+
+  for (const name of ["acp", "acp-status"]) {
+    const cmd = makeCommands(fakeRuntime(), pi).find((c) => c.name === name)!;
+    await cmd.options.handler!("", ctx);
+  }
+
+  assert.equal(sent.length, 2, "one custom message per command");
+  assert.equal(notified.length, 0, "notify must not fire when sendMessage is available");
+  for (const m of sent) {
+    assert.equal(m.customType, "acp-status");
+    assert.equal(m.display, true, "display:true renders persistently in TUI and web hosts");
+    assert.match(m.content, /Context \(session accounting, host footer scale\): 43%/, "panel text is the custom message content");
+  }
+});
+
+test("/acp falls back to notify when pi lacks sendMessage", async () => {
+  const pi = {} as unknown as ExtensionAPI;
+  const notified: string[] = [];
+  const ctx = {
+    ui: { notify: (t: string) => notified.push(t) },
+    getContextUsage: () => ({ tokens: 430_000 }),
+    model: { contextWindow: 1_000_000 },
+    sessionManager: { getSessionId: () => "s6", getSessionFile: () => "/tmp/s6.json" },
+  } as unknown as ExtensionCommandContext;
+
+  const acp = makeCommands(fakeRuntime(), pi).find((c) => c.name === "acp")!;
+  await acp.options.handler!("", ctx);
+
+  assert.equal(notified.length, 1, "fallback notify fires");
+  assert.match(notified[0]!, /Token Breakdown \(sent view\):/, "panel text via notify");
 });

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { entriesToCoreMessages, coreOutToAgentMessages, matchesStoredText, messageIdentity } from "../src/messages.js";
+import { entriesToCoreMessages, coreOutToAgentMessages, matchesStoredText, messageIdentity, ACP_STATUS_CUSTOM_TYPE } from "../src/messages.js";
 import type { CoreMessage } from "acp-kernel";
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 
@@ -194,6 +194,18 @@ test("entriesToCoreMessages drops custom_message with non-text-only array conten
   const core = entriesToCoreMessages(entries);
 
   assert.equal(core.length, 0, "non-text array content yields empty text → skipped");
+});
+
+test("entriesToCoreMessages drops acp-status panels (UI-only, never sent to model)", () => {
+  const entries: SessionEntry[] = [
+    msgEntry("a", user("before")),
+    customEntry("b", ACP_STATUS_CUSTOM_TYPE, "╭── ACP ──╮\npanel body"),
+    customEntry("c", "subagent_result", "other custom messages still project"),
+    msgEntry("d", user("after")),
+  ];
+  const core = entriesToCoreMessages(entries);
+
+  assert.deepEqual(core.map((m) => m.id), ["a", "c", "d"], "acp-status panel excluded, other custom messages kept");
 });
 
 test("custom_message round-trip: entriesToCoreMessages → collectOriginals → coreOutToAgentMessages preserves user role", () => {


### PR DESCRIPTION
## Problem (#255)

In web hosts such as agegr/pi-web, `/acp` and `/acp-status` output goes through `ctx.ui.notify()`, which renders as a transient toast — the status panel disappears and is not part of the session transcript.

## Root cause

Not a pi-web bug: pi-web renders `notify()` as a toast by design (that's the documented semantics of the notify channel) and renders `custom_message` session entries persistently (`CustomMessageView` in the transcript). The bug is on our side — billion-context-pi routes persistent status content through the transient notification channel.

## Fix

- `/acp` and `/acp-status` now emit `pi.sendMessage({ customType: "acp-status", content: text, display: true })` — the documented mechanism for extension-injected messages. This persists a `custom_message` entry in the session JSONL (idle and streaming paths both persist via the session manager's `message_end` handler) and renders persistently in the TUI (`CustomMessageComponent`) and in web hosts (pi-web's `CustomMessageView`).
- `ctx.ui.notify(text)` remains the fallback for hosts without `sendMessage` (older pi).
- `entriesToCoreMessages` skips `acp-status` custom messages: the panel is UI-only and must never be projected into the sent view (otherwise every `/acp` run would add 1-3K tokens to the model's context). The model already has the `acp_status` tool for programmatic status.

## Tests

3 new tests (431 total, all passing):
- both commands emit the panel as a persistent custom message with `display: true`, no notify
- fallback to notify when `pi.sendMessage` is absent
- `entriesToCoreMessages` excludes `acp-status` panels while other extensions' custom messages still project

`npm run typecheck && npm test && npm run build` all green.