### PR TITLE
release v0.1.57

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.56",
+	"version": "0.1.57",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.56",
+			"version": "0.1.57",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.56",
+	"version": "0.1.57",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## Release v0.1.57

Bumps `billion-context-pi` **0.1.56 → 0.1.57**. `acp-kernel` unchanged (still pinned to `0.0.50`).

Ships everything merged to master since v0.1.56 (2026-09-03) — **13 PRs** across the `acp_delegate` subsystem, the new `/acp-fleet` inspector, token accounting, auto-update, tests, and docs.

### acp_delegate
- **#287** — Make `acp_delegate` timeouts and nesting depth configurable via `delegate.{syncTimeoutMinutes,idleTimeoutMinutes,asyncTimeoutMinutes,maxDepth}` (precedence env > acp.json > default). Closes #279.
- **#298** — Add `delegate.maxConcurrent` serial/concurrency cap; excess async runs report `QUEUED`. Closes #294.
- **#288** — Per-role default model + thinking level (`delegate.agents.<role>.{model,thinkingLevel}`). Closes #117.
- **#266** — Skip the completion notification when the model already read the result file (`notifyIfRead`, default `skip`); FAILED runs are never suppressed. Closes #239.
- **#276** — Gate the ACP_DELEGATE system-prompt block on `resolveDelegate().enabled` so it is hidden when delegates are disabled. Closes #275.

### /acp-fleet inspector (new)
- **#295** — Live fleet inspector: `/acp-fleet` shows running/completed `acp_delegate` runs in real time. Closes #292.
- **#303** — Fix `statusIcon` to handle the new `queued` status (cross-PR regression from #295 × #298).
- **#304** — Full rewrite: bordered full-width panel + complete sub-session transcript (conversation + thinking + tool calls/results), styled to match pi's native rendering (background cards, italic thinking, grouped tool blocks, markdown with native theme colors).

### Token accounting
- **#293** — Measure `tokenCount` on the actual sent view; extend sent-view recount to `acp_status` and `/acp`. Fixes #289 (token desync).

### Auto-update
- **#206** — Follow the installed dist-tag channel instead of hardcoding `latest`; track latest for exact prerelease pins.

### Tests
- **#285** — Regression test proving the outbound view stays byte-identical across a process restart. Refs #283.

### Docs
- **#291** — Unified "Which do I need? / 该选哪个?" client-selection table. Closes #290.
- **#300** — Document session migration (copy `.jsonl` + `.acp.json` sidecar).

---
**Validation:** tsc clean · 550 tests / 547 pass / 0 fail / 3 skip · build 718.60 KB.
**Changed files:** `package.json` + `package-lock.json` (version bump only).
