### PR TITLE
fix(delegate): gate ACP_DELEGATE prompt on resolveDelegate().enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -410,7 +410,7 @@ function wireSystemPrompt(pi: ExtensionAPI, runtime: AcpRuntime): void {
     // Refused host (OMP): don't inject the ACP system prompt — the model must
     // not learn about compress/decompress on a host where they can't work.
     if (runtime.refused) return;
-    const delegate = runtime.adapter.delegate !== false;
+    const delegate = resolveDelegate(runtime.adapter).enabled;
     const acp = buildAcpSystemPrompt(runtime.prompts);
     const prompt = delegate ? `${acp}\n${ACP_DELEGATE_PROMPT}` : acp;
     return { systemPrompt: formatSystemPromptForEvent(event.systemPrompt, prompt) };

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -733,6 +733,15 @@ test("delegate:false omits the ACP_DELEGATE NOTIFICATIONS section from the syste
   assert.ok(result.systemPrompt.includes("ACP TAGS"), "core ACP prompt still present when delegate disabled");
 });
 
+test("delegate:{enabled:false} omits the ACP_DELEGATE NOTIFICATIONS section from the system prompt", () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ delegate: { enabled: false } })(api as any);
+  const result = handlers.get("before_agent_start")![0]!({ systemPrompt: "" }, {});
+  assert.ok(!result.systemPrompt.includes("ACP_DELEGATE NOTIFICATIONS"), "delegate section omitted when delegate:{enabled:false}");
+  // Core ACP prompt is still present — only the delegate section is dropped.
+  assert.ok(result.systemPrompt.includes("ACP TAGS"), "core ACP prompt still present when delegate disabled");
+});
+
 // ─── ISSUE-9: modelContextLimit changes in <cwd>/.pi/acp.json hot-reload ──
 
 test("modelContextLimit changes in .pi/acp.json are picked up on the next context event", async () => {


### PR DESCRIPTION
## Summary

Fixes #275 — when `acp_delegate` is disabled via the object form `{ enabled: false }`, the delegate tools are correctly unregistered, but the `ACP_DELEGATE_PROMPT` section was still injected into the system prompt.

## Root cause

Two code paths computed "is delegate enabled?" differently:

- **Tool registration** (`src/index.ts:159`, `session_start`) uses the canonical resolver:
  `resolveDelegate(adapter).enabled` → correctly `false` for `{ enabled: false }`.
- **System-prompt injection** (`src/index.ts:413`, `before_agent_start`) used a naive check:
  `adapter.delegate !== false` → an object is never `=== false`, so this is always `true`.

Net effect: for `delegate: { enabled: false }` the model still received delegate instructions ("use `acp_delegate_wait`, expect completion notifications…") describing tools that were not actually registered.

## Fix

Route the system-prompt decision through the same resolver used by tool registration, so both paths agree:

```diff
-    const delegate = runtime.adapter.delegate !== false;
+    const delegate = resolveDelegate(runtime.adapter).enabled;
```

`resolveDelegate` (`src/config.ts:128`) already normalizes both forms:
- boolean → `delegate !== false`
- object → `delegate.enabled !== false`

## Tests

Added a regression test mirroring the existing `delegate:false` case, but using the object form:

- `tests/integration.test.ts` — `delegate:{enabled:false} omits the ACP_DELEGATE NOTIFICATIONS section from the system prompt`

Confirmed **failing before** the fix (`AssertionError: delegate section omitted when delegate:{enabled:false}`) and passing after.

## Verification

- `npm run typecheck` — clean
- `npm test` — 466 tests, 463 pass, 0 fail, 3 skipped
- `npm run build` — `dist/index.js` builds (self-contained bundle)
