### PR TITLE
feat: live fleet inspector for acp_delegate runs (/acp-fleet)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
+				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
 				"acp-kernel": "0.0.48",
 				"tsup": "^8.5.1",
@@ -1983,6 +1984,20 @@
 				"zod": "^3.25.28 || ^4"
 			}
 		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.83.0",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
+			"integrity": "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.7",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -3375,6 +3390,19 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/joycon": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -3423,6 +3451,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/mlly": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 	},
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.83.0",
+		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
 		"acp-kernel": "0.0.48",
 		"tsup": "^8.5.1",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,8 @@ import { collectCoveredMessageIds, estimateTokens, collectImageTokens, modelSupp
 import { usageAnchorPredatesCompression } from "./floor-stale.js";
 import { buildStatusPanel } from "acp-kernel/panel";
 import { getDelegateUsage } from "./delegate-tool.js";
+import { openFleetInspector } from "./fleet-inspector.js";
+import { resolveDelegate } from "./config.js";
 import { ensureSubagentAcpTools } from "./setup-subagent-tools.js";
 
 declare const CURRENT_VERSION: string;
@@ -119,6 +121,19 @@ export function makeCommands(runtime: AcpRuntime, pi?: ExtensionAPI): Array<{ na
           } else {
             ctx.ui.notify(`Failed to update ${result.path}: ${result.reason ?? "unknown"}`);
           }
+        },
+      },
+    },
+    {
+      name: "acp-fleet",
+      options: {
+        description: "Inspect acp_delegate sub-agent runs: live list + transcript overlay (TUI), text snapshot elsewhere.",
+        handler: async (_args, ctx) => {
+          if (!resolveDelegate(runtime.adapter).enabled) {
+            ctx.ui.notify("acp_delegate is not enabled in this session's config.");
+            return;
+          }
+          await openFleetInspector(ctx);
         },
       },
     },

--- a/src/delegate-tool.ts
+++ b/src/delegate-tool.ts
@@ -28,7 +28,7 @@ const IDLE_GRACE_MS = 5 * 60_000;
 const ASYNC_TIMEOUT_MS = 30 * 60_000;
 const KILL_GRACE_MS = 10_000;
 const RESULT_SUMMARY_CHARS = 500;
-const OUT_DIR = join(tmpdir(), "acp-delegate");
+export const OUT_DIR = join(tmpdir(), "acp-delegate");
 // Coalesce completion notifications: each sendUserMessage follow-up costs a
 // full model turn, so N near-simultaneous finishes merge into ONE message
 // (issue #157). The trailing window (NOTIFY_COALESCE_MS) never extends more
@@ -239,6 +239,68 @@ export function runningRunsSnapshot(): { runId: string; agent: string; task: str
     if (r.status === "running") out.push({ runId: r.runId, agent: r.agent, task: r.task, startedAt: r.startedAt });
   }
   return out;
+}
+
+// ─── Fleet inspector (#292) ─────────────────────────────────────────────────
+
+export interface FleetRunView {
+  runId: string;
+  agent: string;
+  task: string;
+  cwd: string;
+  startedAt: number;
+  finishedAt?: number;
+  status: RunStatus;
+  exitLabel: string;
+  timedOut?: string;
+  resumedFrom?: string;
+  /** Streamed reply text (always retained, even for cancelled runs). */
+  replyFile: string;
+  /** Live tool-activity log (async json-stream runs only). */
+  activityFile?: string;
+  sessionFile?: string;
+  usage?: Usage;
+}
+
+const MAX_FLEET_FINISHED = 12;
+
+/** Running first (oldest spawn on top), then recently finished (newest first,
+ *  capped) — the order the fleet inspector list shows. */
+export function orderRunsForFleet(all: DelegateRun[]): DelegateRun[] {
+  const running = all
+    .filter((r) => r.status === "running")
+    .sort((a, b) => a.startedAt - b.startedAt);
+  const finished = all
+    .filter((r) => r.status !== "running")
+    .sort((a, b) => (b.finishedAt ?? 0) - (a.finishedAt ?? 0))
+    .slice(0, MAX_FLEET_FINISHED);
+  return [...running, ...finished];
+}
+
+function toFleetRunView(r: DelegateRun): FleetRunView {
+  return {
+    runId: r.runId,
+    agent: r.agent,
+    task: r.task,
+    cwd: r.cwd,
+    startedAt: r.startedAt,
+    finishedAt: r.finishedAt,
+    status: r.status,
+    exitLabel: exitLabel(r.exitCode ?? null, r.exitSignal),
+    timedOut: r.timedOut,
+    resumedFrom: r.resumedFrom,
+    replyFile: r.result?.file ?? join(OUT_DIR, `${r.runId}.out`),
+    activityFile: r.activityFile,
+    sessionFile: join(OUT_DIR, `${r.runId}${SESSION_EXT}`),
+    usage: r.usage,
+  };
+}
+
+/** Display-safe snapshot of every delegate run known this session, for the
+ *  fleet inspector (/acp-fleet). In-memory only: runs from previous pi
+ *  processes are not listed (their files remain under OUT_DIR). */
+export function fleetRunsSnapshot(): FleetRunView[] {
+  return orderRunsForFleet(Array.from(runs.values())).map(toFleetRunView);
 }
 
 /** Minimal writable surface accepted by makeEventApplier — real WriteStreams

--- a/src/fleet-inspector.ts
+++ b/src/fleet-inspector.ts
@@ -1,0 +1,305 @@
+import { openSync, fstatSync, readSync, closeSync } from "node:fs";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Key, matchesKey, truncateToWidth } from "@earendil-works/pi-tui";
+import type { Component } from "@earendil-works/pi-tui";
+import { OUT_DIR, fleetRunsSnapshot, type FleetRunView } from "./delegate-tool.js";
+
+const REFRESH_MS = 500;
+const TRANSCRIPT_TAIL_BYTES = 8192;
+const SNAPSHOT_TAIL_BYTES = 4096;
+const MAX_TASK_LEN = 48;
+const MAX_CONTENT_LINES = 30;
+
+export interface InspectorTheme {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+}
+
+interface TuiLike {
+  requestRender(force?: boolean): void;
+  terminal: { rows: number };
+}
+
+function truncateText(s: string, max: number): string {
+  const oneLine = s.replace(/\n/g, " ").trim();
+  if (oneLine.length <= max) return oneLine;
+  return `${oneLine.slice(0, max - 1)}…`;
+}
+
+export function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m${String(s % 60).padStart(2, "0")}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h${String(m % 60).padStart(2, "0")}m`;
+}
+
+export function statusIcon(status: FleetRunView["status"]): string {
+  switch (status) {
+    case "running": return "●";
+    case "completed": return "✓";
+    case "failed": return "✗";
+    case "cancelled": return "⊘";
+  }
+}
+
+export function usageSummary(usage: FleetRunView["usage"]): string | undefined {
+  if (!usage || usage.totalTokens <= 0) return undefined;
+  return `\u2191${usage.input.toLocaleString()} \u2193${usage.output.toLocaleString()}`;
+}
+
+export interface ListRow {
+  run: FleetRunView;
+  label: string;
+  detail: string;
+}
+
+export function buildListRows(runs: FleetRunView[], now: number): ListRow[] {
+  return runs.map((run) => {
+    const dur = formatDuration((run.finishedAt ?? now) - run.startedAt);
+    const state = run.status === "running" ? `running ${dur}` : `${run.status} ${run.exitLabel}`;
+    const label = `${statusIcon(run.status)} ${run.agent} · ${state}${run.timedOut ? ` (${run.timedOut})` : ""}`;
+    const tokens = usageSummary(run.usage);
+    const detail = truncateText(run.task, MAX_TASK_LEN) + (tokens ? ` [${tokens}]` : "");
+    return { run, label, detail };
+  });
+}
+
+/** Last maxBytes of a file as utf8; a partial leading line is dropped so the
+ *  tail always starts on a line boundary. Missing/unreadable → "". */
+export function readTailSync(file: string | undefined, maxBytes: number): string {
+  if (!file) return "";
+  try {
+    const fd = openSync(file, "r");
+    try {
+      const size = fstatSync(fd).size;
+      if (size === 0) return "";
+      const len = Math.min(size, maxBytes);
+      const buf = Buffer.alloc(len);
+      readSync(fd, buf, 0, len, size - len);
+      let text = buf.toString("utf8");
+      if (size > len) {
+        const nl = text.indexOf("\n");
+        text = nl >= 0 ? text.slice(nl + 1) : "";
+      }
+      return text;
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
+}
+
+export function renderListView(rows: ListRow[], selIdx: number, theme: InspectorTheme, width: number): string[] {
+  if (rows.length === 0) {
+    return [
+      truncateToWidth(theme.bold(theme.fg("accent", "acp_delegate")), width),
+      truncateToWidth(theme.fg("dim", "no delegate runs yet — dispatch one with acp_delegate"), width),
+      "",
+      truncateToWidth(theme.fg("dim", "esc close"), width),
+    ];
+  }
+  const lines: string[] = [
+    truncateToWidth(theme.bold(theme.fg("accent", `acp_delegate · ${rows.length} run${rows.length === 1 ? "" : "s"} (live)`)), width),
+  ];
+  rows.forEach((row, i) => {
+    const color = row.run.status === "running" ? "warning" : row.run.status === "completed" ? "success" : row.run.status === "failed" ? "error" : "muted";
+    const prefix = i === selIdx ? "> " : "  ";
+    lines.push(truncateToWidth(`${prefix}${theme.fg(color, row.label)}  ${theme.fg("dim", row.detail)}`, width));
+  });
+  lines.push("");
+  lines.push(truncateToWidth(theme.fg("dim", "↑↓ select · enter inspect · esc close"), width));
+  return lines;
+}
+
+export function renderTranscriptView(run: FleetRunView, tail: string, now: number, theme: InspectorTheme, width: number): string[] {
+  const dur = formatDuration((run.finishedAt ?? now) - run.startedAt);
+  const head = `${statusIcon(run.status)} ${run.agent} · ${run.runId} · ${run.status === "running" ? `running ${dur}` : `${run.status} ${run.exitLabel} after ${dur}`}`;
+  const metaBits = [run.cwd];
+  const tokens = usageSummary(run.usage);
+  if (tokens) metaBits.push(tokens);
+  if (run.resumedFrom) metaBits.push(`resumed from ${run.resumedFrom}`);
+  const lines: string[] = [
+    truncateToWidth(theme.bold(theme.fg("accent", head)), width),
+    truncateToWidth(theme.fg("dim", metaBits.join(" · ")), width),
+    "",
+  ];
+  const body = tail.trimEnd();
+  if (body) {
+    for (const l of body.split("\n")) lines.push(truncateToWidth(l, width));
+  } else {
+    lines.push(theme.fg("dim", "(no output yet)"));
+  }
+  lines.push("");
+  lines.push(truncateToWidth(theme.fg("dim", "pgup/pgdn scroll · esc back"), width));
+  return lines;
+}
+
+/** Plain-text snapshot for non-TUI hosts (rpc/print/json). */
+export function buildSnapshotText(runs: FleetRunView[], now: number): string {
+  if (runs.length === 0) return "acp_delegate: no runs recorded this session.";
+  const parts: string[] = [`acp_delegate · ${runs.length} run(s)`];
+  for (const row of buildListRows(runs, now)) {
+    parts.push(`- ${row.label} — ${row.detail}`);
+    if (row.run.status === "running") {
+      const tail = readTailSync(row.run.activityFile, SNAPSHOT_TAIL_BYTES).trimEnd();
+      if (tail) {
+        for (const l of tail.split("\n").slice(-8)) parts.push(`    ${l}`);
+      }
+    }
+  }
+  parts.push("");
+  parts.push(`Files under ${OUT_DIR}: <runId>.out (reply), <runId>.activity (tool log), <runId>.session.jsonl (session)`);
+  return parts.join("\n");
+}
+
+class FleetInspectorComponent implements Component {
+  private mode: "list" | "transcript" = "list";
+  private rows: ListRow[] = [];
+  private selIdx = 0;
+  private selRunId: string | undefined;
+  private follow = true;
+  private scrollLines = 0;
+  private tailText = "";
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private closed = false;
+
+  constructor(
+    private tui: TuiLike,
+    private theme: InspectorTheme,
+    private doneCb: () => void,
+    private snapshotFn: () => FleetRunView[],
+    private refreshMs: number,
+  ) {}
+
+  start(): void {
+    this.tick();
+    this.timer = setInterval(() => this.tick(), this.refreshMs);
+    this.timer.unref?.();
+  }
+
+  dispose(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  invalidate(): void {
+    // no cache — render() recomputes rows and tails from scratch
+  }
+
+  private tick(): void {
+    if (this.closed) return;
+    const now = Date.now();
+    this.rows = buildListRows(this.snapshotFn(), now);
+    if (this.selRunId) {
+      const idx = this.rows.findIndex((r) => r.run.runId === this.selRunId);
+      this.selIdx = idx >= 0 ? idx : 0;
+    } else if (this.selIdx >= this.rows.length) {
+      this.selIdx = Math.max(0, this.rows.length - 1);
+    }
+    const sel = this.rows[this.selIdx]?.run;
+    if (sel && this.mode === "transcript") {
+      this.tailText = readTailSync(sel.activityFile ?? sel.replyFile, TRANSCRIPT_TAIL_BYTES);
+    }
+    this.tui.requestRender();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, "q")) {
+      if (this.mode === "transcript") {
+        this.mode = "list";
+        this.follow = true;
+        this.scrollLines = 0;
+        this.tui.requestRender();
+      } else {
+        this.close();
+      }
+      return;
+    }
+    if (this.mode === "list") {
+      if (matchesKey(data, Key.up) || matchesKey(data, "k")) this.move(-1);
+      else if (matchesKey(data, Key.down) || matchesKey(data, "j")) this.move(1);
+      else if (matchesKey(data, Key.enter) || matchesKey(data, "x")) this.openTranscript();
+    } else if (matchesKey(data, Key.pageUp)) {
+      this.follow = false;
+      this.scrollLines += 10;
+      this.tui.requestRender();
+    } else if (matchesKey(data, Key.pageDown)) {
+      this.scrollLines = Math.max(0, this.scrollLines - 10);
+      if (this.scrollLines === 0) this.follow = true;
+      this.tui.requestRender();
+    } else if (matchesKey(data, Key.enter)) {
+      this.mode = "list";
+      this.tui.requestRender();
+    }
+  }
+
+  private move(dir: -1 | 1): void {
+    if (this.rows.length === 0) return;
+    const next = Math.min(this.rows.length - 1, Math.max(0, this.selIdx + dir));
+    if (next !== this.selIdx) {
+      this.selIdx = next;
+      this.selRunId = this.rows[next]?.run.runId;
+      this.tui.requestRender();
+    }
+  }
+
+  private openTranscript(): void {
+    const sel = this.rows[this.selIdx];
+    if (!sel) return;
+    this.selRunId = sel.run.runId;
+    this.mode = "transcript";
+    this.follow = true;
+    this.scrollLines = 0;
+    this.tick();
+  }
+
+  private close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.dispose();
+    this.doneCb();
+  }
+
+  render(width: number): string[] {
+    if (this.mode !== "transcript") return renderListView(this.rows, this.selIdx, this.theme, width);
+    const sel = this.rows[this.selIdx]?.run;
+    if (!sel) return renderListView(this.rows, this.selIdx, this.theme, width);
+    const full = renderTranscriptView(sel, this.tailText, Date.now(), this.theme, width);
+    // Header = first 3 lines, footer = last 2; window the body so the view
+    // never outgrows the overlay even on short terminals.
+    const header = full.slice(0, 3);
+    const footer = full.slice(-2);
+    const body = full.slice(3, -2);
+    const contentBudget = Math.max(4, Math.min(MAX_CONTENT_LINES, Math.floor(this.tui.terminal.rows * 0.7) - 5));
+    const start = this.follow ? Math.max(0, body.length - contentBudget) : Math.max(0, Math.min(body.length - contentBudget, body.length - this.scrollLines - contentBudget));
+    const visible = body.slice(start, start + contentBudget);
+    return [...header, ...visible, ...footer];
+  }
+}
+
+/** Open the live fleet inspector: TUI overlay in interactive mode, plain-text
+ *  snapshot notification elsewhere. Resolves when the user closes it. */
+export async function openFleetInspector(ctx: ExtensionContext): Promise<void> {
+  if (ctx.mode !== "tui") {
+    const text = buildSnapshotText(fleetRunsSnapshot(), Date.now());
+    if (ctx.hasUI) ctx.ui.notify(text);
+    else console.log(text);
+    return;
+  }
+  await ctx.ui.custom(async (tui, theme, _keybindings, done) => {
+    const comp = new FleetInspectorComponent(tui, theme, () => done(undefined), fleetRunsSnapshot, REFRESH_MS);
+    comp.start();
+    return comp;
+  }, {
+    overlay: true,
+    overlayOptions: {
+      width: "72%",
+      minWidth: 64,
+      maxHeight: 38,
+      anchor: "center",
+    },
+  });
+}

--- a/src/fleet-widget.ts
+++ b/src/fleet-widget.ts
@@ -35,7 +35,7 @@ function renderLines(runs: WidgetRun[]): string[] | undefined {
     const elapsed = Math.max(0, Math.round((now - r.startedAt) / 1000));
     return `  ● ${r.agent} (${elapsed}s) — ${truncateTask(r.task)}`;
   });
-  return [header, ...rows];
+  return [header, ...rows, "  /acp-fleet · Ctrl+Alt+F — inspect"];
 }
 
 function renderKeyFor(runs: WidgetRun[]): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages, extractText } from "./messages.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
+import { openFleetInspector } from "./fleet-inspector.js";
 import { wireToolGuardrails } from "./tool-guardrails.js";
 import { debug, logError, logInfo, logWarn, logThrow, closeLogStream } from "./log.js";
 import { collectCoveredMessageIds, estimateTokens, lastUserMessageId, collectImageTokens, modelSupportsImages } from "./tokens.js";
@@ -160,6 +161,14 @@ function wireSessionLifecycle(pi: ExtensionAPI, runtime: AcpRuntime): void {
       pi.registerTool(makeDelegateTool(pi));
       pi.registerTool(makeDelegateWaitTool(pi));
       pi.registerTool(makeDelegateCancelTool(pi));
+      // Not every host implements the full ExtensionAPI surface (older pi,
+      // embedded hosts) — shortcuts are a TUI nicety, never load-bearing.
+      if (typeof pi.registerShortcut === "function") {
+        pi.registerShortcut("ctrl+alt+f", {
+          description: "Inspect acp_delegate runs (live list + transcript)",
+          handler: (ctx) => { void openFleetInspector(ctx); },
+        });
+      }
     }
     // Headless hosts exit as soon as the turn ends; awaiting the check keeps
     // the process alive until a running install finishes. TUI stays

--- a/tests/fleet-inspector.test.ts
+++ b/tests/fleet-inspector.test.ts
@@ -1,0 +1,233 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { OUT_DIR, fleetRunsSnapshot, orderRunsForFleet, makeDelegateTool, makeDelegateCancelTool } from "../src/delegate-tool.js";
+import {
+  formatDuration, statusIcon, usageSummary, buildListRows, renderListView, renderTranscriptView, readTailSync, buildSnapshotText,
+  type InspectorTheme, type ListRow,
+} from "../src/fleet-inspector.js";
+
+const plainTheme: InspectorTheme = { fg: (_c, t) => t, bold: (t) => t };
+
+function mkView(over: Record<string, unknown> = {}): any {
+  return {
+    runId: "del_x", agent: "worker", task: "do the thing", cwd: "/tmp/proj",
+    startedAt: Date.now() - 30_000, status: "running", exitLabel: "exit ?",
+    replyFile: "/tmp/acp-delegate/del_x.out", ...over,
+  };
+}
+
+function assertWidthSafe(lines: string[], width: number): void {
+  for (const l of lines) assert.ok(visibleWidth(l) <= width, `line exceeds width ${width}: ${JSON.stringify(l)}`);
+}
+
+// ─── pure formatters ────────────────────────────────────────────────────────
+
+test("formatDuration buckets seconds/minutes/hours", () => {
+  assert.equal(formatDuration(0), "0s");
+  assert.equal(formatDuration(-5_000), "0s");
+  assert.equal(formatDuration(59_999), "59s");
+  assert.equal(formatDuration(61_500), "1m01s");
+  assert.equal(formatDuration(3_723_000), "1h02m");
+});
+
+test("statusIcon maps each run status", () => {
+  assert.equal(statusIcon("running"), "●");
+  assert.equal(statusIcon("completed"), "✓");
+  assert.equal(statusIcon("failed"), "✗");
+  assert.equal(statusIcon("cancelled"), "⊘");
+});
+
+test("usageSummary hides zero-usage and formats tokens", () => {
+  assert.equal(usageSummary(undefined), undefined);
+  assert.equal(usageSummary({ input: 0, output: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }), undefined);
+  const s = usageSummary({ input: 1234, output: 56, totalTokens: 1290, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } });
+  assert.ok(s!.includes("1,234") && s!.includes("56"), s);
+});
+
+// ─── readTailSync ───────────────────────────────────────────────────────────
+
+test("readTailSync returns whole small file, bounded tail with line boundary, '' when missing", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fleet-test-"));
+  try {
+    const small = join(dir, "small.txt");
+    await writeFile(small, "abc\ndef\n");
+    assert.equal(readTailSync(small, 4096), "abc\ndef\n");
+
+    const big = join(dir, "big.txt");
+    let content = "";
+    for (let i = 0; i < 200; i++) content += `line-${i}\n`;
+    await writeFile(big, content);
+    const tail = readTailSync(big, 20);
+    assert.ok(tail.length <= 20, `tail within bound: ${tail.length}`);
+    assert.ok(tail.startsWith("line-"), `partial leading line dropped: ${JSON.stringify(tail.slice(0, 8))}`);
+    assert.ok(tail.endsWith("\n"));
+
+    assert.equal(readTailSync(join(dir, "nope.txt"), 100), "");
+    assert.equal(readTailSync(undefined, 100), "");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ─── list building + rendering ──────────────────────────────────────────────
+
+test("buildListRows shows live duration for running, terminal label + tokens otherwise", () => {
+  const now = Date.now();
+  const rows = buildListRows([
+    mkView({ startedAt: now - 5_000 }),
+    mkView({ runId: "del_y", status: "failed", finishedAt: now - 1_000, exitLabel: "exit 1", usage: { input: 10, output: 2, totalTokens: 12, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, task: "x".repeat(80) }),
+  ], now);
+  assert.match(rows[0]!.label, /● worker · running 5s/);
+  assert.match(rows[1]!.label, /✗ worker · failed exit 1/);
+  assert.ok(!rows[1]!.detail.includes("x".repeat(49)), "long task truncated");
+  assert.ok(rows[1]!.detail.includes("↑10 ↓2"), "token summary appended");
+});
+
+test("renderListView is width-safe, marks selection, handles empty list", () => {
+  const rows: ListRow[] = buildListRows([mkView(), mkView({ runId: "del_y", agent: "oracle" })], Date.now());
+  const lines = renderListView(rows, 1, plainTheme, 30);
+  assertWidthSafe(lines, 30);
+  assert.ok(!lines[1]!.startsWith("> "), "first row not selected");
+  assert.ok(lines[2]!.startsWith("> "), "selected row has marker");
+  assert.ok(lines[lines.length - 1]!.includes("select"), "hint row survives truncation");
+  assert.ok(renderListView(rows, 1, plainTheme, 60).at(-1)!.includes("esc close"), "full hint at wide width");
+
+  const empty = renderListView([], 0, plainTheme, 30);
+  assertWidthSafe(empty, 30);
+  assert.ok(empty.some((l) => l.includes("no delegate runs yet")));
+});
+
+test("renderTranscriptView shows header, meta, tail and is width-safe", () => {
+  const run = mkView({ sessionFile: undefined, resumedFrom: "del_prev" });
+  const lines = renderTranscriptView(run, "step 1\nstep 2", Date.now(), plainTheme, 40);
+  assertWidthSafe(lines, 40);
+  assert.ok(lines[0]!.includes("del_x") && lines[0]!.includes("running"));
+  assert.ok(lines[1]!.includes("/tmp/proj") && lines[1]!.includes("resumed from del_prev"));
+  assert.ok(lines.includes("step 1") && lines.includes("step 2"));
+
+  const idle = renderTranscriptView(mkView(), "", Date.now(), plainTheme, 40);
+  assert.ok(idle.includes("(no output yet)"));
+});
+
+test("buildSnapshotText lists runs, tails running activity, points at files dir", () => {
+  assert.equal(buildSnapshotText([], Date.now()), "acp_delegate: no runs recorded this session.");
+  const dir = tmpdir();
+  const actFile = join(dir, "acp-delegate", "del_snap.activity");
+  const text = buildSnapshotText([mkView({ activityFile: actFile })], Date.now());
+  assert.ok(text.includes("1 run(s)"));
+  assert.ok(text.includes("● worker · running"));
+  assert.ok(text.includes(actFile ? OUT_DIR : ""));
+});
+
+// ─── ordering ───────────────────────────────────────────────────────────────
+
+test("orderRunsForFleet: running first by spawn time, then finished newest-first capped", () => {
+  const t = Date.now();
+  const all = [
+    mkView({ runId: "f_mid", status: "failed", startedAt: t - 5000, finishedAt: t - 500 }),
+    mkView({ runId: "r_new", startedAt: t - 1000 }),
+    mkView({ runId: "r_old", startedAt: t - 4000 }),
+    mkView({ runId: "f_new", status: "completed", startedAt: t - 3000, finishedAt: t - 100 }),
+    ...Array.from({ length: 14 }, (_, i) =>
+      mkView({ runId: `f_cap_${i}`, status: "completed", startedAt: t - i, finishedAt: t - 1000 - i * 100 })),
+  ];
+  const ordered = orderRunsForFleet(all as any[]).map((r) => r.runId);
+  assert.deepEqual(ordered.slice(0, 2), ["r_old", "r_new"], "running first, oldest spawn on top");
+  assert.deepEqual(ordered.slice(2, 4), ["f_new", "f_mid"], "finished newest-first by finishedAt");
+  assert.ok(!ordered.includes("f_cap_13"), "oldest finished dropped by the cap");
+  assert.equal(ordered.length, 2 + 12, "finished list capped at 12");
+});
+
+// ─── e2e: real spawns through PI_CLI_PATH fake scripts ─────────────────────
+
+function mockCtx(cwd: string): ExtensionContext {
+  return {
+    model: { provider: "test", id: "test-model" },
+    sessionManager: { buildContextEntries: () => [] },
+    mode: "tui",
+    cwd,
+  } as unknown as ExtensionContext;
+}
+
+async function waitFor(pred: () => boolean, deadlineMs: number, what: string): Promise<void> {
+  const end = Date.now() + deadlineMs;
+  while (!pred()) {
+    if (Date.now() > end) throw new Error(`timeout waiting: ${what}`);
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+test("fleetRunsSnapshot maps real spawns: failed run fields, running-first order, cancel", async () => {
+  const prevCli = process.env.PI_CLI_PATH;
+  const workDir = await mkdtemp(join(tmpdir(), "fleet-e2e-"));
+  const scriptsDir = await mkdtemp(join(tmpdir(), "fleet-scripts-"));
+  // Delegate children run `node <PI_CLI_PATH>` — fakes must be JS modules.
+  const failScript = join(scriptsDir, "fail.js");
+  const sleepScript = join(scriptsDir, "sleep.js");
+  await writeFile(failScript, "process.exit(1);\n");
+  await writeFile(sleepScript, "setInterval(() => {}, 1000);\n");
+  const sent: string[] = [];
+  const pi = { sendUserMessage: (t: string) => sent.push(t) } as unknown as Parameters<typeof makeDelegateTool>[0];
+  const tool = makeDelegateTool(pi);
+  const cancelTool = makeDelegateCancelTool(pi);
+  const cleanupIds: string[] = [];
+  try {
+    // 1) failing child → failed run with mapped fields
+    process.env.PI_CLI_PATH = failScript;
+    const res = await tool.execute("tc-fleet-fail", { agent: "oracle", task: "will fail", cwd: workDir, async: true }, undefined, undefined, mockCtx(workDir));
+    const launch = (res.content[0] as { text?: string }).text ?? "";
+    const failId = /`(del_[a-z0-9_]+)`/.exec(launch)?.[1];
+    assert.ok(failId, `runId in launch message: ${launch}`);
+    cleanupIds.push(failId!);
+    await waitFor(() => sent.length > 0, 15_000, "failure notification");
+    assert.match(sent[0]!, /FAILED|exit 1/);
+
+    let snap = fleetRunsSnapshot().find((r) => r.runId === failId);
+    assert.ok(snap, "failed run present in snapshot");
+    assert.equal(snap!.status, "failed");
+    assert.equal(snap!.exitLabel, "exit 1");
+    assert.equal(snap!.agent, "oracle");
+    assert.equal(snap!.task, "will fail");
+    assert.ok(existsSync(snap!.replyFile), `reply file retained: ${snap!.replyFile}`);
+    assert.ok(snap!.activityFile && snap!.activityFile.endsWith(".activity"), "async pi host has activity file");
+    assert.equal(snap!.sessionFile, join(OUT_DIR, `${failId}.session.jsonl`));
+
+    // 2) sleeping child → running, ordered first
+    process.env.PI_CLI_PATH = sleepScript;
+    const res2 = await tool.execute("tc-fleet-sleep", { agent: "worker", task: "long task", cwd: workDir, async: true }, undefined, undefined, mockCtx(workDir));
+    const sleepId = /`(del_[a-z0-9_]+)`/.exec((res2.content[0] as { text?: string }).text ?? "")?.[1];
+    assert.ok(sleepId, "second runId extracted");
+    cleanupIds.push(sleepId!);
+    await waitFor(() => fleetRunsSnapshot().some((r) => r.runId === sleepId && r.status === "running"), 15_000, "running status");
+
+    const ordered = fleetRunsSnapshot();
+    assert.equal(ordered[0]?.runId, sleepId, "running run listed first");
+    assert.equal(ordered[0]?.status, "running");
+
+    // 3) cancel flips status synchronously; finalize (child close) records the result
+    await cancelTool.execute("tc-fleet-cancel", { runId: sleepId! });
+    assert.equal(fleetRunsSnapshot().find((r) => r.runId === sleepId)?.status, "cancelled");
+    // finishedAt is the finalize marker: sync cancel only flips status; the
+    // child-close handler records finishedAt + result (FleetRunView hides it).
+    await waitFor(() => fleetRunsSnapshot().find((r) => r.runId === sleepId)?.finishedAt !== undefined, 15_000, "cancelled finalize");
+    const after = fleetRunsSnapshot().find((r) => r.runId === sleepId);
+    assert.equal(after?.replyFile, join(OUT_DIR, `${sleepId}.out`));
+    assert.ok(existsSync(after!.replyFile), "cancelled run keeps its files");
+  } finally {
+    if (prevCli === undefined) delete process.env.PI_CLI_PATH;
+    else process.env.PI_CLI_PATH = prevCli;
+    for (const id of cleanupIds) {
+      for (const ext of [".out", ".activity", ".session.jsonl"]) {
+        await rm(join(OUT_DIR, id + ext), { force: true });
+      }
+    }
+    await rm(workDir, { recursive: true, force: true });
+    await rm(scriptsDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -59,12 +59,12 @@ function userMsg(id: string, text: string) {
   return { type: "message", id, parentId: null, timestamp: "", message: { role: "user", content: text, timestamp: Date.now() } };
 }
 
-test("factory registers the compress tool and 5 flat commands", () => {
+ test("factory registers the compress tool and 6 flat commands", () => {
   const { api, handlers } = captureApi();
   createAcpExtension()(api as any);
 
   assert.ok(api.tools.some((t) => t.name === "compress"), "compress tool registered");
-  assert.deepEqual([...api.commands.keys()].sort(), ["acp", "acp-decompress", "acp-search", "acp-status", "acp-subagents"]);
+  assert.deepEqual([...api.commands.keys()].sort(), ["acp", "acp-decompress", "acp-fleet", "acp-search", "acp-status", "acp-subagents"]);
   assert.ok(handlers.has("context"), "context event wired");
   assert.ok(handlers.has("session_before_compact"), "compaction-disable wired");
   assert.ok(handlers.has("before_agent_start"), "system-prompt wired");


### PR DESCRIPTION
Closes #292

## 背景
#292 问"acp 分配 subAgent 时怎么进入对应的 subAgent 中查看"。此前只能 `tail -f /tmp/acp-delegate/<runId>.activity` 偷看，或结束后 `pi --session` 回放。本 PR 实现第一层：TUI 内实时只读 inspector（owner 已拍板只做读-only 层）。

## 功能
- **`/acp-fleet` 命令 + `Ctrl+Alt+F` 快捷键**：打开 overlay 面板
  - 列表视图：running 在前、最近完成在后（上限 12），每行 agent / runId / 状态图标 / 耗时 / task / tokens
  - Enter 或 x 进入 transcript 视图：实时滚动 .activity 流（工具调用 + 输出 tail），↑↓/PgUp/PgDn 滚动，底部自动跟随
  - Esc/q 返回/关闭；500ms tick 自动刷新
- **非 TUI host**（print/json/RPC）：同一命令输出文本快照（运行中 run 的 activity tail + 文件路径指引）
- fleet-widget 状态条新增提示行 `/acp-fleet · Ctrl+Alt+F — inspect`

## 实现要点
- 数据源完全复用 delegate-tool 已有的 `.activity`/`.out` 文件流，零新协议
- `fleetRunsSnapshot(): FleetRunView[]` 暴露 run 状态，不泄露 child/waiter 等内部字段
- pi-tui 的 Key/matchesKey/truncateToWidth 以 devDep 精确 pin 0.83.0 并由 tsup 内联 → dist 保持零运行时依赖（已验证 dist 仅 import node builtins）
- OMP host 的 ExtensionAPI 无 registerShortcut → typeof guard 保护

## 测试
- 新增 tests/fleet-inspector.test.ts（10 个：纯函数 + 真实 spawn e2e，覆盖 failed/running/cancelled 生命周期与文件落盘）
- 全量 475 tests：472 pass / 0 fail / 3 skipped（既有 skip）；typecheck、build 均绿