### PR TITLE
feat(delegate): make acp_delegate timeouts and nesting depth configurable (closes #279)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -107,6 +107,10 @@ All keys below are currently **ACTIVE**.
 |-----|------|---------|--------|-------------|
 | `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | Enable the `acp_delegate` tools and their system-prompt section. |
 | `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | Controls how delegate sub-agent token usage is reported. |
+| `delegate.maxDepth` | number | `2` | 🟢 ACTIVE | Max nesting depth for `acp_delegate` (main session = depth 0; a session *at* this depth is a leaf and cannot delegate again). Set `1` so delegates never nest. |
+| `delegate.syncTimeoutMinutes` | number | `5` | 🟢 ACTIVE | Hard timeout for **synchronous** `acp_delegate` calls, in minutes. `0` / `null` disables it. |
+| `delegate.idleTimeoutMinutes` | number | `5` | 🟢 ACTIVE | Idle watchdog for async delegate children — force-finish after this many minutes without output. `0` / `null` disables it. |
+| `delegate.asyncTimeoutMinutes` | number | `30` | 🟢 ACTIVE | Absolute hard limit for async delegate children, in minutes. `0` / `null` disables it. |
 
 **Provider throttle retry keys**
 
@@ -141,6 +145,10 @@ All keys below are currently **ACTIVE**.
 | `ACP_MODEL_CONTEXT_LIMIT` | Override the context limit (takes highest precedence). |
 | `ACP_DEBUG` | Set to `1` / `true` to enable debug logging. |
 | `ACP_LOG_FILE` | Override the log file path (default `~/.pi/acp.log`). |
+| `PI_ACP_DELEGATE_MAX_DEPTH` | Override `delegate.maxDepth`. |
+| `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES` | Override `delegate.syncTimeoutMinutes`; `0` disables the sync hard timeout. |
+| `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES` | Override `delegate.idleTimeoutMinutes`; `0` disables the idle watchdog. |
+| `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES` | Override `delegate.asyncTimeoutMinutes`; `0` disables the async hard limit. |
 
 > **Only the documented keys are read from `acp.json`.** Other tuning knobs (`preserveRecentMessages`, `protectedTools`) are code-level and not user-overridable. The three compression thresholds form a three-tier escalation: growth-driven soft nudges → forced nudges at `compress.maxContextLimit` → emergency truncation at `compress.emergencyThresholdPercent`.
 
@@ -213,6 +221,34 @@ The `delegate` sub-object controls the `acp_delegate` sub-agent tool family (`ac
 - **Default:** `"separate"`
 - **Status:** 🟢 ACTIVE
 - **Description:** Controls how delegate sub-agent token usage is reported back to the main session. `"separate"` (default) tracks delegate tokens in a separate accumulator — the main session totals stay clean and delegate usage shows as its own block in `acp_status` (excluded from main totals). `"merged"` folds delegate token usage into the tool-result `usage` field so it is counted as part of the main session totals. Only meaningful when `delegate.enabled` is `true`.
+
+### `delegate.maxDepth`
+
+- **Type:** integer ≥ 1
+- **Default:** `2`
+- **Status:** 🟢 ACTIVE
+- **Description:** Maximum nesting depth for `acp_delegate`. Depth counts how far a session sits below the main session (main = 0); a session may only spawn a delegate while its own depth is **below** this limit, so a session *at* the limit becomes a leaf and cannot delegate again. The default `2` allows main → delegate → sub-delegate; set `1` for an orchestrator / leaf-worker pattern where delegates never nest further. The resolved limit is propagated to children via the internal `PI_ACP_DELEGATE_MAX_DEPTH` environment variable, so it binds the whole delegation tree even if a child loads a different project `acp.json`. Invalid values (non-integer, `< 1`) fall back to the default with a warning log. Environment override: `PI_ACP_DELEGATE_MAX_DEPTH` (takes precedence over this key).
+
+### `delegate.syncTimeoutMinutes`
+
+- **Type:** number (minutes, fractional allowed) or `0` / `null`
+- **Default:** `5`
+- **Status:** 🟢 ACTIVE
+- **Description:** Hard timeout for **synchronous** `acp_delegate` calls — the child process is killed (SIGTERM) if it has not finished within this window. Set `0` (or `null`) to run synchronous delegates without a hard timeout. Fractional minutes are accepted (e.g. `0.5` = 30s). Invalid values fall back to the default with a warning log. Environment override: `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES` (`0` disables).
+
+### `delegate.idleTimeoutMinutes`
+
+- **Type:** number (minutes, fractional allowed) or `0` / `null`
+- **Default:** `5`
+- **Status:** 🟢 ACTIVE
+- **Description:** Idle watchdog for async delegate children: if a child produces **no output** for this long, it is considered hung and force-finished. This is the primary defense against a stuck child holding its stdout pipe open. Set `0` (or `null`) to disable it — ACP logs a prominent warning when you do; `acp_delegate_cancel` remains available as a manual escape hatch. Fractional minutes are accepted. Invalid values fall back to the default with a warning log. Environment override: `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES` (`0` disables).
+
+### `delegate.asyncTimeoutMinutes`
+
+- **Type:** number (minutes, fractional allowed) or `0` / `null`
+- **Default:** `30`
+- **Status:** 🟢 ACTIVE
+- **Description:** Absolute hard limit for **asynchronous** delegate children, regardless of activity. Set `0` (or `null`) to run long tasks without an absolute cap — the idle watchdog still applies unless separately disabled. Fractional minutes are accepted. Invalid values fall back to the default with a warning log. Environment override: `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES` (`0` disables).
 
 ---
 
@@ -420,3 +456,31 @@ Environment variables take precedence over the JSON config files. They are usefu
 - **Default:** `~/.pi/acp.log`
 - **Status:** 🟢 ACTIVE
 - **Description:** Override the path to the log file. By default, structured logs are written to `~/.pi/acp.log` (the file rotates to `~/.pi/acp.log.old` at 10 MB). Point this at a different location to keep per-project or per-run logs separate.
+
+### `PI_ACP_DELEGATE_MAX_DEPTH`
+
+- **Type:** integer ≥ 1
+- **Default:** *(unset — follows `delegate.maxDepth`, then 2)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the maximum delegate nesting depth for one session without editing config. Takes precedence over `delegate.maxDepth`. The resolved value is what gets propagated down the delegation tree. Do not set this manually mid-tree: it is also the internal variable ACP uses to pass the *effective limit* into child processes.
+
+### `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES`
+
+- **Type:** number (minutes) or `0`
+- **Default:** *(unset — follows `delegate.syncTimeoutMinutes`, then 5)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the synchronous `acp_delegate` hard timeout. Set `0` to disable the sync hard timeout for one session. Takes precedence over `delegate.syncTimeoutMinutes`.
+
+### `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES`
+
+- **Type:** number (minutes) or `0`
+- **Default:** *(unset — follows `delegate.idleTimeoutMinutes`, then 5)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the async idle watchdog window. Set `0` to disable the idle watchdog for one session (ACP logs a warning; `acp_delegate_cancel` remains as a manual escape hatch). Takes precedence over `delegate.idleTimeoutMinutes`.
+
+### `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES`
+
+- **Type:** number (minutes) or `0`
+- **Default:** *(unset — follows `delegate.asyncTimeoutMinutes`, then 30)*
+- **Status:** 🟢 ACTIVE
+- **Description:** Override the absolute hard limit for async delegate children. Set `0` to run long tasks without an absolute cap (the idle watchdog still applies unless disabled). Takes precedence over `delegate.asyncTimeoutMinutes`.

--- a/CONFIGURATION.zh-CN.md
+++ b/CONFIGURATION.zh-CN.md
@@ -106,6 +106,10 @@
 |----|------|--------|------|------|
 | `delegate.enabled` | boolean | `true` | 🟢 ACTIVE | 启用 `acp_delegate` 工具及其系统提示部分。 |
 | `delegate.displayUsage` | string | `"separate"` | 🟢 ACTIVE | 控制 delegate 子代理的 token 用量如何报回主会话。 |
+| `delegate.maxDepth` | number | `2` | 🟢 ACTIVE | `acp_delegate` 最大嵌套深度（主会话 = 深度 0；处于该深度的会话成为叶子，不能再委派）。设为 `1` 可禁止 delegate 再嵌套。 |
+| `delegate.syncTimeoutMinutes` | number | `5` | 🟢 ACTIVE | **同步** `acp_delegate` 调用的硬超时（分钟）。`0` / `null` 禁用。 |
+| `delegate.idleTimeoutMinutes` | number | `5` | 🟢 ACTIVE | 异步 delegate 子进程的闲置看门狗——无输出超过该时长即强制结束。`0` / `null` 禁用。 |
+| `delegate.asyncTimeoutMinutes` | number | `30` | 🟢 ACTIVE | 异步 delegate 子进程的绝对硬上限（分钟）。`0` / `null` 禁用。 |
 
 **provider 限流重试键**
 
@@ -140,6 +144,10 @@
 | `ACP_MODEL_CONTEXT_LIMIT` | 覆盖上下文窗口大小（优先级最高）。 |
 | `ACP_DEBUG` | 设为 `1` / `true` 开启调试日志。 |
 | `ACP_LOG_FILE` | 覆盖日志文件路径（默认 `~/.pi/acp.log`）。 |
+| `PI_ACP_DELEGATE_MAX_DEPTH` | 覆盖 `delegate.maxDepth`。 |
+| `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES` | 覆盖 `delegate.syncTimeoutMinutes`；`0` 禁用同步硬超时。 |
+| `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES` | 覆盖 `delegate.idleTimeoutMinutes`；`0` 禁用闲置看门狗。 |
+| `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES` | 覆盖 `delegate.asyncTimeoutMinutes`；`0` 禁用异步硬上限。 |
 
 > **只有文档中列出的键才会从 `acp.json` 读取。** 其他调优参数（`preserveRecentMessages`、`protectedTools`）是代码级别的，不开放给用户。三个压缩阈值构成三级递进：基于增长的软 nudge → 越过 `compress.maxContextLimit` 后的强制 nudge → 越过 `compress.emergencyThresholdPercent` 后的紧急截断。
 
@@ -205,6 +213,34 @@
 - **默认值：** `"separate"`
 - **状态：** 🟢 ACTIVE
 - **说明：** 控制 delegate 子代理的 token 用量如何报回主会话。`"separate"`（默认）将 delegate token 记入独立累加器——主会话总量保持干净，delegate 用量在 `acp_status` 中单独显示一块（不计入主总量）。`"merged"` 将 delegate token 用量并入工具返回的 `usage` 字段，算作主会话总量的一部分。仅在 `delegate.enabled` 为 `true` 时有意义。
+
+### `delegate.maxDepth`
+
+- **类型：** 整数 ≥ 1
+- **默认值：** `2`
+- **状态：** 🟢 ACTIVE
+- **说明：** `acp_delegate` 的最大嵌套深度。深度表示会话距主会话的层数（主会话 = 0）；只有当自身深度**低于**该限制时才能再委派，因此*处于*该深度的会话成为叶子、不能再委派。默认 `2` 允许 主 → delegate → 二级 delegate；设为 `1` 可实现编排者 / 叶子工作者模式（delegate 不再嵌套）。解析后的限制值通过内部环境变量 `PI_ACP_DELEGATE_MAX_DEPTH` 传递给子进程，即使某个子进程加载了不同的项目级 `acp.json`，也能约束整棵委派树。非法值（非整数、`< 1`）回退到默认值并记录警告日志。环境变量覆盖：`PI_ACP_DELEGATE_MAX_DEPTH`（优先于本键）。
+
+### `delegate.syncTimeoutMinutes`
+
+- **类型：** number（分钟，支持小数）或 `0` / `null`
+- **默认值：** `5`
+- **状态：** 🟢 ACTIVE
+- **说明：** **同步** `acp_delegate` 调用的硬超时——子进程未在该时间窗内结束即被杀死（SIGTERM）。设为 `0`（或 `null`）可禁用同步硬超时。支持小数分钟（如 `0.5` = 30 秒）。非法值回退到默认值并记录警告日志。环境变量覆盖：`PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES`（`0` 禁用）。
+
+### `delegate.idleTimeoutMinutes`
+
+- **类型：** number（分钟，支持小数）或 `0` / `null`
+- **默认值：** `5`
+- **状态：** 🟢 ACTIVE
+- **说明：** 异步 delegate 子进程的闲置看门狗：若子进程在该时长内**没有任何输出**，即视为挂死并强制结束。这是防止卡住的子进程长期占用 stdout 管道的主要防线。设为 `0`（或 `null`）可禁用它——ACP 会记录一条醒目的警告；`acp_delegate_cancel` 仍可作为手动逃生通道。支持小数分钟。非法值回退到默认值并记录警告日志。环境变量覆盖：`PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES`（`0` 禁用）。
+
+### `delegate.asyncTimeoutMinutes`
+
+- **类型：** number（分钟，支持小数）或 `0` / `null`
+- **默认值：** `30`
+- **状态：** 🟢 ACTIVE
+- **说明：** **异步** delegate 子进程的绝对硬上限，与是否活跃无关。设为 `0`（或 `null`）可让长任务不受绝对上限约束——闲置看门狗仍然生效（除非另行禁用）。支持小数分钟。非法值回退到默认值并记录警告日志。环境变量覆盖：`PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES`（`0` 禁用）。
 
 ---
 
@@ -412,3 +448,31 @@ provider 的 key 是 **Pi provider 名**(如 `"anthropic"`、`"openai"`、`"zhip
 - **默认值：** `~/.pi/acp.log`
 - **状态：** 🟢 ACTIVE
 - **说明：** 覆盖日志文件路径。默认情况下，结构化日志写入 `~/.pi/acp.log`（文件在 10MB 时轮转为 `~/.pi/acp.log.old`）。指向不同位置可为每个项目或每次运行保留独立日志。
+
+### `PI_ACP_DELEGATE_MAX_DEPTH`
+
+- **类型：** 整数 ≥ 1
+- **默认值：** *(未设置——遵循 `delegate.maxDepth`，再回退到 2)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 不编辑配置文件，为单个会话覆盖 delegate 最大嵌套深度。优先于 `delegate.maxDepth`。解析后的值会被向下传递到整棵委派树。请勿在委派树中间手动设置它：这也是 ACP 用来把*生效限制*传入子进程的内部变量。
+
+### `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES`
+
+- **类型：** number（分钟）或 `0`
+- **默认值：** *(未设置——遵循 `delegate.syncTimeoutMinutes`，再回退到 5)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖同步 `acp_delegate` 的硬超时。设为 `0` 可为单个会话禁用同步硬超时。优先于 `delegate.syncTimeoutMinutes`。
+
+### `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES`
+
+- **类型：** number（分钟）或 `0`
+- **默认值：** *(未设置——遵循 `delegate.idleTimeoutMinutes`，再回退到 5)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖异步闲置看门狗的时间窗。设为 `0` 可为单个会话禁用闲置看门狗（ACP 会记录警告；`acp_delegate_cancel` 仍可作为手动逃生通道）。优先于 `delegate.idleTimeoutMinutes`。
+
+### `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES`
+
+- **类型：** number（分钟）或 `0`
+- **默认值：** *(未设置——遵循 `delegate.asyncTimeoutMinutes`，再回退到 30)*
+- **状态：** 🟢 ACTIVE
+- **说明：** 覆盖异步 delegate 子进程的绝对硬上限。设为 `0` 可让长任务不受绝对上限约束（闲置看门狗仍然生效，除非另行禁用）。优先于 `delegate.asyncTimeoutMinutes`。

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { defaultConfig, type Config, type Prompts } from "acp-kernel";
 import type { ThrottleRetryConfig } from "./throttle-retry.js";
+import { logWarn } from "./log.js";
 
 /** Delegate sub-agent configuration. */
 export interface DelegateConfig {
@@ -13,7 +14,46 @@ export interface DelegateConfig {
    *  "merged" — delegate token usage folded into the tool-result usage field,
    *  counted as part of the main session totals. */
   displayUsage?: "merged" | "separate";
+  /** Maximum acp_delegate nesting depth. Default: 2 (main → child → grandchild;
+   *  the grandchild cannot delegate further). Set 1 to forbid nested delegation
+   *  (orchestrator → leaf workers only). The resolved value is propagated to
+   *  child processes via PI_ACP_DELEGATE_MAX_DEPTH so the cap follows the whole
+   *  delegation tree, even when a child loads a different project acp.json. */
+  maxDepth?: number;
+  /** Hard timeout for synchronous delegates (async=false, or async auto-downgraded
+   *  on one-shot hosts), in minutes. Default: 5. 0 or null disables the timeout
+   *  (the run blocks until the child exits or the tool call is cancelled). */
+  syncTimeoutMinutes?: number | null;
+  /** Idle watchdog for async delegates: kill when no output arrives for this many
+   *  minutes. Default: 5. This is the main defense against a stuck child holding
+   *  its stdout fd open, so disabling it (0/null) logs a warning — use
+   *  acp_delegate_cancel as the manual escape hatch. */
+  idleTimeoutMinutes?: number | null;
+  /** Hard time limit for async delegates, in minutes. Default: 30. 0 or null
+   *  disables the limit. */
+  asyncTimeoutMinutes?: number | null;
 }
+
+/** Resolved delegate policy: what actually takes effect after merging acp.json,
+ *  env overrides and defaults. Timeout fields are milliseconds; null means the
+ *  corresponding timeout/watchdog is disabled. */
+export interface DelegatePolicy {
+  enabled: boolean;
+  displayUsage: "merged" | "separate";
+  maxDepth: number;
+  syncTimeoutMs: number | null;
+  idleMs: number | null;
+  asyncTimeoutMs: number | null;
+}
+
+export const DEFAULT_DELEGATE_POLICY: DelegatePolicy = {
+  enabled: true,
+  displayUsage: "separate",
+  maxDepth: 2,
+  syncTimeoutMs: 5 * 60_000,
+  idleMs: 5 * 60_000,
+  asyncTimeoutMs: 30 * 60_000,
+};
 
 /** Compression tuning fields, shared by all three levels (global, provider,
  *  model). Percentage fields accept a ratio (0.75) or percent string ("75%").
@@ -124,19 +164,59 @@ export const DEFAULT_TOOL_BASH_TIMEOUT = 60;
 export const DEFAULT_TOOL_OUTPUT_MAX_BYTES = 200_000;
 
 /** Resolve delegate config from the adapter, handling the boolean shorthand
- *  and the legacy flat `displayUsage` alias. */
-export function resolveDelegate(adapter: AdapterConfig): { enabled: boolean; displayUsage: "merged" | "separate" } {
+ *  and the legacy flat `displayUsage` alias. Precedence: env > acp.json >
+ *  default (same convention as ACP_MODEL_CONTEXT_LIMIT). Invalid values fall
+ *  back to the default with a logged warning — they never fail the session. */
+export function resolveDelegate(adapter: AdapterConfig): DelegatePolicy {
   const d = adapter.delegate;
-  if (typeof d === "object" && d !== null) {
-    return {
-      enabled: d.enabled !== false,
-      displayUsage: d.displayUsage ?? adapter.displayUsage ?? "separate",
-    };
+  const cfg: DelegateConfig = typeof d === "object" && d !== null ? d : {};
+  const enabled = typeof d === "object" && d !== null ? d.enabled !== false : d !== false;
+  const displayUsage = cfg.displayUsage ?? adapter.displayUsage ?? "separate";
+  const maxDepth = resolveMaxDepth(process.env.PI_ACP_DELEGATE_MAX_DEPTH ?? cfg.maxDepth);
+  const syncTimeoutMs = resolveTimeoutMinutes(
+    process.env.PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES ?? cfg.syncTimeoutMinutes,
+    "syncTimeoutMinutes",
+    DEFAULT_DELEGATE_POLICY.syncTimeoutMs!,
+  );
+  const idleMs = resolveTimeoutMinutes(
+    process.env.PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES ?? cfg.idleTimeoutMinutes,
+    "idleTimeoutMinutes",
+    DEFAULT_DELEGATE_POLICY.idleMs!,
+  );
+  const asyncTimeoutMs = resolveTimeoutMinutes(
+    process.env.PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES ?? cfg.asyncTimeoutMinutes,
+    "asyncTimeoutMinutes",
+    DEFAULT_DELEGATE_POLICY.asyncTimeoutMs!,
+  );
+  if (idleMs === null) {
+    logWarn("config", {
+      event: "delegate-idle-watchdog-disabled",
+      hint: "no-output watchdog is off; hung async runs must be cancelled manually via acp_delegate_cancel",
+    });
   }
-  return {
-    enabled: d !== false,
-    displayUsage: adapter.displayUsage ?? "separate",
-  };
+  return { enabled, displayUsage, maxDepth, syncTimeoutMs, idleMs, asyncTimeoutMs };
+}
+
+function resolveMaxDepth(value: number | string | undefined): number {
+  if (value === undefined) return DEFAULT_DELEGATE_POLICY.maxDepth;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    logWarn("config", { event: "delegate-config-invalid", field: "maxDepth", value, fallback: DEFAULT_DELEGATE_POLICY.maxDepth });
+    return DEFAULT_DELEGATE_POLICY.maxDepth;
+  }
+  return n;
+}
+
+function resolveTimeoutMinutes(value: number | string | null | undefined, field: string, defaultMs: number): number | null {
+  if (value === undefined) return defaultMs;
+  if (value === null) return null;
+  const n = Number(value);
+  if (n === 0) return null;
+  if (!Number.isFinite(n) || n < 0) {
+    logWarn("config", { event: "delegate-config-invalid", field, value, fallback: `${defaultMs / 60_000}m` });
+    return defaultMs;
+  }
+  return n * 60_000;
 }
 
 /** Per-field deepest-wins merge of the three compression levels (global →

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -16,16 +16,13 @@ import type {
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
 import { debug, logError, logInfo, logWarn } from "./log.js";
+import { DEFAULT_DELEGATE_POLICY, type DelegatePolicy } from "./config.js";
 import { attachWatchdogs } from "./delegate-watchdog.js";
 import { parseEventLine, activityLines, newPortion, ThinkingCollector, type Usage } from "./delegate-events.js";
 import { isPiHost } from "./runtime.js";
 
-const MAX_DEPTH = 2;
-const SYNC_TIMEOUT_MS = 5 * 60_000;
 const EOF_GRACE_MS = 10_000;
 const SETTLED_GRACE_MS = 10_000;
-const IDLE_GRACE_MS = 5 * 60_000;
-const ASYNC_TIMEOUT_MS = 30 * 60_000;
 const KILL_GRACE_MS = 10_000;
 const RESULT_SUMMARY_CHARS = 500;
 const OUT_DIR = join(tmpdir(), "acp-delegate");
@@ -55,6 +52,17 @@ export function delegateSpawnOptions(cwd: string, env: NodeJS.ProcessEnv): Spawn
     env,
     stdio: ["pipe", "pipe", "pipe"],
     shell: false,
+  };
+}
+
+/** Child process env for a nested delegate: depth increments by one, and the
+ *  resolved maxDepth rides along so the cap binds the whole delegation tree
+ *  even when the child loads a different project acp.json. */
+export function delegateChildEnv(parentDepth: number, maxDepth: number): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PI_ACP_DELEGATE_DEPTH: String(parentDepth + 1),
+    PI_ACP_DELEGATE_MAX_DEPTH: String(maxDepth),
   };
 }
 
@@ -229,6 +237,12 @@ let delegateDisplayUsage: "merged" | "separate" = "separate";
 
 export function setDelegateDisplayUsage(mode: "merged" | "separate"): void {
   delegateDisplayUsage = mode;
+}
+
+let delegatePolicy: DelegatePolicy = DEFAULT_DELEGATE_POLICY;
+
+export function setDelegatePolicy(policy: DelegatePolicy): void {
+  delegatePolicy = policy;
 }
 
 
@@ -931,8 +945,9 @@ async function runDelegate(
     return `Unknown agent "${args.agent}". Choose one of: ${AGENT_NAMES.join(", ")}.`;
   }
   const parentDepth = Number(process.env.PI_ACP_DELEGATE_DEPTH ?? "0");
-  if (Number.isNaN(parentDepth) || parentDepth >= MAX_DEPTH) {
-    return `Delegate nesting limit reached (depth ${parentDepth}, max ${MAX_DEPTH}). The delegate cannot spawn further delegates.`;
+  const maxDepth = delegatePolicy.maxDepth;
+  if (Number.isNaN(parentDepth) || parentDepth >= maxDepth) {
+    return `Delegate nesting limit reached (depth ${parentDepth}, max ${maxDepth}). The delegate cannot spawn further delegates.`;
   }
   if (!args.task || !args.task.trim()) {
     if (!args.resumeFrom) {
@@ -956,10 +971,7 @@ async function runDelegate(
   const taskText = args.task?.trim() || (args.resumeFrom ? "(resumed — the original task is in the session history)" : "");
 
   const cwd = args.cwd && args.cwd.trim() ? args.cwd : ctx.cwd;
-  const childEnv = {
-    ...process.env,
-    PI_ACP_DELEGATE_DEPTH: String(parentDepth + 1),
-  };
+  const childEnv = delegateChildEnv(parentDepth, maxDepth);
   const runId = `del_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
   const { cliArgs, tmpDir, isAsync, useJsonStream, sessionFile } = await buildChildArgs(args, agent.prompt, ctx, runId);
   // One-shot modes (print/json = `pi -p` / SDK) exit after one turn, so async
@@ -1016,7 +1028,7 @@ async function runDelegate(
           debug.event("delegate-eof-grace", { runId, ms: EOF_GRACE_MS });
         },
       },
-      { eofGraceMs: EOF_GRACE_MS, idleMs: IDLE_GRACE_MS, timeoutMs: ASYNC_TIMEOUT_MS, killGraceMs: KILL_GRACE_MS },
+      { eofGraceMs: EOF_GRACE_MS, idleMs: delegatePolicy.idleMs, timeoutMs: delegatePolicy.asyncTimeoutMs, killGraceMs: KILL_GRACE_MS },
     );
     // Two stream files are fed from the --mode json event stream: text_delta
     // tokens go to the reply stream (.out), tool activity (and optionally
@@ -1212,14 +1224,14 @@ async function runDelegate(
       useJsonStream
         ? `Live activity is streaming to \`${activityFile}\` — read it anytime to watch the delegate work (tool calls and their output${args.showThinking ? ", plus thinking" : ""}).`
         : `The reply is streaming to \`${replyFile}\` — read it anytime to see partial output (this host has no json event mode, so tool activity is not visible).`,
-      `A watchdog force-finishes a hung run: no output for ${IDLE_GRACE_MS / 60_000}m, 10s after output ends, or a ${ASYNC_TIMEOUT_MS / 60_000}m hard limit — the result reflects whatever was produced.`,
+      asyncWatchdogDescription(),
       ``,
       `Call acp_delegate_wait({ runId: "${runId}" }) to block for the result (default 10s timeout). If the wait times out, or you skip it, a completion notification (with the result file path) is still injected here automatically when the delegate finishes — so you may also just continue other work now and let the result find you.`,
     ].join("\n");
   }
 
-  // Sync: block until the child finishes (bounded by a timeout).
-  const result = await waitForChild(child, signal);
+  // Sync: block until the child finishes (bounded by the configured timeout).
+  const result = await waitForChild(child, signal, delegatePolicy.syncTimeoutMs);
   void cleanupTmp(tmpDir);
   const body =
     result.timedOut || result.code !== 0
@@ -1298,7 +1310,7 @@ interface ChildResult {
   timedOut: boolean;
 }
 
-function waitForChild(child: ChildProcess, signal: AbortSignal | undefined): Promise<ChildResult> {
+function waitForChild(child: ChildProcess, signal: AbortSignal | undefined, timeoutMs: number | null): Promise<ChildResult> {
   return new Promise((resolve) => {
     const stdoutChunks: Buffer[] = [];
     let stderrText = "";
@@ -1307,19 +1319,22 @@ function waitForChild(child: ChildProcess, signal: AbortSignal | undefined): Pro
       stderrText += c.toString("utf8");
     });
 
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      finish({ code: null, stdout: "", stderr: stderrText, timedOut: true });
-    }, SYNC_TIMEOUT_MS);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutMs !== null) {
+      timer = setTimeout(() => {
+        child.kill("SIGTERM");
+        finish({ code: null, stdout: "", stderr: stderrText, timedOut: true });
+      }, timeoutMs);
+    }
 
     const onAbort = () => {
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
       child.kill("SIGTERM");
     };
     signal?.addEventListener("abort", onAbort, { once: true });
 
     function finish(r: ChildResult) {
-      clearTimeout(timer);
+      if (timer) clearTimeout(timer);
       signal?.removeEventListener("abort", onAbort);
       resolve(r);
     }
@@ -1337,6 +1352,23 @@ function waitForChild(child: ChildProcess, signal: AbortSignal | undefined): Pro
       finish({ code: null, stdout: "", stderr: err.message, timedOut: false });
     });
   });
+}
+
+function fmtMinutes(ms: number): string {
+  const m = ms / 60_000;
+  return Number.isInteger(m) ? `${m}m` : `${m.toFixed(1)}m`;
+}
+
+/** Model-facing summary of the ACTIVE async watchdog limits — built from the
+ *  resolved policy so it stays truthful when timeouts are customized or
+ *  disabled via acp.json/env. */
+export function asyncWatchdogDescription(): string {
+  const parts: string[] = [];
+  if (delegatePolicy.idleMs !== null) parts.push(`no output for ${fmtMinutes(delegatePolicy.idleMs)}`);
+  parts.push(`${EOF_GRACE_MS / 1000}s after output ends`);
+  if (delegatePolicy.asyncTimeoutMs !== null) parts.push(`a ${fmtMinutes(delegatePolicy.asyncTimeoutMs)} hard limit`);
+  const joined = parts.length > 1 ? `${parts.slice(0, -1).join(", ")}, or ${parts[parts.length - 1]}` : parts[0]!;
+  return `A watchdog force-finishes a hung run: ${joined} — the result reflects whatever was produced.`;
 }
 
 function formatSyncResult(agent: string, runId: string, task: string, r: ChildResult, file: string): string {

--- a/src/delegate-watchdog.ts
+++ b/src/delegate-watchdog.ts
@@ -2,8 +2,10 @@ import type { Readable } from "node:stream";
 
 export interface WatchdogOptions {
   eofGraceMs: number;
-  idleMs: number;
-  timeoutMs: number;
+  /** Kill when no output for this long. 0/null disables the idle timer. */
+  idleMs?: number | null;
+  /** Hard time limit. 0/null disables the limit timer. */
+  timeoutMs?: number | null;
   killGraceMs: number;
 }
 
@@ -89,15 +91,21 @@ export function attachWatchdogs(
     settledGraceTimer.unref?.();
   };
 
+  const idleMs = opts.idleMs ?? 0;
+  const timeoutMs = opts.timeoutMs ?? 0;
+
   const poke = (): void => {
+    if (idleMs <= 0) return;
     if (idleTimer) clearTimeout(idleTimer);
-    idleTimer = setTimeout(() => killByWatchdog(`no output for ${opts.idleMs / 60_000}m`), opts.idleMs);
+    idleTimer = setTimeout(() => killByWatchdog(`no output for ${idleMs / 60_000}m`), idleMs);
     idleTimer.unref?.();
   };
 
   poke();
-  timeoutTimer = setTimeout(() => killByWatchdog(`${opts.timeoutMs / 60_000}m limit`), opts.timeoutMs);
-  timeoutTimer.unref?.();
+  if (timeoutMs > 0) {
+    timeoutTimer = setTimeout(() => killByWatchdog(`${timeoutMs / 60_000}m limit`), timeoutMs);
+    timeoutTimer.unref?.();
+  }
 
   const onStdoutEnd = (): void => {
     if (hooks.isSettled()) return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,13 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { CoreMessage, NudgeDecision, CompressionBlock, Prompts } from "acp-kernel";
 import { renderNudgeText, resolvePrompts, defaultPrompts, viableRanges } from "acp-kernel";
-import { type AdapterConfig, resolveDelegate } from "./config.js";
+import { type AdapterConfig, resolveDelegate, DEFAULT_DELEGATE_POLICY } from "./config.js";
 import { createRuntime, type AcpRuntime } from "./runtime.js";
 import { makeCompressTool, isCompressSuccessText, isCompressNoopText } from "./compress-tool.js";
 import { makeDecompressTool } from "./decompress-tool.js";
 import { makeSearchTool } from "./search-tool.js";
 import { makeStatusTool } from "./status-tool.js";
-import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage } from "./delegate-tool.js";
+import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage, setDelegatePolicy } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages, extractText } from "./messages.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
@@ -137,6 +137,7 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     runtime.clearCompressRetryTracking();
     resetDelegateUsage();
     setDelegateDisplayUsage("separate");
+    setDelegatePolicy(DEFAULT_DELEGATE_POLICY);
     const sid = ctx.sessionManager.getSessionId();
     // Model identity on every session start: diagnosing "which model loops
     // on compress rejections" from user logs required cwd forensics — the log
@@ -146,7 +147,9 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
     logInfo("session", { event: "start", sid, cwd: ctx.cwd, debug: runtime.adapter.debug ?? null, version: typeof CURRENT_VERSION !== "undefined" ? CURRENT_VERSION : null, model: modelInfo?.id ?? null, modelApi: modelInfo?.api ?? null, contextWindow: modelInfo?.contextWindow ?? null });
     try {
       await runtime.reloadConfig(ctx.cwd);
-      setDelegateDisplayUsage(resolveDelegate(runtime.adapter).displayUsage);
+      const delegateCfg = resolveDelegate(runtime.adapter);
+      setDelegateDisplayUsage(delegateCfg.displayUsage);
+      setDelegatePolicy(delegateCfg);
     } catch (e) {
       logThrow("config", e, { sid, phase: "session_start" });
     }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -138,6 +138,93 @@ test("resolveDelegate: object displayUsage takes priority over legacy flat", () 
   assert.equal(r.displayUsage, "separate");
 });
 
+// ─── #279: configurable maxDepth + timeouts ─────────────────────────────────
+
+test("resolveDelegate: maxDepth + timeouts default to 2 / 5m / 5m / 30m", () => {
+  const r = resolveDelegate({});
+  assert.equal(r.maxDepth, 2);
+  assert.equal(r.syncTimeoutMs, 5 * 60_000);
+  assert.equal(r.idleMs, 5 * 60_000);
+  assert.equal(r.asyncTimeoutMs, 30 * 60_000);
+});
+
+test("resolveDelegate: custom maxDepth + timeouts (minutes → ms)", () => {
+  const r = resolveDelegate({ delegate: { maxDepth: 1, syncTimeoutMinutes: 10, idleTimeoutMinutes: 7.5, asyncTimeoutMinutes: 120 } });
+  assert.equal(r.maxDepth, 1);
+  assert.equal(r.syncTimeoutMs, 10 * 60_000);
+  assert.equal(r.idleMs, 450_000);
+  assert.equal(r.asyncTimeoutMs, 120 * 60_000);
+});
+
+test("resolveDelegate: 0/null disables a timeout, others keep defaults", () => {
+  const r = resolveDelegate({ delegate: { syncTimeoutMinutes: 0, idleTimeoutMinutes: null, asyncTimeoutMinutes: 90 } });
+  assert.equal(r.syncTimeoutMs, null);
+  assert.equal(r.idleMs, null);
+  assert.equal(r.asyncTimeoutMs, 90 * 60_000);
+});
+
+test("resolveDelegate: invalid numeric values fall back to defaults", () => {
+  const r = resolveDelegate({ delegate: { maxDepth: 0, syncTimeoutMinutes: -5, idleTimeoutMinutes: Number.NaN } });
+  assert.equal(r.maxDepth, 2);
+  assert.equal(r.syncTimeoutMs, 5 * 60_000);
+  assert.equal(r.idleMs, 5 * 60_000);
+});
+
+const DELEGATE_ENV_KEYS = [
+  "PI_ACP_DELEGATE_MAX_DEPTH",
+  "PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES",
+  "PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES",
+  "PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES",
+] as const;
+
+function withDelegateEnv(mutate: (env: NodeJS.ProcessEnv) => void, fn: () => void): void {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of DELEGATE_ENV_KEYS) saved[k] = process.env[k];
+  try {
+    mutate(process.env);
+    fn();
+  } finally {
+    for (const k of DELEGATE_ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  }
+}
+
+test("resolveDelegate: env overrides acp.json; unset env falls back to config", () => {
+  withDelegateEnv(
+    (env) => {
+      env.PI_ACP_DELEGATE_MAX_DEPTH = "1";
+      env.PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES = "0";
+    },
+    () => {
+      const r = resolveDelegate({ delegate: { maxDepth: 5, asyncTimeoutMinutes: 120 } });
+      assert.equal(r.maxDepth, 1, "env beats config");
+      assert.equal(r.asyncTimeoutMs, null, "env 0 disables");
+    },
+  );
+  const r2 = resolveDelegate({ delegate: { maxDepth: 5, asyncTimeoutMinutes: 120 } });
+  assert.equal(r2.maxDepth, 5, "config used when env unset");
+  assert.equal(r2.asyncTimeoutMs, 120 * 60_000);
+});
+
+test("resolveDelegate: invalid env values fall back without failing", () => {
+  let r!: ReturnType<typeof resolveDelegate>;
+  withDelegateEnv(
+    (env) => {
+      env.PI_ACP_DELEGATE_MAX_DEPTH = "abc";
+      env.PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES = "-3";
+      env.PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES = "1.5x";
+    },
+    () => {
+      r = resolveDelegate({ delegate: { syncTimeoutMinutes: 8 } });
+    },
+  );
+  assert.equal(r.maxDepth, 2, "invalid env maxDepth → default");
+  assert.equal(r.syncTimeoutMs, 5 * 60_000, "invalid env timeout → default (not config)");
+  assert.equal(r.idleMs, 5 * 60_000, "invalid env idle → default");
+});
+
 test("resolveCompress returns {} when no compress configured", () => {
   assert.deepEqual(resolveCompress(undefined, "anthropic", "claude"), {});
 });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -4,7 +4,8 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, effectiveExitCode, formatRunResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, buildRecoveryNotice, makeDelegateTool, exitLabel, cancelledFileNote, delegateStdinText, readActivityTail, scheduleRunNotification, flushDelegateNotifications, formatBatchRunSection } from "../src/delegate-tool.js";
+import { buildChildArgs, delegateSpawnOptions, injectedWaitMessage, buildWaitResult, buildCancelResult, getDelegateUsage, resetDelegateUsage, injectResult, effectiveExitCode, formatRunResult, resolveWaitTimeoutMs, findUndeliveredRuns, undeliveredNoticeFrom, buildRecoveryNotice, makeDelegateTool, exitLabel, cancelledFileNote, delegateStdinText, readActivityTail, scheduleRunNotification, flushDelegateNotifications, formatBatchRunSection, setDelegatePolicy, delegateChildEnv, asyncWatchdogDescription } from "../src/delegate-tool.js";
+import { DEFAULT_DELEGATE_POLICY } from "../src/config.js";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 /** Minimal ctx mock - buildChildArgs reads ctx.model and sessionManager. */
@@ -806,4 +807,63 @@ test("formatBatchRunSection carries the timeout note and error excerpt", () => {
   const ok = formatBatchRunSection(mkRun("del_ok", "completed", { result: { code: 0, file: "/tmp/del_ok.out", body: "hidden" } }));
   assert.ok(ok.includes("[acp_delegate completed]"), "completed status");
   assert.ok(!ok.includes("hidden"), "completed runs carry no body");
+});
+
+// ─── #279: configurable maxDepth + timeouts ─────────────────────────────────
+
+test("depth gate honors configured maxDepth (rejection paths, no spawn)", async () => {
+  const pi = { sendUserMessage: () => {} } as unknown as Parameters<typeof makeDelegateTool>[0];
+  const tool = makeDelegateTool(pi);
+  const ctx = { ...mockCtx("pi"), mode: "tui", cwd: process.cwd() } as unknown as ExtensionContext;
+  const prev = process.env.PI_ACP_DELEGATE_DEPTH;
+  const textOf = (res: Awaited<ReturnType<typeof tool.execute>>): string => (res.content[0] as { text?: string }).text ?? "";
+  try {
+    setDelegatePolicy(DEFAULT_DELEGATE_POLICY);
+    process.env.PI_ACP_DELEGATE_DEPTH = "2";
+    let res = await tool.execute("tc-depth-a", { agent: "oracle", task: "x" }, undefined, undefined, ctx);
+    assert.match(textOf(res), /nesting limit reached \(depth 2, max 2\)/, "default maxDepth 2 rejects depth 2");
+
+    setDelegatePolicy({ ...DEFAULT_DELEGATE_POLICY, maxDepth: 1 });
+    process.env.PI_ACP_DELEGATE_DEPTH = "1";
+    res = await tool.execute("tc-depth-b", { agent: "oracle", task: "x" }, undefined, undefined, ctx);
+    assert.match(textOf(res), /nesting limit reached \(depth 1, max 1\)/, "maxDepth 1 rejects depth 1");
+
+    setDelegatePolicy({ ...DEFAULT_DELEGATE_POLICY, maxDepth: 3 });
+    process.env.PI_ACP_DELEGATE_DEPTH = "3";
+    res = await tool.execute("tc-depth-c", { agent: "oracle", task: "x" }, undefined, undefined, ctx);
+    assert.match(textOf(res), /nesting limit reached \(depth 3, max 3\)/, "maxDepth 3 rejects depth 3");
+  } finally {
+    if (prev === undefined) delete process.env.PI_ACP_DELEGATE_DEPTH;
+    else process.env.PI_ACP_DELEGATE_DEPTH = prev;
+    setDelegatePolicy(DEFAULT_DELEGATE_POLICY);
+  }
+});
+
+test("delegateChildEnv increments depth and propagates the maxDepth cap", () => {
+  const env = delegateChildEnv(1, 3);
+  assert.equal(env.PI_ACP_DELEGATE_DEPTH, "2", "child depth = parent + 1");
+  assert.equal(env.PI_ACP_DELEGATE_MAX_DEPTH, "3", "cap follows the delegation tree");
+  assert.equal(env.PATH, process.env.PATH, "parent env inherited");
+});
+
+test("asyncWatchdogDescription reflects the resolved policy", () => {
+  try {
+    setDelegatePolicy(DEFAULT_DELEGATE_POLICY);
+    assert.equal(
+      asyncWatchdogDescription(),
+      "A watchdog force-finishes a hung run: no output for 5m, 10s after output ends, or a 30m hard limit — the result reflects whatever was produced.",
+    );
+    setDelegatePolicy({ ...DEFAULT_DELEGATE_POLICY, idleMs: 10 * 60_000, asyncTimeoutMs: 90 * 60_000 });
+    assert.equal(
+      asyncWatchdogDescription(),
+      "A watchdog force-finishes a hung run: no output for 10m, 10s after output ends, or a 90m hard limit — the result reflects whatever was produced.",
+    );
+    setDelegatePolicy({ ...DEFAULT_DELEGATE_POLICY, idleMs: null, asyncTimeoutMs: null });
+    assert.equal(
+      asyncWatchdogDescription(),
+      "A watchdog force-finishes a hung run: 10s after output ends — the result reflects whatever was produced.",
+    );
+  } finally {
+    setDelegatePolicy(DEFAULT_DELEGATE_POLICY);
+  }
 });

--- a/tests/delegate-tool.test.ts
+++ b/tests/delegate-tool.test.ts
@@ -843,7 +843,9 @@ test("delegateChildEnv increments depth and propagates the maxDepth cap", () => 
   const env = delegateChildEnv(1, 3);
   assert.equal(env.PI_ACP_DELEGATE_DEPTH, "2", "child depth = parent + 1");
   assert.equal(env.PI_ACP_DELEGATE_MAX_DEPTH, "3", "cap follows the delegation tree");
-  assert.equal(env.PATH, process.env.PATH, "parent env inherited");
+  for (const [key, value] of Object.entries(process.env)) {
+    assert.equal(env[key], value, `parent env ${key} inherited`);
+  }
 });
 
 test("asyncWatchdogDescription reflects the resolved policy", () => {

--- a/tests/watchdog.test.ts
+++ b/tests/watchdog.test.ts
@@ -15,7 +15,7 @@ interface Harness {
   watchdog: ReturnType<typeof attachWatchdogs>;
 }
 
-function setup(overrides?: { idleMs?: number; timeoutMs?: number; killGraceMs?: number; eofGraceMs?: number; initiallySettled?: boolean }): Harness {
+function setup(overrides?: { idleMs?: number | null; timeoutMs?: number | null; killGraceMs?: number; eofGraceMs?: number; initiallySettled?: boolean }): Harness {
   const stdout = new EventEmitter();
   const kills: NodeJS.Signals[] = [];
   const reasons: string[] = [];
@@ -38,8 +38,8 @@ function setup(overrides?: { idleMs?: number; timeoutMs?: number; killGraceMs?: 
     },
     {
       eofGraceMs: overrides?.eofGraceMs ?? 1_000,
-      idleMs: overrides?.idleMs ?? 1_000,
-      timeoutMs: overrides?.timeoutMs ?? 60_000,
+      idleMs: overrides?.idleMs !== undefined ? overrides.idleMs : 1_000,
+      timeoutMs: overrides?.timeoutMs !== undefined ? overrides.timeoutMs : 60_000,
       killGraceMs: overrides?.killGraceMs ?? 1_000,
     },
   );
@@ -169,5 +169,36 @@ test("settle before the grace fires stops the kill (normal exit path)", async ()
   h.settle();
   await sleep(220);
   assert.equal(h.kills.length, 0, "no kill once settled before grace");
+  h.watchdog.dispose();
+});
+
+// ─── #279: configurable timeouts — 0/null disables ──────────────────────────
+
+test("idleMs 0 disables the idle watchdog (silence never kills)", async () => {
+  const h = setup({ idleMs: 0, timeoutMs: 60_000 });
+  await sleep(80);
+  assert.equal(h.kills.length, 0, "no idle kill when disabled");
+  assert.equal(h.reasons.length, 0, "no onKill reason");
+  h.watchdog.dispose();
+});
+
+test("timeoutMs 0 disables the hard limit (poked child never killed)", async () => {
+  const h = setup({ idleMs: 400, timeoutMs: 0 });
+  for (let i = 0; i < 7; i++) {
+    await sleep(50);
+    h.watchdog.poke();
+  }
+  assert.equal(h.kills.length, 0, "no hard-limit kill while output keeps flowing");
+  h.settle();
+  h.watchdog.dispose();
+});
+
+test("both idleMs and timeoutMs null: only EOF grace remains", async () => {
+  const h = setup({ idleMs: null, timeoutMs: null, eofGraceMs: 30 });
+  await sleep(80);
+  assert.equal(h.kills.length, 0, "no time-based kill");
+  h.stdout.emit("end");
+  await sleep(60);
+  assert.equal(h.eofGraceCount, 1, "EOF grace still fires");
   h.watchdog.dispose();
 });


### PR DESCRIPTION
Closes #279

## 概述

`acp_delegate` 的嵌套深度与三个超时值此前硬编码在 `src/delegate-tool.ts`。本 PR 使其可通过 `acp.json` 配置，默认值全部保持不变（完全向后兼容）：

```json
{
  "delegate": {
    "maxDepth": 1,
    "syncTimeoutMinutes": 10,
    "idleTimeoutMinutes": 10,
    "asyncTimeoutMinutes": 120
  }
}
```

| 键 | 默认值 | 说明 |
|----|--------|------|
| `delegate.maxDepth` | `2` | 最大嵌套深度（主会话 = 深度 0；处于该深度的会话成为叶子，不能再委派）。设为 `1` 即 delegate 不再嵌套 |
| `delegate.syncTimeoutMinutes` | `5` | 同步调用硬超时（分钟），支持小数 |
| `delegate.idleTimeoutMinutes` | `5` | 异步子进程闲置看门狗：无输出超过该时长即强制结束 |
| `delegate.asyncTimeoutMinutes` | `30` | 异步子进程绝对硬上限（分钟），支持小数 |

## 设计决策

- **`0` / `null` 禁用**（#279 的可选需求）：三个超时均可设 `0` 或 `null` 禁用。禁用闲置看门狗时 ACP 记录醒目警告（它是防卡死子进程占用 stdout 的主要防线，`acp_delegate_cancel` 仍是手动逃生通道）。
- **环境变量覆盖**，优先级 env > acp.json > 默认值（与 `ACP_MODEL_CONTEXT_LIMIT` 等既有约定一致）：
  - `PI_ACP_DELEGATE_MAX_DEPTH`
  - `PI_ACP_DELEGATE_SYNC_TIMEOUT_MINUTES`
  - `PI_ACP_DELEGATE_IDLE_TIMEOUT_MINUTES`
  - `PI_ACP_DELEGATE_ASYNC_TIMEOUT_MINUTES`
- **跨项目一致性**：解析后的 maxDepth 经内部环境变量 `PI_ACP_DELEGATE_MAX_DEPTH` 传给子进程——即使某个子进程加载了不同的项目级 `acp.json`，整棵委派树仍受同一限制约束。这取代了 #279 中提到的手动设置 `PI_ACP_DELEGATE_DEPTH` 的别扭做法。
- **非法值永不失败**：非整数、`< 1`（maxDepth）、负数、无法解析的值一律回退默认值并记录警告日志（沿用 #117 确立的原则）。
- 模型可见的工具描述文案现在动态反映生效的 async/idle 值。

## 测试

- config 解析新增单测：默认值 / 自定义值（含小数分钟）/ `0`、`null` 禁用 / 非法值回退 / env 覆盖优先级（含 env 字符串 `"0"` 的禁用路径）
- watchdog 禁用语义：`idleMs: 0` 永不因闲置杀子进程、`timeoutMs: 0` 有持续输出的子进程不被硬杀、两者同禁时 EOF grace 仍生效
- delegate 深度门禁拒绝路径（maxDepth 1/2/3）、子进程 env 传播（深度 +1、MAX_DEPTH 透传）、工具描述文案
- 全量套件：**477 tests, 474 pass, 0 fail, 3 skipped**（skip 为既有）；typecheck 与 build 均通过

## 文档

- `CONFIGURATION.md` 与 `CONFIGURATION.zh-CN.md`：键总表、各键详情节、环境变量总表与详情节同步更新
