### PR TITLE
fix: name the tier-ready alternative in the tier3-rewrite rejection

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -273,6 +273,26 @@ function tier3OnlyRewrite(newBlocks: CompressionBlock[], allBlocks: CompressionB
   return spans;
 }
 
+// #344: the rewrite guard stops the loop but its recovery hint only covers
+// message-type ranges. When the session's actionable mass is tier blocks, name
+// them so repetition-prone models get a concrete next action instead of
+// hunting (and re-hitting the guard).
+function tierReadyHint(state: CompressionState, config: ReturnType<AcpRuntime["configFor"]>): string {
+  if (!config.tiers.enabled) return "";
+  const active = state.blocks.filter((b) => b.active);
+  const first = (bs: CompressionBlock[]) => bs[0]?.blockId ?? "";
+  const last = (bs: CompressionBlock[]) => bs[bs.length - 1]?.blockId ?? "";
+  const t2 = active.filter((b) => b.tier === 2);
+  if (t2.length >= config.tiers.tier3Trigger) {
+    return `Actionable now: condense tier-2 blocks ${first(t2)}..${last(t2)} into a single tier-3 block (compress({ content: [{ startId: "${first(t2)}", endId: "${last(t2)}", summary: "..." }] })).`;
+  }
+  const t1 = active.filter((b) => b.tier === 1);
+  if (t1.length >= config.tiers.tier2Trigger) {
+    return `Actionable now: distill tier-1 blocks ${first(t1)}..${last(t1)} into a single tier-2 block (compress({ content: [{ startId: "${first(t1)}", endId: "${last(t1)}", summary: "..." }] })).`;
+  }
+  return "";
+}
+
 async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: ExtensionContext, toolCallId?: string): Promise<string> {
   const maybeRanges = normalizeRanges(args);
   // Argument errors throw (not return): pi-agent-core only sets isError:true
@@ -362,8 +382,10 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
       event: "tier3-rewrite-rejected",
       spans: rewriteSpans,
     });
+    const hint = tierReadyHint(state, config);
     throw new Error(
       `Range ${rewriteSpans.join(", ")} only re-condenses terminal tier-3 block(s) — T3 is the highest tier, so rewriting it reclaims nothing and can repeat forever (dog/billion-context-pi#3). Nothing was compressed. ` +
+        (hint ? `${hint} ` : "") +
         `Use search_context or decompress to retrieve details, or pick a range containing uncompressed messages (acp_status lists compressible ranges).`,
     );
   }

--- a/tests/t3-rewrite-guard.test.ts
+++ b/tests/t3-rewrite-guard.test.ts
@@ -57,10 +57,10 @@ function fakeCtx(entries: Array<ReturnType<typeof userMsg>>, stateFile: string) 
   };
 }
 
-async function setup(stateFile: string) {
+async function setup(stateFile: string, adapter: Record<string, unknown> = {}) {
   await rm(stateFile + ".acp.json", { force: true });
   const { api, handlers } = captureApi();
-  createAcpExtension({ modelContextLimit: 200_000 })(api as never);
+  createAcpExtension({ modelContextLimit: 200_000, ...adapter } as never)(api as never);
   const entries = Array.from({ length: 12 }, (_, i) => userMsg(i));
   const ctx = fakeCtx(entries, stateFile);
   await handlers.get("context")![0]!({ type: "context", messages: [] }, ctx);
@@ -103,6 +103,27 @@ test("tier-3-only rewrite is rejected and state is rolled back (dog/billion-cont
   assert.equal(after.blocks.length, atT3.blocks.length);
   assert.equal(after.blocks.filter((b: { active: boolean }) => b.active).length, 1);
   assert.equal(after.blocks.find((b: { active: boolean }) => b.active).tier, 3);
+});
+
+test("tier-3 rewrite rejection names the tier-ready alternative (#344)", async () => {
+  const stateFile = "/tmp/pai-acp-t3-hint.session.json";
+  const { run } = await setup(stateFile, { preserveRecentMessages: 0 });
+  const sum = (t: string) => t + " " + ZH.repeat(80);
+
+  for (let i = 0; i < 6; i++) {
+    await run([{ startId: `m0000${1 + i * 2}`, endId: `m0000${2 + i * 2}`, summary: sum(`s${i}`) }]);
+  }
+  await run([{ startId: "b1", endId: "b1", summary: sum("t2") }]);
+  await run([{ startId: "b7", endId: "b7", summary: sum("t3") }]);
+  const st = await stateOf(stateFile);
+  assert.equal(st.blocks.filter((b: { active: boolean; tier: number }) => b.active && b.tier === 1).length, 5);
+
+  await assert.rejects(
+    () => run([{ startId: "b8", endId: "b8", summary: sum("rw") }]),
+    (err: Error) =>
+      /only re-condenses terminal tier-3 block/.test(err.message) &&
+      /Actionable now: distill tier-1 blocks b2\.\.b6 into a single tier-2 block/.test(err.message),
+  );
 });
 
 test("lower-tier distillation still allowed: T2 block condenses to T3", async () => {


### PR DESCRIPTION
Fixes #344

- `tierReadyHint(state, config)`: T3-condensation span when active tier-2 blocks ≥ `tiers.tier3Trigger`; else T2-distillation span when active tier-1 blocks ≥ `tiers.tier2Trigger`; else empty.
- The hint names concrete block ids and an example compress call: `Actionable now: distill tier-1 blocks b55..b69 into a single tier-2 block (compress({ content: [{ startId: "b55", endId: "b69", summary: "..." }] })).`
- Computed from the pre-compression state (the state the rejection rolls back to).

Production repro (session 01a07b3c, 2026-09-09 14:39–14:42): two rejections for the consumed span `b7..b42` while 8 tier-1 blocks (b55..b69) sat ready — the model flailed into a below-min range next.

Tests: new `tier-3 rewrite rejection names the tier-ready alternative (#344)` (setup gains an optional adapter-override param, used with `preserveRecentMessages: 0` to free m00009..m00012); full suite 636 pass + 3 skip; typecheck clean.