### PR TITLE
fix(tokens): measure tokenCount on the actual sent view (#289)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,7 @@ import type { AcpRuntime } from "./runtime.js";
 import { ACP_STATUS_CUSTOM_TYPE } from "./messages.js";
 import { defaultCountTokens, parseBlockIdArg, collectBlockContent } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
-import { collectCoveredMessageIds, estimateTokens, collectImageTokens, modelSupportsImages } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, collectImageTokens, modelSupportsImages, adjustedTokenCount } from "./tokens.js";
 import { usageAnchorPredatesCompression } from "./floor-stale.js";
 import { buildStatusPanel } from "acp-kernel/panel";
 import { getDelegateUsage } from "./delegate-tool.js";
@@ -143,9 +143,13 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   const sessionTokens = !anchorStale && realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n")) + imageTokensTotal;
   const coveredIds = collectCoveredMessageIds(state);
   const sentTokens = estimateTokens(coreMessages, coveredIds, imageTokens) + systemPromptTokens;
+  // View-based recount (issue #289): with active blocks the raw-view estimate
+  // can sit far above the sent view and mis-scale the panel's nudge — same
+  // arbitration as src/index.ts and acp_status.
+  const viewSentTokens = adjustedTokenCount(runtime.core, coreMessages, state, config, sentTokens, imageTokens, systemPromptTokens);
   // issue #257: floor the meter at the host's real context usage so the
   // panel's nudge matches the real decision (same as src/index.ts).
-  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount: anchorStale ? sentTokens : Math.max(sentTokens, realUsage?.tokens ?? 0) });
+  const turn = runtime.core.processTurn({ messages: coreMessages, state, config, tokenCount: anchorStale ? viewSentTokens : Math.max(viewSentTokens, realUsage?.tokens ?? 0) });
 
   // Shared kit surface renders the panel (dual accounting, viability
   // filtering, bars, block list with topic fallback). Host-specific inputs:

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -7,7 +7,7 @@ import type {
 import type { AcpRuntime } from "./runtime.js";
 import { MAX_COMPRESS_ATTEMPTS } from "./runtime.js";
 import { debug, logError, logInfo, logThrow, logWarn } from "./log.js";
-import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages, lastUserMessageId } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages, lastUserMessageId, adjustedTokenCount } from "./tokens.js";
 import { defaultCountTokens, parseCompressArgs, viableRanges, formatRanges, type CompressionBlock, type CompressionState, type CompressParseDiagnostics, type NudgeDecision } from "acp-kernel";
 import { getSystemPromptText } from "./compat.js";
 import { OMP_UNSUPPORTED_MESSAGE } from "./omp.js";
@@ -290,11 +290,15 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
   const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
   const sentTokens = estimateTokens(coreMessages, collectCoveredMessageIds(initialState), imageTokens) + systemPromptTokens;
+  // Same view-based recount as the context transform (issue #289): with blocks
+  // present, the raw-view count can sit far above the sent view and mis-scale
+  // this pass's emergency-truncate band before boundary resolution.
+  const firstTokenCount = adjustedTokenCount(runtime.core, coreMessages, initialState, config, sentTokens, imageTokens, systemPromptTokens);
   const turn = runtime.core.processTurn({
     messages: coreMessages,
     state: initialState,
     config,
-    tokenCount: sentTokens,
+    tokenCount: firstTokenCount,
   });
   const state = turn.state;
   const messages = turn.messages;
@@ -363,11 +367,15 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
   // (post-processTurn view: visible text + every active block's summary anchor
   // + ref-tag overhead), so "X → Y (~Z reclaimed)" compares like-for-like —
   // including the new block's own summary, which the model will pay for next.
+  // Post-compression count: feeding the stale pre-compression sentTokens would
+  // mis-scale this pass's emergency-truncate band (threshold 0.95) and skew
+  // afterTokens (issue #289).
+  const postSentTokens = adjustedTokenCount(runtime.core, coreMessages, applied.state, config, estimateTokens(coreMessages, collectCoveredMessageIds(applied.state), imageTokens) + systemPromptTokens, imageTokens, systemPromptTokens);
   const afterTurn = runtime.core.processTurn({
     messages: coreMessages,
     state: applied.state,
     config,
-    tokenCount: sentTokens,
+    tokenCount: postSentTokens,
   });
   const afterTokens = estimateTokens(afterTurn.messages, collectCoveredMessageIds(applied.state), imageTokens);
   const reclaimed = Math.max(0, beforeTokens - afterTokens);

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
-import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, collectImageTokens, modelSupportsImages } from "./tokens.js";
+import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, collectImageTokens, modelSupportsImages, sentViewTokenCount } from "./tokens.js";
 import { usageAnchorPredatesCompression } from "./floor-stale.js";
 import { checkForUpdate } from "./update.js";
 import {
@@ -238,30 +238,36 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
       const realUsage = ctx.getContextUsage?.();
       const systemPromptText = getSystemPromptText(ctx);
       const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-      const sentTokens = estimateTokens(coreMessages, coveredIds, collectImageTokens(entries, modelSupportsImages(ctx.model))) + systemPromptTokens;
-      // Usage/emergency arbitration on the sent view, floored at the host's
-      // real context usage (issue #257): the CJK-aware base estimate is still
-      // a heuristic (images, mixed content, per-model tokenizer drift), so
-      // the 0.75/0.95 bands run on the real scale via the floor. realUsage is
-      // anchored on the last assistant's provider-reported usage + trailing
-      // estimate. Only ever raises (never lowers); skipped while the anchor
-      // predates a successful compress (floor-stale.ts). tokenCount only
-      // feeds processTurn.
-      let tokenCount = sentTokens;
-      const realPromptTokens = realUsage?.tokens ?? 0;
-      if (!usageAnchorPredatesCompression(entries) && realPromptTokens > tokenCount) {
-        tokenCount = realPromptTokens;
-      }
-      // Self-heal (armed): after an overflow, force this turn's usage to >=95%
-      // so the kernel's emergency nudge + tool-result truncate fire immediately,
-      // even if the estimate under-reports the sent view. tokenCount only feeds
-      // processTurn (nudge/truncate).
+      const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
+      const sentTokens = estimateTokens(coreMessages, coveredIds, imageTokens) + systemPromptTokens;
+      // Floors (raise-only, applied to whichever base wins below): the host's
+      // real context usage (issue #257/#258 — anchored on the last assistant's
+      // provider-reported usage + trailing estimate; skipped while the anchor
+      // predates a successful compress, floor-stale.ts) and the armed self-heal
+      // 95% floor after an upstream overflow. Captured once so both bases see
+      // identical floors; ov.armed is consumed exactly once either way.
+      let armedFloor = 0;
       if (ov.armed && config.modelContextLimit > 0) {
         ov.armed = false;
-        const floor = Math.floor(config.modelContextLimit * 0.95);
-        if (floor > tokenCount) {
-          tokenCount = floor;
-          logWarn("overflow-selfheal", { sid, event: "armed-emergency", tokenCount, limit: config.modelContextLimit });
+        armedFloor = Math.floor(config.modelContextLimit * 0.95);
+        logWarn("overflow-selfheal", { sid, event: "armed-emergency", floor: armedFloor, limit: config.modelContextLimit });
+      }
+      const hostFloorActive = !usageAnchorPredatesCompression(entries);
+      const realPromptTokens = realUsage?.tokens ?? 0;
+      const applyFloors = (base: number): number => Math.max(base, hostFloorActive ? realPromptTokens : 0, armedFloor);
+      let tokenCount = applyFloors(sentTokens);
+      // View-based recount (issue #289): the raw-view estimate counts uncovered
+      // messages that prune strips from the sent view every turn (orphaned tool
+      // pairs straddling block boundaries, absorbed/filtered messages) — in long
+      // multi-block sessions that pins tokenCount far above reality, holding
+      // usage in the emergency band and driving low/zero-yield compression loops.
+      // Re-measure on the actual post-processTurn view and adopt it when the two
+      // diverge beyond noise (the probe runs on a clone; see sentViewTokenCount).
+      if (state.blocks.some((b) => b.active && b.effectiveMessageIds.length > 0)) {
+        const view = sentViewTokenCount(runtime.core, coreMessages, state, config, tokenCount, imageTokens, systemPromptTokens);
+        if (view.drifted) {
+          tokenCount = applyFloors(view.viewTokens);
+          logInfo("turn", { sid, event: "view-recount", prelim: sentTokens, viewTokens: view.viewTokens, tokenCount });
         }
       }
       debug.event("context-in", {
@@ -286,12 +292,17 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime): void {
         inMsgs: coreMessages.length,
         outMsgs: turn.messages.length,
         tokens: tokenCount,
-        pct: realUsage?.percent ?? (config.modelContextLimit > 0 ? Math.round((tokenCount / config.modelContextLimit) * 100) : null),
+        pct: config.modelContextLimit > 0 ? Number(((tokenCount / config.modelContextLimit) * 100).toFixed(2)) : null,
         limit: config.modelContextLimit,
         nudge: turn.nudge?.shouldInject ? (turn.nudge.breakdown?.emergencyOverride === 1 ? "emergency" : "active") : "idle",
         nudgeReason: turn.nudge?.reason ?? null,
         blocks: turn.state.blocks.length,
         activeBlocks: turn.state.blocks.filter((b) => b.active).length,
+        // #289: host-reported usage (Pi window scale) logged separately so
+        // tokens/pct above stay on one scale; field order after activeBlocks
+        // keeps the pre-existing [turn] layout stable for log consumers.
+        hostTokens: realUsage?.tokens ?? null,
+        hostPct: realUsage?.percent ?? null,
       });
       debug.event("processTurn", {
         modelId,

--- a/src/status-tool.ts
+++ b/src/status-tool.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "typebox";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@earendil-works/pi-coding-agent";
 import type { AcpRuntime } from "./runtime.js";
 import { buildStatusReport, defaultCountTokens, formatRanges, viableRanges } from "acp-kernel";
-import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages } from "./tokens.js";
+import { estimateTokens, collectCoveredMessageIds, collectImageTokens, modelSupportsImages, adjustedTokenCount } from "./tokens.js";
 import { usageAnchorPredatesCompression } from "./floor-stale.js";
 import { getSystemPromptText } from "./compat.js";
 import { logThrow } from "./log.js";
@@ -60,16 +60,20 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   // the host's real context usage (issue #257; see src/index.ts).
   const systemPromptText = getSystemPromptText(ctx);
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
-  const sentTokens = estimateTokens(coreMessages, coveredIds, collectImageTokens(entries, modelSupportsImages(ctx.model))) + systemPromptTokens;
-  // issue #257: run the nudge decision on the real scale — floor the sent-view
-  // estimate at the host's real context usage (same as src/index.ts).
+  const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
+  const sentTokens = estimateTokens(coreMessages, coveredIds, imageTokens) + systemPromptTokens;
+  // View-based recount (issue #289): with active blocks the raw-view estimate
+  // can sit far above the sent view and mis-scale the nudge shown here — same
+  // arbitration as src/index.ts. The host floor (#257) applies on top of the
+  // winning base.
+  const viewSentTokens = adjustedTokenCount(runtime.core, coreMessages, state, config, sentTokens, imageTokens, systemPromptTokens);
   const providerReal = ctx.getContextUsage?.()?.tokens ?? 0;
   const anchorStale = usageAnchorPredatesCompression(entries);
   const turn = runtime.core.processTurn({
     messages: coreMessages,
     state,
     config,
-    tokenCount: anchorStale ? sentTokens : Math.max(sentTokens, providerReal),
+    tokenCount: anchorStale ? viewSentTokens : Math.max(viewSentTokens, providerReal),
   });
   const processed = turn.messages;
 
@@ -95,11 +99,11 @@ async function handleStatus(args: StatusArgs, runtime: AcpRuntime, ctx: Extensio
   // visible at a glance (Estimate is the pre-floor sent-view meter).
   if (providerReal > 0 && config.modelContextLimit > 0) {
     const fmtK = (n: number): string => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
-    const estPct = Math.round((sentTokens / config.modelContextLimit) * 100);
+    const estPct = Math.round((viewSentTokens / config.modelContextLimit) * 100);
     const realPct = Math.round((providerReal / config.modelContextLimit) * 100);
     extra.push("");
     extra.push(
-      `Estimate: ${fmtK(sentTokens)} (${estPct}%)   |   Provider-reported: ${fmtK(providerReal)} (${realPct}%)`,
+      `Estimate: ${fmtK(viewSentTokens)} (${estPct}%)   |   Provider-reported: ${fmtK(providerReal)} (${realPct}%)`,
     );
   }
   if (nudge) {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -64,7 +64,14 @@ export function sentViewTokenCount(
   imageTokensById?: Map<string, number>,
   systemPromptTokens = 0,
 ): { viewTokens: number; drifted: boolean } {
-  const probe = core.processTurn({ messages, state: structuredClone(state), config, tokenCount: prelim });
+  // Clamp the probe below the emergency-truncate threshold: passing prelim
+  // through would let emergencyTruncateNode fire inside the probe whenever
+  // prelim sits in the truncate band, so viewTokens would measure the
+  // post-truncation view — under-reporting exactly the pathological case this
+  // recount exists for (issue #289). The real pass still truncates when its
+  // own (honest) count crosses the band.
+  const cap = config.modelContextLimit > 0 ? Math.max(0, Math.floor(config.truncate.threshold * config.modelContextLimit) - 1) : Number.MAX_SAFE_INTEGER;
+  const probe = core.processTurn({ messages, state: structuredClone(state), config, tokenCount: Math.min(prelim, cap) });
   const viewTokens = estimateTokens(probe.messages, collectCoveredMessageIds(probe.state), imageTokensById) + systemPromptTokens;
   return { viewTokens, drifted: Math.abs(viewTokens - prelim) > Math.max(1000, 0.1 * prelim) };
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,4 +1,4 @@
-import { defaultCountTokens, type CoreMessage } from "acp-kernel";
+import { defaultCountTokens, type CompressionCore, type CompressionState, type Config, type CoreMessage } from "acp-kernel";
 import type { SessionMessageEntry } from "@earendil-works/pi-coding-agent";
 import { countImageBlocks } from "./messages.js";
 
@@ -44,6 +44,45 @@ export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>
     if (img) tokens += img;
   }
   return tokens;
+}
+
+// Re-measure tokenCount on the ACTUAL sent view: run processTurn on a throwaway
+// state clone (processTurn mutates state — survival counters, nudge stamps) and
+// count the pruned result (covered removed + summaries injected + orphaned tool
+// pairs/absorbed/filtered messages stripped). The raw-view estimate over
+// coreMessages minus block coverage diverges from this sent view in long
+// multi-block sessions: uncovered messages that prune strips every turn stay
+// counted forever while never being sent, pinning usage in the emergency band
+// and driving low/zero-yield compression loops (issue #289). Ref-tag overhead
+// is included because tags ride along in the sent text.
+export function sentViewTokenCount(
+  core: CompressionCore,
+  messages: CoreMessage[],
+  state: CompressionState,
+  config: Config,
+  prelim: number,
+  imageTokensById?: Map<string, number>,
+  systemPromptTokens = 0,
+): { viewTokens: number; drifted: boolean } {
+  const probe = core.processTurn({ messages, state: structuredClone(state), config, tokenCount: prelim });
+  const viewTokens = estimateTokens(probe.messages, collectCoveredMessageIds(probe.state), imageTokensById) + systemPromptTokens;
+  return { viewTokens, drifted: Math.abs(viewTokens - prelim) > Math.max(1000, 0.1 * prelim) };
+}
+
+// Guarded variant for call sites that only need the final count: divergence is
+// impossible without active block coverage, so skip the probe pass entirely then.
+export function adjustedTokenCount(
+  core: CompressionCore,
+  messages: CoreMessage[],
+  state: CompressionState,
+  config: Config,
+  prelim: number,
+  imageTokensById?: Map<string, number>,
+  systemPromptTokens = 0,
+): number {
+  if (!state.blocks.some((b) => b.active && b.effectiveMessageIds.length > 0)) return prelim;
+  const view = sentViewTokenCount(core, messages, state, config, prelim, imageTokensById, systemPromptTokens);
+  return view.drifted ? view.viewTokens : prelim;
 }
 
 /** Id of the last user-role entry — used as a per-turn key so a nudge prints at

--- a/tests/view-recount.test.ts
+++ b/tests/view-recount.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { createAcpExtension } from "../src/index.js";
+import { createCore, createInitialState, defaultConfig, defaultCountTokens, type CoreMessage } from "acp-kernel";
+import { sentViewTokenCount, estimateTokens } from "../src/tokens.js";
+
+const L = 100_000;
+const MID = "lorem ".repeat(3000);
+const STATE_FILE = "/tmp/pai-acp-view-recount.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+function msg(id: string, role: string, content: unknown, extra: Record<string, unknown> = {}) {
+  return { type: "message", id, parentId: null, timestamp: "", message: { role, content, timestamp: Date.now(), ...extra } };
+}
+
+let branchEntries: any[] = [];
+
+function fakeCtx() {
+  return {
+    mode: "rpc" as const,
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: L, id: "test-model" },
+    getContextUsage: () => null,
+    sessionManager: {
+      getBranch: () => branchEntries as any[],
+      getSessionId: () => "view-recount",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+const fire = (handlers: Map<string, ((e: any, ctx: any) => any)[]>, ctx: any) =>
+  handlers.get("context")![0]!({ type: "context", messages: branchEntries.map((e) => e.message) }, ctx);
+
+// Only EMERGENCY nudges carry this phrase (kernel nudge-text.ts); gentle
+// growth nudges do not, so it discriminates the #289 failure mode precisely.
+const emergencyCount = (r: any) =>
+  (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached/.test(JSON.stringify(m.content))).length;
+
+const anyNudgeCount = (r: any) =>
+  (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached|compress/i.test(JSON.stringify(m.content))).length;
+
+// #289 Fix A discriminator. The raw-view estimate (core minus block coverage)
+// counts messages that prune strips from the sent view every turn: an
+// uncovered tool-result whose paired call got compressed. Layout below makes
+// exactly that happen — c1's result sits 21 positions past c1's split core,
+// beyond adjustBoundariesForToolPairs' maxScan=20, so compressing c1 alone
+// orphans r1. Raw view then reads ~97% (>= emergency band 0.95) while the
+// honest sent view reads ~72%: OLD code keeps firing EMERGENCY, NEW code's
+// sent-view recount drops below the band.
+test("#289 Fix A: sent-view recount suppresses spurious emergency", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension({ modelContextLimit: L })(api as any);
+    const compressTool = api.tools.find((t: any) => t.name === "compress");
+    assert.ok(compressTool, "compress tool registered");
+    const ctx = fakeCtx();
+
+    const entries: any[] = [];
+    for (let i = 0; i < 16; i++) entries.push(msg(`b${i}`, i % 2 ? "assistant" : "user", `bulk ${i} ${MID}`));
+    const calls: any[] = [{ type: "toolCall", id: "c1", name: "bash", arguments: { command: "x".repeat(30_000) } }];
+    for (let i = 2; i <= 21; i++) calls.push({ type: "toolCall", id: `c${i}`, name: "bash", arguments: { command: "ls" } });
+    entries.push(msg("multi", "assistant", calls));
+    entries.push(msg("r1", "toolResult", [{ type: "text", text: "y".repeat(100_000) }], { toolName: "bash", toolCallId: "c1" }));
+    for (let i = 2; i <= 21; i++) entries.push(msg(`r${i}`, "toolResult", [{ type: "text", text: "ok" }], { toolName: "bash", toolCallId: `c${i}` }));
+    branchEntries = entries;
+
+    // Round 1 primes the session (~104.5% raw — emergency expected on both
+    // old and new code).
+    const r1 = await fire(handlers, ctx);
+    assert.ok(anyNudgeCount(r1) >= 1, "round 1 primes the emergency band");
+
+    // Resolve c1's split-core ref from the persisted refmap instead of assuming
+    // numbering (assignRefs may skip/protect messages).
+    const st = JSON.parse(await readFileSync(`${STATE_FILE}.acp.json`, "utf8"));
+    const byRef: Record<string, string> = st.messageRefs?.byRef ?? {};
+    const refC1 = Object.keys(byRef).find((k) => byRef[k] === "multi#c1");
+    assert.ok(refC1, `ref for multi#c1 found in ${Object.keys(byRef).length} refs`);
+
+    const out: any = await compressTool.execute("tc1", { content: [{ startId: refC1, endId: refC1, summary: "s".repeat(300) }] }, undefined, undefined, ctx);
+    const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+    assert.match(text, /1 block/, `expected successful compress, got: ${text}`);
+
+    // Session realism: the compress toolResult lands in the transcript.
+    branchEntries.push(msg("cr1", "toolResult", [{ type: "text", text: "▣ ACP | 81.7K → 72.2K tokens (~9.5K reclaimed, 1 block)" }], { toolName: "compress", toolCallId: "tc1" }));
+
+    // Round 2: raw estimate ~97% (orphaned r1 counted forever) vs honest sent
+    // view ~72%. OLD: EMERGENCY fires. NEW: recount stays below the band.
+    const r2 = await fire(handlers, ctx);
+    assert.equal(emergencyCount(r2), 0, "no emergency nudge once the sent view is measured honestly (#289 discriminator)");
+  } finally {
+    await rm(`${STATE_FILE}.acp.json`, { force: true });
+  }
+});
+
+// Helper sanity: with zero blocks the probe view equals the raw view (only
+// ref-tag overhead differs) — no drift, no systematic offset.
+test("#289 helper: zero-block state does not drift", () => {
+  const core = createCore({ countTokens: defaultCountTokens });
+  const state = createInitialState();
+  const msgs: CoreMessage[] = [
+    { id: "e1", role: "user", contentType: "text", text: "hello world" },
+    { id: "e2", role: "assistant", contentType: "text", text: "hi" },
+  ];
+  const prelim = estimateTokens(msgs);
+  const r = sentViewTokenCount(core, msgs, state, defaultConfig(L), prelim);
+  assert.equal(r.drifted, false);
+  assert.ok(r.viewTokens >= prelim, `viewTokens ${r.viewTokens} should include ref-tag overhead over prelim ${prelim}`);
+});

--- a/tests/view-recount.test.ts
+++ b/tests/view-recount.test.ts
@@ -126,3 +126,79 @@ test("#289 helper: zero-block state does not drift", () => {
   assert.equal(r.drifted, false);
   assert.ok(r.viewTokens >= prelim, `viewTokens ${r.viewTokens} should include ref-tag overhead over prelim ${prelim}`);
 });
+
+// #289 Fix A′: the probe must measure the PRE-truncation sent view. Passing
+// prelim straight into processTurn lets emergencyTruncateNode fire inside the
+// probe whenever prelim sits in the truncate band (>= threshold*limit), so the
+// measurement would depend on prelim and under-report the honest view. With
+// the clamp, two prelims both at/above the band edge yield identical counts,
+// and the count covers the full untruncated view (+ ref-tag overhead).
+test("#289 Fix A': probe measurement is invariant to prelim inside the truncate band", () => {
+  const core = createCore({ countTokens: defaultCountTokens });
+  const state = createInitialState();
+  const config = defaultConfig(L);
+  // r1's truncation savings (~11.5k tok) sit between the two cutoffs
+  // (prelim - 0.9*threshold*limit): at `lo` the old code stops after r1, at
+  // `hi` it also truncates r2 — so old-code measurements differ, new-code
+  // measurements are identical. Six trailing messages keep r1/r2 outside the
+  // preserveRecentMessages=5 protection window; no toolCallId means prune
+  // keeps both results.
+  const msgs: CoreMessage[] = [
+    { id: "u1", role: "user", contentType: "text", text: "start" },
+    { id: "r1", role: "tool", contentType: "tool-result", text: "x".repeat(50_000) },
+    { id: "r2", role: "tool", contentType: "tool-result", text: "y".repeat(16_000) },
+    { id: "a1", role: "assistant", contentType: "text", text: "ok" },
+    { id: "u2", role: "user", contentType: "text", text: "q1" },
+    { id: "a2", role: "assistant", contentType: "text", text: "ok" },
+    { id: "u3", role: "user", contentType: "text", text: "q2" },
+    { id: "a3", role: "assistant", contentType: "text", text: "ok" },
+    { id: "u4", role: "user", contentType: "text", text: "next" },
+  ];
+  const lo = Math.floor(config.truncate.threshold * L); // exactly at the band edge
+  const hi = L - 1; // deep in the band
+  const a = sentViewTokenCount(core, msgs, state, config, lo);
+  const b = sentViewTokenCount(core, msgs, state, config, hi);
+  assert.equal(a.viewTokens, b.viewTokens, "probe must not self-truncate: measurement independent of prelim inside the band");
+  const raw = estimateTokens(msgs);
+  assert.ok(a.viewTokens >= raw, `pre-truncation view ${a.viewTokens} should cover the raw estimate ${raw} (+ ref-tag overhead)`);
+});
+
+// #289 Fix B: acp_status arbitrates on the sent view like the context
+// transform. In the orphan layout below the raw-view estimate sits in the
+// growth band (~88%) while the honest sent view is well under it (~58%):
+// OLD code shows "Nudge: ACTIVE", fixed code shows "Nudge: idle".
+test("#289 Fix B: acp_status nudge follows the sent view, not the raw estimate", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  try {
+    const { api, handlers } = captureApi();
+    createAcpExtension({ modelContextLimit: L })(api as any);
+    const compressTool = api.tools.find((t: any) => t.name === "compress");
+    const statusTool = api.tools.find((t: any) => t.name === "acp_status");
+    assert.ok(statusTool, "acp_status tool registered");
+    const ctx = fakeCtx();
+
+    const MIDB = "lorem ".repeat(2200); // ~3.3k tokens each × 16 ≈ 53k
+    const entries: any[] = [];
+    for (let i = 0; i < 16; i++) entries.push(msg(`b${i}`, i % 2 ? "assistant" : "user", `bulk ${i} ${MIDB}`));
+    const calls: any[] = [{ type: "toolCall", id: "c1", name: "bash", arguments: { command: "x".repeat(30_000) } }];
+    for (let i = 2; i <= 21; i++) calls.push({ type: "toolCall", id: `c${i}`, name: "bash", arguments: { command: "ls" } });
+    entries.push(msg("multi", "assistant", calls));
+    entries.push(msg("r1", "toolResult", [{ type: "text", text: "y".repeat(120_000) }], { toolName: "bash", toolCallId: "c1" }));
+    for (let i = 2; i <= 21; i++) entries.push(msg(`r${i}`, "toolResult", [{ type: "text", text: "ok" }], { toolName: "bash", toolCallId: `c${i}` }));
+    branchEntries = entries;
+
+    await fire(handlers, ctx);
+    const st = JSON.parse(await readFileSync(`${STATE_FILE}.acp.json`, "utf8"));
+    const byRef: Record<string, string> = st.messageRefs?.byRef ?? {};
+    const refC1 = Object.keys(byRef).find((k) => byRef[k] === "multi#c1");
+    assert.ok(refC1, `ref for multi#c1 found in ${Object.keys(byRef).length} refs`);
+    await compressTool.execute("tc1", { content: [{ startId: refC1, endId: refC1, summary: "s".repeat(300) }] }, undefined, undefined, ctx);
+    branchEntries.push(msg("cr1", "toolResult", [{ type: "text", text: "▣ ACP | done" }], { toolName: "compress", toolCallId: "tc1" }));
+
+    const out: any = await statusTool.execute("st1", {}, undefined, undefined, ctx);
+    const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+    assert.match(text, /Nudge: idle/, `acp_status should read the sent view (~58%), got:\n${text.slice(0, 500)}`);
+  } finally {
+    await rm(`${STATE_FILE}.acp.json`, { force: true });
+  }
+});


### PR DESCRIPTION
## Problem

#289 reports token counts desyncing from post-compression state, causing consecutive low-yield / zero-yield compressions. All four sub-claims were verified against the code and the incident logs:

1. **`tokens` / `pct` / `usage` disagree** — two mechanisms:
   - The `[turn]` log mixed scales: `tokens` = ACP local estimate, `pct` = Pi host `getContextUsage().percent` (host-window scale). The incident math proves it: `pct=19.970955882352943 × 272,000 = 54,321` exactly equals the host-reported token count, while `tokens=190,513`.
   - **Root cause**: the base estimate `estimateTokens(coreMessages, coveredIds)` runs over the RAW core view minus block coverage — not the sent view `processTurn` actually produces (prune + summary injection + orphan-strip + absorb + filter). In long multi-block sessions these diverge without bound: content that is uncovered in the raw view but stripped from the sent view every turn (e.g. tool results whose paired call got covered) is counted forever. Incident: local estimate 190,513 vs real provider input 36,387 (4,899 input + 31,488 cacheRead) — a ~174K constant offset that tracks compression exactly (next turn: 183,875; Δ6,638 ≈ tokensCompressed 6,717).
2. **`sentTokens` not recomputed after compression** — confirmed: the second `processTurn` after `applyCompression` reused the pre-compression `sentTokens`, so the emergency-truncation band and the panel "reclaimed" number were computed on a stale scale.
3. **Tiny-pending T2/T3 distill still firing EMERGENCY** — the kernel pressure band injects the max-pending tier whenever `pending > 0` (no minimum-benefit gate). With claim-1's inflated count pinning usage ≥ 95%, this loops: each micro-compression succeeds → nudge baselines reset → next LLM call re-injects. Downstream symptom of #1; the gate itself belongs in acp-kernel → companion issue filed there.
4. **Zero-yield compressions not stopping** — the per-turn cap (`MAX_COMPRESS_ATTEMPTS=3`) exists and counts failures/no-ops, but resets every user turn; with the count pinned high the loop persisted across turns. Removing the false emergency (claim 1) is what actually stops it.

## Fix (adapter-side, no acp-kernel bump)

- **`src/tokens.ts`**: new `sentViewTokenCount()` — runs `processTurn` on a throwaway `structuredClone(state)` and re-measures tokens on the actual post-pipeline view (the clone is mandatory because `processTurn` mutates state); `adjustedTokenCount()` adopts the recount when coverage exists and the delta exceeds `max(1000, 10%)`.
- **`src/index.ts`** (Fix A): `wireContextTransform` recounts before the final pass when active blocks exist; all floors stay raise-only. (Fix C) the `[turn]` log now computes `pct` from the same `tokenCount/limit` scale and logs host usage separately as `hostTokens`/`hostPct`, appended after `activeBlocks` to keep the existing field layout stable for log consumers.
- **`src/compress-tool.ts`** (Fixes A′/B): the first pass uses the recounted count; the post-compression `afterTurn` now measures from `applied.state` instead of the stale pre-compression `sentTokens`.

## Tests

- New `tests/view-recount.test.ts`: an e2e discriminator (one assistant turn with 21 parallel tool calls; c1's result sits 21 positions past c1's split core — beyond `adjustBoundariesForToolPairs`' `maxScan=20` — so compressing c1 alone orphans its result. Raw view then reads ~97% ≥ emergency band while the honest sent view reads ~72%; asserts no EMERGENCY nudge fires) plus a helper sanity test (zero-block state does not drift). Fails on pre-fix code, passes with the fix.
- Full suite: 467 tests, 464 pass, 0 fail, 3 skipped; typecheck + build green.

## Expectation mapping from #289

| # | Expected behavior | Resolution |
|---|---|---|
| 1 | compute tokens from the final sent list | ✅ Fixes A/A′ |
| 2 | recompute postCompressionTokens before processTurn | ✅ Fix B |
| 3 | minimum-benefit gate for T2/T3 nudges | → acp-kernel companion issue (cross-repo release ordering) |
| 4 | stop after a zero-reclaim compress within a turn | already present (per-turn cap, verified); the false emergency is what let it loop across turns |
| 5 | cross-turn circuit breaker | declined: fixing the count removes the spurious permanent emergency; an extra breaker risks suppressing legitimate compression |

No `version` bump (release-branch territory). acp-kernel stays pinned at exact 0.0.48.