### PR TITLE
release v0.1.57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.56",
+	"version": "0.1.57",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.56",
+			"version": "0.1.57",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.56",
+	"version": "0.1.57",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.57

Cuts a new release to ship the `acp_delegate` prompt fix from #276.

### Why a new version (not reusing 0.1.56)

v0.1.56 (#282) was branched from the **pre-fix** base, so it does **not** contain the delegate fix — commit `91c0206` is not an ancestor of the v0.1.56 release commit. The fix reached `master` via #276 only after that cut. This release is based on current `master` (`bcd841e`), which does include the fix.

### Changes
- Bump `version` `0.1.56` → `0.1.57` (`package.json` + `package-lock.json`)
- No dependency changes — `acp-kernel` stays at `0.0.50` (already shipped in v0.1.56)

### Ships
- #276 — `fix(delegate): gate ACP_DELEGATE prompt on resolveDelegate().enabled`

### Pre-flight
- `npm run typecheck` — clean
- `npm test` — 466 tests, 463 pass, 0 fail, 3 skipped
- `npm run build` — OK
