### PR TITLE
release v0.1.55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.54",
+	"version": "0.1.55",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.54",
+			"version": "0.1.55",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.54",
+	"version": "0.1.55",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## v0.1.55

自 v0.1.54 以来合入的 5 个 PR,主题:compress 稳定性 + delegate 健壮性 + OMP 宿主拒绝。

| PR | 内容 |
|---|---|
| #237 | OMP 宿主拒绝 ACP 服务(指向 billion-context proxy) |
| #251 | compress 死循环打断 + `enabled` 总开关 (closes #250) |
| #254 | compress 尾括号修复 (fixes #253) |
| #236 | delegate 失败日志保留 + 诊断 + `resumeFrom` 续跑 (closes #235) |
| #230 | delegate 完成通知合并为单条批量消息 (closes #157) |

仅 bump 版本号(package.json + package-lock.json),与既有 release 流程一致。合并后触发 release workflow → npm publish。