### PR TITLE
release v0.1.56

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.55",
+	"version": "0.1.56",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.55",
+			"version": "0.1.56",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.48",
+				"acp-kernel": "0.0.50",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3185,9 +3185,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.48",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.48.tgz",
-			"integrity": "sha512-uXrLWQ7/CdJG2XDHXfW/1voEhilwfXnfyB38Fdf/27MDXJ/juMJowBLoyN4vPk3zcMBbB2TlKwaboc8IP6yDcA==",
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.50.tgz",
+			"integrity": "sha512-ruwDMPcH4CYQDK9vDVdAcwc5vhAFxmracd1zSpDw/PHvfKOy0s3cj4FUtBBrfb1HVtUOVLJFPmad17CdWr0l5g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.55",
+	"version": "0.1.56",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -60,7 +60,7 @@
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.48",
+		"acp-kernel": "0.0.50",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Release commit bumps BOTH fields per this repo's convention:
- `billion-context-pi` 0.1.55 → **0.1.56**
- `acp-kernel` 0.0.48 → **0.0.50** (exact pin)

## Why this release

Drops the ref-slot reclamation that shipped in acp-kernel 0.0.48 (PR #176, reverted in kernel #191). That code pruned and **re-issued ref numbers** every turn, which can silently misattribute on decompress (wrong content, not an error) — violating the id-immutability invariant now recorded in AGENTS.md (#280).

## Pre-flight

- kernel 0.0.50 verified live on npm (`npm view acp-kernel version`) before this bump
- `npm run typecheck` ✓
- `npm test`: local sandbox has 67 known environment failures (node 25 local vs 22/24 CI, `runContextRound` mock hits `undefined[0]`); **fail set is byte-identical between kernel 0.0.48 and 0.0.50 — zero behavioral delta from the upgrade**; CI on master runs the same suite green (node 22/24) and is the authority
- `npm run build` ✓; `grep -c pruneDeadRefs dist/index.js` → 0 (reclamation gone from the bundle)