### PR TITLE
release v0.1.61

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.60",
+	"version": "0.1.61",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.60",
+			"version": "0.1.61",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.60",
+	"version": "0.1.61",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 发版内容(自 v0.1.60)

- #341 `fix: sync kernel-compacted compress anchor text into outbound arguments`(fixes #340,内核 #232 配套:风暴会话出口锚点 args 290,196 → 22,327 chars,−92.3%;acp-kernel pin 0.0.56 → 0.0.60)
- #345 `fix: name the tier-ready alternative in the tier3-rewrite rejection`(fixes #344:拒绝文本附带可行动的 tier 蒸馏目标,防重复尝试)

## 校验

- typecheck ✅ / tests 636 pass +3 skip ✅ / build ✅
- acp-kernel 0.0.60 已在 npm(发布顺序满足)

合并后 CI 自动发布。