### PR TITLE
release v0.1.53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.52",
+	"version": "0.1.53",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.52",
+			"version": "0.1.53",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.52",
+	"version": "0.1.53",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
发布 v0.1.53(AGENTS.md §5 流程):`release v0.1.53` 提交,仅 `package.json`(0.1.52→0.1.53)+ `package-lock.json`(npm install 刷新)。acp-kernel pin 不变(0.0.46,无内核变更)。

**包含**(自 v0.1.52):
- #258 — fix: nudge/emergency 仲裁改用 provider 真实上下文(#257)+ density 校准系统移除
- #261 — fix(floor): provider-usage floor 跳过压缩后一轮的 stale anchor(#258 评审修复)

预检:typecheck ✅ · 422 pass / 0 fail ✅ · build ✅。合并后 CI 自动发布。