### PR TITLE
release v0.1.54

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.53",
+	"version": "0.1.54",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.53",
+			"version": "0.1.54",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.53",
+	"version": "0.1.54",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.54 — ships acp-kernel 0.0.48 (#263):
- kernel #175 stale-ref gate messages report true causes with diagnostics
- kernel #176 reclaim dead message refs, reuse exhausted capacity, classify boundary failures