### PR TITLE
fix(fleet): handle 'queued' status in statusIcon

### DIFF
--- a/src/fleet-inspector.ts
+++ b/src/fleet-inspector.ts
@@ -37,6 +37,7 @@ export function formatDuration(ms: number): string {
 
 export function statusIcon(status: FleetRunView["status"]): string {
   switch (status) {
+    case "queued": return "○";
     case "running": return "●";
     case "completed": return "✓";
     case "failed": return "✗";

--- a/tests/fleet-inspector.test.ts
+++ b/tests/fleet-inspector.test.ts
@@ -37,6 +37,7 @@ test("formatDuration buckets seconds/minutes/hours", () => {
 });
 
 test("statusIcon maps each run status", () => {
+  assert.equal(statusIcon("queued"), "○");
   assert.equal(statusIcon("running"), "●");
   assert.equal(statusIcon("completed"), "✓");
   assert.equal(statusIcon("failed"), "✗");


### PR DESCRIPTION
## 背景：master 的 tsc 是红的（跨 PR 回归）

#298 给 `RunStatus` 加了 `"queued"`，但 #295 的 `fleet-inspector.ts:statusIcon()` switch 只写了 running/completed/failed/cancelled 四个 case。类型里有 5 个状态后，switch 不再穷尽 → `tsc --noEmit` 报 TS2366「Function lacks ending return statement」。

两个 PR 各自分支 CI 都绿，**合并到 master 才炸**。已在干净的 `c80d8a2` checkout 上复现（修复前 tsc exit 1）。

## 修复

- `src/fleet-inspector.ts`：给 `statusIcon` 补 `case "queued": return "○";`（空心圆，与 running 的实心 ● 配对）
- `tests/fleet-inspector.test.ts`：在 `statusIcon maps each run status` 里补 `queued` 断言（该测试自称覆盖每个状态，之前漏了第 5 个）

顺带修掉一个运行时问题：queued run 在 `/acp-fleet` inspector 里渲染时原本没有图标。

## 验证（干净 checkout + 按 master lockfile 的依赖）

- `npx tsc --noEmit` → **exit 0**（修复前 exit 1）
- `npm test` → 507 / 504 pass / 0 fail / 3 skip
- `npm run build` → dist/index.js 665KB

## 建议合并顺序

本 PR 只改 2 行、无功能风险，建议**优先合掉**让 master 恢复绿；之后 rebase #288 / #266 时 CI 就不会再被这个既有错误拖红。

> 注：#288 里也带了一个同样的 fleet 修复（独立 commit `4c2b8ef`）。本 PR 合入后，那个 commit 可 drop 掉避免重复。
