### PR TITLE
feat(delegate): skip completion notification when model already read the result file (notifyIfRead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Worker runs on Pi's full default toolset - no `--tools` allowlist is applied, so
 
 The full delegate result is saved to a file (`/tmp/acp-delegate/<runId>.out`); the tool result and injected notification carry only the **task title + file path** (no preview) - use `read` for the details. This keeps the parent context lean.
 
-- **Interactive (TUI) & RPC modes**: `async:true` (default) runs the child in the background; a short completion notification is injected into the chat when it finishes.
+- **Interactive (TUI) & RPC modes**: `async:true` (default) runs the child in the background; a short completion notification is injected into the chat when it finishes — **unless the model already read the result file after the run finished** (detected via the `read` tool or a bash command referencing the file), in which case the notification is skipped: the model already has the result, so re-injecting it would only waste context. Set `delegate: { notifyIfRead: "always" }` in `acp.json` to restore the always-inject behavior.
 - **Print / JSON modes** (`pi -p`, SDK): `async:true` auto-downgrades to **synchronous** — the result returns as the tool result in the same turn (the parent exits after one turn, so background injection would be lost).
 - **Failures are loud, never silent.** A run that fails (nonzero exit, spawn error, watchdog timeout) injects a `FAILED ⚠️` notification carrying a short error excerpt, so a failed delegate cannot hide among sibling completions. If a notification cannot be delivered at all, a recovery notice is attached to the next delegate notification or the next `acp_delegate` / `acp_delegate_wait` / `acp_delegate_cancel` tool result — a dispatched run's failure always reaches the model before it wraps up.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,12 @@ export interface DelegateConfig {
    *  oracle, or any custom role). See DelegateRoleConfig. Only affects roles
    *  that are named here; other roles inherit the parent model + Pi defaults. */
   agents?: Record<string, DelegateRoleConfig>;
+  /** What happens to the completion notification when the model has already
+   *  read the delegate's result file after the run finished.
+   *  "skip" (default) — the notification is not injected; the model already
+   *  saw the result, so re-injecting it would only waste context.
+   *  "always" — always inject the notification (previous behavior). */
+  notifyIfRead?: "skip" | "always";
 }
 
 /** Resolved delegate policy: what actually takes effect after merging acp.json,
@@ -83,6 +89,9 @@ export interface DelegatePolicy {
   thinkingLevel?: string;
   /** Per-role defaults keyed by role name (undefined when unset). */
   agents?: Record<string, DelegateRoleConfig>;
+  /** Whether to suppress the completion notification when the model already
+   *  read the result file after the run finished. Always resolved ("skip" default). */
+  notifyIfRead: "skip" | "always";
 }
 
 export const DEFAULT_DELEGATE_POLICY: DelegatePolicy = {
@@ -93,6 +102,7 @@ export const DEFAULT_DELEGATE_POLICY: DelegatePolicy = {
   idleMs: 5 * 60_000,
   asyncTimeoutMs: 30 * 60_000,
   maxConcurrent: Infinity,
+  notifyIfRead: "skip",
 };
 
 /** Compression tuning fields, shared by all three levels (global, provider,
@@ -235,7 +245,7 @@ export function resolveDelegate(adapter: AdapterConfig): DelegatePolicy {
       hint: "no-output watchdog is off; hung async runs must be cancelled manually via acp_delegate_cancel",
     });
   }
-  return { enabled, displayUsage, maxDepth, syncTimeoutMs, idleMs, asyncTimeoutMs, maxConcurrent, thinkingLevel: cfg.thinkingLevel, agents: cfg.agents };
+  return { enabled, displayUsage, maxDepth, syncTimeoutMs, idleMs, asyncTimeoutMs, maxConcurrent, thinkingLevel: cfg.thinkingLevel, agents: cfg.agents, notifyIfRead: cfg.notifyIfRead ?? "skip" };
 }
 
 function resolveMaxDepth(value: number | string | undefined): number {

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -213,6 +213,15 @@ interface DelegateRun {
   /** True while the run sits in the coalescing notification queue (scheduled
    *  for the next batched flush, not yet delivered). */
   notifyQueued?: boolean;
+  /** When the model successfully read this run's result file (read tool, or a
+   *  bash command referencing it). A read at/after finishedAt means the model
+   *  already saw the final result — the completion notification is then
+   *  suppressed (notifyIfRead: "skip"). */
+  readAt?: number;
+  /** True when the completion notification was suppressed because the model
+   *  had already read the result file. Treated as delivered (injected=true)
+   *  so wait/recovery never re-surface the result. */
+  readSuppressed?: boolean;
 }
 const runs = new Map<string, DelegateRun>();
 
@@ -338,6 +347,50 @@ function normalizeModelRef(m: string | undefined): string | undefined {
   if (!m) return undefined;
   const s = m.trim();
   return s.includes("/") ? s : undefined;
+}
+
+let delegateNotifyIfRead: "skip" | "always" = "skip";
+
+export function setDelegateNotifyIfRead(mode: "skip" | "always"): void {
+  delegateNotifyIfRead = mode;
+}
+
+/** Mark the run whose result file the model just read (via the `read` tool).
+ *  Returns true when a run matched. A read of the final result file after the
+ *  run finished means the model already saw the result — the completion
+ *  notification is then suppressed (notifyIfRead: "skip"). */
+export function markDelegateResultRead(filePath: string): boolean {
+  if (!filePath) return false;
+  const abs = resolvePath(filePath);
+  let matched = false;
+  for (const run of runs.values()) {
+    if (join(OUT_DIR, `${run.runId}.out`) === abs) {
+      run.readAt = Date.now();
+      suppressIfReadNow(run);
+      matched = true;
+    }
+  }
+  return matched;
+}
+
+/** Mark runs referenced by a bash command (e.g. `cat <result file>`).
+ *  Matches runIds appearing anywhere in the command string; only existing
+ *  runs are affected, so task text that merely contains "del_..." is inert. */
+export function markDelegateRunReadByCommand(command: string): boolean {
+  if (!command) return false;
+  const ids = command.match(/del_[a-z0-9]+_[a-z0-9]+/g);
+  if (!ids) return false;
+  let matched = false;
+  const now = Date.now();
+  for (const id of new Set(ids)) {
+    const run = runs.get(id);
+    if (run) {
+      run.readAt = now;
+      suppressIfReadNow(run);
+      matched = true;
+    }
+  }
+  return matched;
 }
 
 
@@ -636,7 +689,7 @@ Agents (pick by name):
 ${AGENT_NAMES.map(agentListLine).join("\n")}
 
 Behavior:
-• async=true (default): returns immediately with a runId. The delegate runs in the background. Call acp_delegate_wait({ runId }) to block for its result (up to a timeout); if you let the timeout lapse, or never call wait, a short completion notification (status + file path) is still injected into this chat when it finishes. In one-shot sessions (print/json) async auto-downgrades to sync so the result is returned inline within the same turn. Call acp_delegate again to launch more runs in parallel.${concurrencyNote}
+• async=true (default): returns immediately with a runId. The delegate runs in the background. Call acp_delegate_wait({ runId }) to block for its result (up to a timeout); if you let the timeout lapse, or never call wait, a short completion notification (status + file path) is still injected into this chat when it finishes — unless you already read the result file after it finished, in which case the notification is skipped (you have the result). In one-shot sessions (print/json) async auto-downgrades to sync so the result is returned inline within the same turn. Call acp_delegate again to launch more runs in parallel.${concurrencyNote}
 • async=false: blocks until the delegate finishes. The full output is saved to a file; the tool result contains the path. Use the \`read\` tool to open the file for the complete content.
 
 There is NO non-blocking status tool. To get a delegate's result, call acp_delegate_wait with the runId — it blocks until the run finishes or the timeout elapses. Use acp_delegate_cancel only to stop a run you no longer want.
@@ -913,10 +966,15 @@ function withUndeliveredNotice(result: AgentToolResult<unknown>): AgentToolResul
  *  once via this tool result). Returns null when the run was NOT injected,
  *  in which case the caller delivers the full payload via formatRunResult(). */
 export function injectedWaitMessage(
-  run: { injected?: boolean; result?: { file: string } },
+  run: { injected?: boolean; readSuppressed?: boolean; result?: { file: string } },
   runId: string,
   remainingLine: string,
 ): string | null {
+  if (run.readSuppressed) {
+    const file = run.result?.file;
+    const fileLine = file ? ` The result file is: \`${file}\`.` : "";
+    return `Delegate \`${runId}\` already finished and you read its result file — no completion notification was injected.${remainingLine}${fileLine}`;
+  }
   if (!run.injected) return null;
   const file = run.result?.file;
   const fileLine = file ? ` If you need details, read the result file: \`${file}\`.` : "";
@@ -1366,6 +1424,19 @@ async function runDelegate(
               delegateStatusWidget.poke();
               return;
             }
+            // Read-tracking: if the model already read the final result file
+            // after this run finished, skip the completion notification — it
+            // would only re-inject content the model already saw. Completed runs
+            // only: a FAILED run's file holds partial output without any failure
+            // marker, so the model cannot tell it failed from the file — the
+            // FAILED notification must still go out.
+            if (run.status === "completed" && shouldSuppressRead(run, delegateNotifyIfRead)) {
+              applyReadSuppression(run, runId);
+              debug.event("delegate-done", { runId, code, status: run.status, injected: false, suppressed: true, outLen: output.length, file });
+              logInfo("delegate", { event: "done", runId, agent: args.agent, code, status: run.status, injected: false, suppressed: true, outLen: output.length, file });
+              delegateStatusWidget.poke();
+              return;
+            }
             scheduleRunNotification(pi, run);
             debug.event("delegate-done", { runId, code, status: run.status, injected: false, queued: true, outLen: output.length, file });
             logInfo("delegate", { event: "done", runId, agent: args.agent, code, status: run.status, injected: false, queued: true, outLen: output.length, file });
@@ -1439,7 +1510,7 @@ async function runDelegate(
         : `Delegated to **${args.agent}** (runId \`${runId}\`).`,
       `Task: ${truncate(taskText, 160)}`,
       `QUEUED — at most ${delegatePolicy.maxConcurrent} background delegate(s) run concurrently; ${Math.max(0, delegateGate.queuedCount - 1)} ahead of it. It starts automatically when a slot frees.`,
-      `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result; a completion notification is injected when it finishes.`,
+      `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result; a completion notification is injected when it finishes (unless you already read the result file after it finished — then it's skipped).`,
     ].join("\n");
   }
 
@@ -1664,6 +1735,42 @@ export function effectiveExitCode(code: number | null, output: string, stderr: s
   return code ?? (output || stderr ? 0 : null);
 }
 
+/** Should the completion notification be suppressed because the model already
+ *  read the final result file? Only a read at/after finishedAt counts — a read
+ *  while the run was still in flight (readAt < finishedAt) saw partial output,
+ *  so the notification still goes out. */
+export function shouldSuppressRead(
+  run: { readAt?: number; finishedAt?: number },
+  mode: "skip" | "always",
+): boolean {
+  if (mode !== "skip") return false;
+  if (run.readAt === undefined || run.finishedAt === undefined) return false;
+  return run.readAt >= run.finishedAt;
+}
+
+/** Suppress the completion notification for a run the model already read:
+ *  mark it delivered (so wait/recovery/flush never re-surface the result),
+ *  account its usage in separate mode, and log the skip. Idempotent. */
+export function applyReadSuppression(run: DelegateRun, runId: string): void {
+  run.readSuppressed = true;
+  run.injected = true;
+  if (run.usage && !run.usageReported && delegateDisplayUsage === "separate") {
+    addDelegateUsage(run.usage);
+    run.usageReported = true;
+  }
+  debug.event("delegate-inject-suppressed", { runId, reason: "result-file-read", readAt: run.readAt, finishedAt: run.finishedAt });
+  logInfo("delegate", { event: "inject-suppressed", runId, reason: "result-file-read", readAt: run.readAt, finishedAt: run.finishedAt });
+}
+
+/** Apply read-suppression immediately when a qualifying read just happened.
+ *  Covers the window where the notification is already queued in the
+ *  coalescing batch but not yet flushed: marking the run delivered here makes
+ *  the flush skip it. Inert for running runs (readAt < finishedAt) and for
+ *  "always" mode. */
+function suppressIfReadNow(run: DelegateRun): void {
+  if (shouldSuppressRead(run, delegateNotifyIfRead)) applyReadSuppression(run, run.runId);
+}
+
 /** status (set by finalize from the effective exit code) is the authority for
  *  the FAILED/completed decision; the raw code is diagnostic display only
  *  ("exit ?"), so the notification can never disagree with run.status. */
@@ -1765,6 +1872,10 @@ function notifyTerminalFailure(pi: ExtensionAPI, run: DelegateRun): void {
   const hadWaiter = run.waiter !== undefined;
   run.waiter?.();
   if (hadWaiter || run.consumed) return;
+  if (shouldSuppressRead(run, delegateNotifyIfRead)) {
+    applyReadSuppression(run, run.runId);
+    return;
+  }
   scheduleRunNotification(pi, run);
 }
 

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -1735,10 +1735,14 @@ export function effectiveExitCode(code: number | null, output: string, stderr: s
   return code ?? (output || stderr ? 0 : null);
 }
 
-/** Should the completion notification be suppressed because the model already
- *  read the final result file? Only a read at/after finishedAt counts — a read
- *  while the run was still in flight (readAt < finishedAt) saw partial output,
- *  so the notification still goes out. */
+/** Pure read-after-finish predicate: should the completion notification be
+ *  suppressed because the model already read the final result file? Only a
+ *  read at/after finishedAt counts — a read while the run was still in flight
+ *  (readAt < finishedAt) saw partial output, so the notification still goes
+ *  out. Callers additionally gate on run.status === "completed": a FAILED
+ *  run's file holds only partial output with no failure marker, so the model
+ *  cannot tell it failed from the file — failure notifications are never
+ *  suppressed (failures are loud). */
 export function shouldSuppressRead(
   run: { readAt?: number; finishedAt?: number },
   mode: "skip" | "always",
@@ -1765,10 +1769,11 @@ export function applyReadSuppression(run: DelegateRun, runId: string): void {
 /** Apply read-suppression immediately when a qualifying read just happened.
  *  Covers the window where the notification is already queued in the
  *  coalescing batch but not yet flushed: marking the run delivered here makes
- *  the flush skip it. Inert for running runs (readAt < finishedAt) and for
+ *  the flush skip it. Inert for running runs (readAt < finishedAt), for
+ *  non-completed runs (failed/cancelled — see shouldSuppressRead), and for
  *  "always" mode. */
 function suppressIfReadNow(run: DelegateRun): void {
-  if (shouldSuppressRead(run, delegateNotifyIfRead)) applyReadSuppression(run, run.runId);
+  if (run.status === "completed" && shouldSuppressRead(run, delegateNotifyIfRead)) applyReadSuppression(run, run.runId);
 }
 
 /** status (set by finalize from the effective exit code) is the authority for
@@ -1867,15 +1872,13 @@ export function injectResult(
  *  error, result persistence error). A parked waiter owns the result; with no
  *  waiter the model must still learn the run failed — the coalescing queue
  *  delivers it, and runs whose send fails land in the undelivered set for
- *  recovery. */
+ *  recovery. Read-suppression never applies here: a failed run's file holds
+ *  only partial output with no failure marker, so the notification must go
+ *  out. */
 function notifyTerminalFailure(pi: ExtensionAPI, run: DelegateRun): void {
   const hadWaiter = run.waiter !== undefined;
   run.waiter?.();
   if (hadWaiter || run.consumed) return;
-  if (shouldSuppressRead(run, delegateNotifyIfRead)) {
-    applyReadSuppression(run, run.runId);
-    return;
-  }
   scheduleRunNotification(pi, run);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { makeCompressTool, isCompressSuccessText, isCompressNoopText } from "./c
 import { makeDecompressTool } from "./decompress-tool.js";
 import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
-import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage, setDelegatePolicy, setDelegateDefaults } from "./delegate-tool.js";
+import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage, setDelegatePolicy, setDelegateDefaults, setDelegateNotifyIfRead, markDelegateResultRead, markDelegateRunReadByCommand } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages, extractText } from "./messages.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
@@ -57,6 +57,7 @@ export function createAcpExtension(adapter: AdapterConfig = {}): ExtensionFactor
     }
     const runtime = createRuntime(adapter);
     wireCompactionDisable(pi, runtime);
+    wireDelegateReadTracking(pi);
     wireSessionLifecycle(pi, runtime);
     wireContextTransform(pi, runtime);
     wireSystemPrompt(pi, runtime);
@@ -112,6 +113,24 @@ function wireCompactionDisable(pi: ExtensionAPI, runtime: AcpRuntime): void {
 // in pi, and interactive/rpc sessions are long-lived so their main loop
 // consumes the follow-up queue naturally — no shutdown drain needed.)
 
+// Read-tracking for delegate completion notifications (notifyIfRead: "skip"):
+// when the model reads a delegate's result file, mark the run as read so the
+// completion notification is skipped if the run finishes after that read.
+// Registered once per process; the runs registry is per-process, so delegate
+// child processes (nested delegates) track their own runs independently.
+function wireDelegateReadTracking(pi: ExtensionAPI): void {
+  pi.on("tool_result", (event) => {
+    if (event.isError) return;
+    if (event.toolName === "read") {
+      const p = (event.input as { path?: unknown }).path;
+      if (typeof p === "string") markDelegateResultRead(p);
+    } else if (event.toolName === "bash") {
+      const cmd = (event.input as { command?: unknown }).command;
+      if (typeof cmd === "string") markDelegateRunReadByCommand(cmd);
+    }
+  });
+}
+
 function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
   let ompWarned = false;
   pi.on("session_start", async (_event, ctx) => {
@@ -152,6 +171,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
       setDelegateDisplayUsage(delegateCfg.displayUsage);
       setDelegatePolicy(delegateCfg);
       setDelegateDefaults({ thinkingLevel: delegateCfg.thinkingLevel, agents: delegateCfg.agents });
+      setDelegateNotifyIfRead(delegateCfg.notifyIfRead);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
     }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -91,22 +91,30 @@ test("resolveConfig handles all three compress fields together", () => {
   assert.equal(cfg.nudge.growthCap, 40000);
 });
 
-test("resolveDelegate: undefined delegate defaults to enabled + separate", () => {
+test("resolveDelegate: undefined delegate defaults to enabled + separate + skip", () => {
   const r = resolveDelegate({});
   assert.equal(r.enabled, true);
   assert.equal(r.displayUsage, "separate");
+  assert.equal(r.notifyIfRead, "skip");
 });
 
 test("resolveDelegate: boolean true shorthand", () => {
   const r = resolveDelegate({ delegate: true });
   assert.equal(r.enabled, true);
   assert.equal(r.displayUsage, "separate");
+  assert.equal(r.notifyIfRead, "skip");
 });
 
 test("resolveDelegate: boolean false shorthand", () => {
   const r = resolveDelegate({ delegate: false });
   assert.equal(r.enabled, false);
   assert.equal(r.displayUsage, "separate");
+  assert.equal(r.notifyIfRead, "skip");
+});
+
+test("resolveDelegate: notifyIfRead always is honored, skip is the default", () => {
+  assert.equal(resolveDelegate({ delegate: { notifyIfRead: "always" } }).notifyIfRead, "always");
+  assert.equal(resolveDelegate({ delegate: { enabled: true } }).notifyIfRead, "skip");
 });
 
 test("resolveDelegate: object with enabled + displayUsage", () => {

--- a/tests/delegate-read-suppress.test.ts
+++ b/tests/delegate-read-suppress.test.ts
@@ -12,6 +12,9 @@ import {
   getDelegateUsage,
   setDelegateDisplayUsage,
   makeDelegateTool,
+  makeDelegateWaitTool,
+  runningRunsSnapshot,
+  flushDelegateNotifications,
 } from "../src/delegate-tool.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
@@ -139,4 +142,44 @@ test("markDelegateRunReadByCommand matches runIds referenced in a bash command",
 test("markDelegateRunReadByCommand ignores runId-looking text with no matching run", async () => {
   await seedRunId();
   assert.equal(markDelegateRunReadByCommand("echo del_nosuchrun_1234"), false, "unknown runId does not match");
+});
+
+// ─── failures are loud: read-suppression never applies to FAILED runs ──────
+// A failed run's result file holds only partial output — no exit status, no
+// failure marker. A model polling the file after the failure cannot tell the
+// run failed from the file alone, so the FAILED notification must go out even
+// when readAt >= finishedAt.
+
+test("failed run read after finish still gets its FAILED notification", async () => {
+  const sent: string[] = [];
+  const pi = { sendUserMessage: (t: string) => sent.push(t) } as unknown as Parameters<typeof makeDelegateTool>[0];
+  const tool = makeDelegateTool(pi);
+  const ctx = { ...mockCtx(), mode: "tui", cwd: process.cwd() } as unknown as ExtensionContext;
+  const res = await tool.execute(
+    "tc-fail-loud",
+    { agent: "oracle", task: "e2e", cwd: "/nonexistent-e2e-cwd", async: true },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const launch = (res.content[0] as { text?: string }).text ?? "";
+  const runId = /`(del_[a-z0-9_]+)`/.exec(launch)?.[1];
+  assert.ok(runId, `runId in launch message: ${launch}`);
+  const settleDeadline = Date.now() + 5000;
+  while (runningRunsSnapshot().length > 0 && Date.now() < settleDeadline) await new Promise((r) => setTimeout(r, 50));
+  assert.equal(runningRunsSnapshot().length, 0, "run settled");
+  // The model reads the result file AFTER the failure (e.g. it was polling
+  // for the result). readAt >= finishedAt now holds, but the run failed.
+  assert.equal(markDelegateResultRead(join(OUT_DIR, `${runId}.out`)), true, "read of the failed run's file matches");
+  flushDelegateNotifications();
+  const deliverDeadline = Date.now() + 5000;
+  while (!sent.some((t) => t.includes(runId!)) && Date.now() < deliverDeadline) await new Promise((r) => setTimeout(r, 50));
+  const mine = sent.find((t) => t.includes(runId!));
+  assert.ok(mine, `FAILED notification delivered despite the post-finish read, got ${JSON.stringify(sent)}`);
+  assert.match(mine!, /FAILED/);
+  assert.ok(!mine!.includes("no completion notification was injected"), "no suppression wording in the notification");
+  const waitTool = makeDelegateWaitTool(pi);
+  const waitRes = await waitTool.execute("tc-fail-loud-wait", { runId: runId! }, undefined, undefined, ctx);
+  const waitText = (waitRes.content[0] as { text?: string }).text ?? "";
+  assert.ok(!waitText.includes("no completion notification was injected"), `wait does not claim the notification was suppressed: ${waitText}`);
 });

--- a/tests/delegate-read-suppress.test.ts
+++ b/tests/delegate-read-suppress.test.ts
@@ -1,0 +1,142 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  shouldSuppressRead,
+  applyReadSuppression,
+  markDelegateResultRead,
+  markDelegateRunReadByCommand,
+  injectedWaitMessage,
+  resetDelegateUsage,
+  getDelegateUsage,
+  setDelegateDisplayUsage,
+  makeDelegateTool,
+} from "../src/delegate-tool.js";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+const OUT_DIR = join(tmpdir(), "acp-delegate");
+const USAGE_FIXTURE = { input: 150, output: 80, cacheRead: 0, cacheWrite: 0, totalTokens: 230, cost: { input: 0.0015, output: 0.0008, cacheRead: 0, cacheWrite: 0, total: 0.0023 } };
+
+/** Minimal ctx mock (same shape as delegate-tool.test.ts). */
+function mockCtx(): ExtensionContext {
+  const sessionManager = { buildContextEntries: () => [] };
+  return { model: { provider: "test", id: "test-model" }, sessionManager } as unknown as ExtensionContext;
+}
+
+// ─── shouldSuppressRead: pure decision ──────────────────────────────────────
+
+test("shouldSuppressRead: skip mode + read at/after finish → suppressed", () => {
+  assert.equal(shouldSuppressRead({ readAt: 100, finishedAt: 100 }, "skip"), true, "read exactly at finish counts");
+  assert.equal(shouldSuppressRead({ readAt: 200, finishedAt: 100 }, "skip"), true, "read after finish counts");
+});
+
+test("shouldSuppressRead: read while running (partial output) → not suppressed", () => {
+  assert.equal(shouldSuppressRead({ readAt: 50, finishedAt: 100 }, "skip"), false);
+});
+
+test("shouldSuppressRead: no read or no finish → not suppressed", () => {
+  assert.equal(shouldSuppressRead({}, "skip"), false);
+  assert.equal(shouldSuppressRead({ readAt: 100 }, "skip"), false, "read with unknown finish time is not provably final");
+  assert.equal(shouldSuppressRead({ finishedAt: 100 }, "skip"), false);
+});
+
+test("shouldSuppressRead: always mode never suppresses", () => {
+  assert.equal(shouldSuppressRead({ readAt: 200, finishedAt: 100 }, "always"), false);
+});
+
+// ─── applyReadSuppression: delivered marking + usage accounting ─────────────
+
+test("applyReadSuppression marks delivered and accumulates usage in separate mode", () => {
+  resetDelegateUsage();
+  setDelegateDisplayUsage("separate");
+  const run: any = { runId: "del_x", usage: USAGE_FIXTURE };
+  applyReadSuppression(run, "del_x");
+  assert.equal(run.readSuppressed, true);
+  assert.equal(run.injected, true, "treated as delivered so wait/recovery never re-surface it");
+  assert.equal(run.usageReported, true);
+  assert.equal(getDelegateUsage()?.input, 150, "usage still accounted in separate mode");
+});
+
+test("applyReadSuppression does not double-count already-reported usage", () => {
+  resetDelegateUsage();
+  setDelegateDisplayUsage("separate");
+  const run: any = { runId: "del_x", usage: USAGE_FIXTURE, usageReported: true };
+  applyReadSuppression(run, "del_x");
+  assert.equal(getDelegateUsage(), undefined, "no accumulation when already reported");
+});
+
+test("applyReadSuppression without usage leaves the total undefined", () => {
+  resetDelegateUsage();
+  setDelegateDisplayUsage("separate");
+  const run: any = { runId: "del_x" };
+  applyReadSuppression(run, "del_x");
+  assert.equal(getDelegateUsage(), undefined);
+});
+
+// ─── injectedWaitMessage: readSuppressed branch ─────────────────────────────
+
+test("injectedWaitMessage: readSuppressed run explains the skipped notification", () => {
+  const msg = injectedWaitMessage(
+    { readSuppressed: true, injected: true, result: { file: "/tmp/acp-delegate/del_x.out" } },
+    "del_x",
+    "",
+  );
+  assert.ok(msg, "returns a message for a read-suppressed run");
+  assert.ok(msg!.includes("del_x"), "names the runId");
+  assert.ok(msg!.includes("read its result file"), "explains why no notification arrived");
+  assert.ok(msg!.includes("/tmp/acp-delegate/del_x.out"), "points at the result file");
+  assert.ok(!msg!.includes("already delivered"), "does not claim a notification was delivered");
+});
+
+test("injectedWaitMessage: readSuppressed takes precedence over plain injected", () => {
+  const msg = injectedWaitMessage(
+    { readSuppressed: true, injected: true, result: {} },
+    "del_x",
+    " 2 delegates are still running.",
+  );
+  assert.ok(msg!.includes("2 delegates are still running"), "passes through the remaining line");
+  assert.ok(!msg!.includes("already delivered"), "suppressed wording wins");
+});
+
+// ─── read marking against the live runs registry ────────────────────────────
+// Seeds a real run via an ENOENT spawn (no LLM needed): the run lands in the
+// module registry, then the mark functions must match it by result-file path
+// and by runId-in-command.
+
+async function seedRunId(): Promise<string> {
+  const sent: string[] = [];
+  const pi = { sendUserMessage: (t: string) => sent.push(t) } as unknown as Parameters<typeof makeDelegateTool>[0];
+  const tool = makeDelegateTool(pi);
+  const ctx = { ...mockCtx(), mode: "tui", cwd: process.cwd() } as unknown as ExtensionContext;
+  const res = await tool.execute(
+    "tc-read-mark",
+    { agent: "oracle", task: "e2e", cwd: "/nonexistent-e2e-cwd", async: true },
+    undefined,
+    undefined,
+    ctx,
+  );
+  const launch = (res.content[0] as { text?: string }).text ?? "";
+  const runId = /`(del_[a-z0-9_]+)`/.exec(launch)?.[1];
+  assert.ok(runId, `runId in launch message: ${launch}`);
+  return runId!;
+}
+
+test("markDelegateResultRead matches the run's result file path", async () => {
+  const runId = await seedRunId();
+  assert.equal(markDelegateResultRead(join(OUT_DIR, `${runId}.out`)), true, "result file path matches the run");
+  assert.equal(markDelegateResultRead("/tmp/unrelated-file.txt"), false, "unrelated path does not match");
+  assert.equal(markDelegateResultRead(""), false, "empty path is inert");
+});
+
+test("markDelegateRunReadByCommand matches runIds referenced in a bash command", async () => {
+  const runId = await seedRunId();
+  assert.equal(markDelegateRunReadByCommand(`cat ${join(OUT_DIR, `${runId}.out`)}`), true, "cat of the result file matches");
+  assert.equal(markDelegateRunReadByCommand("ls /tmp"), false, "command without a runId does not match");
+  assert.equal(markDelegateRunReadByCommand(""), false, "empty command is inert");
+});
+
+test("markDelegateRunReadByCommand ignores runId-looking text with no matching run", async () => {
+  await seedRunId();
+  assert.equal(markDelegateRunReadByCommand("echo del_nosuchrun_1234"), false, "unknown runId does not match");
+});


### PR DESCRIPTION
子 agent follow-up 消息增加「已读」功能：模型已经读过结果文件时，默认不再注入完成通知（#239）。

## 背景
async delegate 结束后会注入一条完成通知（status + 结果文件路径）。但模型经常在 delegate 运行期间/结束后就 `read` 过结果文件，通知再注入一遍只是重复内容、浪费上下文。

## 实现
- **已读标记**：模型读取 delegate 结果文件（`/tmp/acp-delegate/<runId>.out`）时记录 `readAt`
  - `read` 工具读该文件 → `markDelegateResultRead`
  - bash 命令引用 runId（如 `cat <结果文件>`）→ `markDelegateRunReadByCommand`
  - 事件来源：pi 的 `tool_result` 事件（`src/index.ts` `wireDelegateReadTracking`，只处理成功结果）
- **抑制判定**：`readAt >= finishedAt`（任务**结束后**读过完整结果）才抑制；运行期间的读取算部分结果，通知照常发
- **与 coalesce 队列（#230）集成**：抑制检查在 `scheduleRunNotification` 入队前执行；`applyReadSuppression` 标记 `injected=true`，flush 的 `owned()` 与 `findUndeliveredRuns` 自动跳过，不会重复投递。另加 `suppressIfReadNow` 覆盖「已入队未 flush 时读到结果」的窗口
- **wait 文案**：对已抑制的 run 调 `acp_delegate_wait` 返回「你已读过结果文件，所以没有注入通知」，不误报「已送达」
- **用量**：separate 模式下被抑制 run 的 token 用量照常累计
- **配置**：`delegate.notifyIfRead` = `"skip"`（默认）| `"always"`（恢复总是注入）

## 验证
- 新增 `tests/delegate-read-suppress.test.ts`（抑制判定、用量累计、wait 文案、runId 匹配）+ 扩展 `tests/config.test.ts`
- 全量测试 475 通过 / 0 失败，`tsc --noEmit` 干净（基于 master v0.1.55，含 #230 coalesce 架构，已解决 cherry-pick 冲突）

Closes #239
