### PR TITLE
fix(state): keep in-memory subagent compress state across turns (issue #322)

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -86,10 +86,14 @@ export class SessionStateStore {
 
   async save(state: CompressionState, sessionFile: string | undefined, sessionId: string): Promise<void> {
     const file = stateFileFor(sessionFile);
-    if (!file) return;
     const key = cacheKey(sessionFile, sessionId);
     const liveRefOrigins = this.cache.get(key)?.liveRefOrigins ?? [];
+    // Cache update is unconditional: file-less (in-memory) sessions have no
+    // sidecar to persist, but their state must still survive across turns in
+    // this process — otherwise every compress result is dropped and the model
+    // re-compresses the same original context forever (issue #322).
     this.cache.set(key, { state, liveRefOrigins });
+    if (!file) return;
     const dir = path.dirname(file);
     await fs.mkdir(dir, { recursive: true }).catch((e: unknown) => {
       logError("state", { event: "save-mkdir-failed", dir, error: e instanceof Error ? e.message : String(e) });

--- a/tests/compress-tool.test.ts
+++ b/tests/compress-tool.test.ts
@@ -156,3 +156,49 @@ test("compress normalizes double-escaped \\uXXXX summaries before storage", asyn
   assert.ok(block.summary.includes("合".repeat(25)), "stored summary must contain decoded CJK");
   assert.ok(!block.summary.includes("\\u5408"), "stored summary must not contain literal \\uXXXX runs");
 });
+
+// issue #322: in-memory subagent sessions (pi-subagents rememberAgents:false →
+// SessionManager.inMemory()) have getSessionFile() === undefined. A successful
+// compress must stay visible to the NEXT context round; before the fix save()
+// returned before updating the in-process cache, so every turn reloaded the
+// pristine initial state and the model re-compressed the same original context.
+test("compress in an in-memory session (no session file) survives to the next context round", async () => {
+  const { api, handlers } = captureApi();
+  // minCompressRange gate needs ≥5000 chars per range; each entry carries 6000
+  // CJK chars, and preserveRecentMessages:1 keeps both targets outside the
+  // protected trailing zones (same pattern as the #309 test).
+  createAcpExtension({ modelContextLimit: 200_000, preserveRecentMessages: 1 })(api as any);
+  const BIG = "中".repeat(6000);
+  const entries = [userMsg("e1", BIG), userMsg("e2", BIG), userMsg("e3", BIG), userMsg("e4", BIG)];
+  const ctx = fakeCtx(entries, undefined);
+  ctx.__setUsage(100_000);
+  await runContextRound(handlers, ctx); // prime refs
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const statusTool = api.tools.find((t: any) => t.name === "acp_status")!;
+  async function doCompress(callId: string, range: { startId: string; endId: string; summary: string }) {
+    const out = await compressTool.execute(callId, { content: [range] }, undefined, undefined, ctx);
+    return typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  }
+  async function statusText() {
+    const out = await statusTool.execute("st1", { scope: "compressed" }, undefined, undefined, ctx);
+    return typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  }
+
+  const first = await doCompress("tc1", { startId: "m00001", endId: "m00001", summary: "first block: initial context round compressed for the in-memory session test" });
+  assert.ok(first.includes("▣ ACP"), `first compress failed: ${first}`);
+  assert.ok(!first.includes("Errors:"), `first compress rejected: ${first}`);
+
+  await runContextRound(handlers, ctx); // next turn — the bug lost state here
+
+  let report = await statusText();
+  assert.match(report, /b1 \(T1\)/, `next round must still show block b1: ${report}`);
+
+  const second = await doCompress("tc2", { startId: "m00002", endId: "m00002", summary: "second block: follow-up context round compressed for the in-memory session test" });
+  assert.ok(second.includes("▣ ACP"), `second compress failed: ${second}`);
+  assert.ok(!second.includes("Errors:"), `second compress rejected: ${second}`);
+
+  report = await statusText();
+  assert.match(report, /b1 \(T1\)/, `b1 must survive after the second compress: ${report}`);
+  assert.match(report, /b2 \(T1\)/, `second block must be numbered b2 (nextBlockId retained), not reset to b1: ${report}`);
+});

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -249,6 +249,51 @@ test("no parentSession in header → fresh state even with empty blocks", async 
   await rm(dir, { recursive: true, force: true });
 });
 
+// issue #322: file-less (in-memory) sessions — pi-subagents SessionManager.inMemory()
+// with rememberAgents:false → getSessionFile() === undefined. save() used to return
+// before updating the in-process cache, so every successful compress was dropped and
+// the next turn reloaded the pristine initial state (blocks=0, nextBlockId=1).
+test("in-memory session: save then load round-trips state without a session file", async () => {
+  const store = new SessionStateStore();
+  const initial = await store.load(undefined, "in-memory-sid");
+  assert.equal(initial.blocks.length, 0);
+  assert.equal(initial.nextBlockId, 1);
+
+  const compressed = { ...initial };
+  compressed.blocks.push(makeBlock("b1"));
+  compressed.nextBlockId = 2;
+
+  await store.save(compressed, undefined, "in-memory-sid");
+  const reloaded = await store.load(undefined, "in-memory-sid");
+
+  assert.equal(reloaded.blocks.length, 1);
+  assert.equal(reloaded.blocks[0]!.blockId, "b1");
+  assert.equal(reloaded.nextBlockId, 2, "nextBlockId must not reset across reloads");
+});
+
+test("in-memory sessions: distinct sessionIds stay isolated", async () => {
+  const store = new SessionStateStore();
+  const stateA = await store.load(undefined, "sid-A");
+  const stateB = await store.load(undefined, "sid-B");
+
+  const updatedA = { ...stateA };
+  updatedA.blocks.push(makeBlock("bA"));
+  updatedA.nextBlockId = 2;
+  const updatedB = { ...stateB };
+  updatedB.blocks.push(makeBlock("bB"));
+  updatedB.nextBlockId = 3;
+
+  await store.save(updatedA, undefined, "sid-A");
+  await store.save(updatedB, undefined, "sid-B");
+
+  const reA = await store.load(undefined, "sid-A");
+  const reB = await store.load(undefined, "sid-B");
+  assert.deepEqual(reA.blocks.map((b) => b.blockId), ["bA"]);
+  assert.deepEqual(reB.blocks.map((b) => b.blockId), ["bB"]);
+  assert.equal(reA.nextBlockId, 2);
+  assert.equal(reB.nextBlockId, 3);
+});
+
 test("live ref origins remain isolated across interleaved sessions", async () => {
   const dir = await tempDir();
   const fileA = path.join(dir, "a.session.json");


### PR DESCRIPTION
Fixes #322

## Problem
In file-less in-memory subagent sessions (pi-subagents `rememberAgents:false` → `SessionManager.inMemory()`, so `getSessionFile() === undefined`), a successful `compress` was silently lost: the next context round reloaded pristine state (`blocks=0`, `nextBlockId=1`) and the model re-compressed the same original context over and over (field report: 152 duplicate compressions, ~$156).

## Root cause
`SessionStateStore.save()` (src/state.ts) hit `if (!file) return;` **before** updating the in-process cache — even though `cacheKey()` already supports file-less keys (`session:<sessionId>`) and `load()` seeds that key with the initial state. Every save in an in-memory session was dropped; every load returned the stale initial entry.

## Fix
Move the cache update ahead of the disk gate in `save()`: cache is updated unconditionally, sidecar persistence still only when a session file exists. One-line reorder in src/state.ts, no API change.

## Tests
- `tests/state.test.ts`: store-level round-trip for a file-less session (save→load keeps blocks + nextBlockId) and isolation between distinct in-memory sessionIds.
- `tests/compress-tool.test.ts`: cross-turn regression — compress m00001 in a file-less session, advance one context round, `acp_status scope:"compressed"` must show `b1 (T1)`; a second compress must be numbered `b2` (guards nextBlockId reset). Verified to FAIL against pre-fix code (negative run done locally).

## Verification
- `npm run typecheck` ✅
- `npm test`: 612 passed, 0 failed, 3 skipped ✅
- `npm run build` ✅ (dist/index.js 719.79 KB, acp-kernel bundled inline)

Boundary noted in the issue thread: `invalidate()` at `session_start` still resets in-memory state across process restarts — out of scope for this fix.