### PR TITLE
release v0.1.62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.61",
+	"version": "0.1.62",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.61",
+			"version": "0.1.62",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.61",
+	"version": "0.1.62",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 发版内容(自 v0.1.61)

- #339 `feat: compress.reasoning — drop oversized thinking from closed-turn compress calls`(fixes #336:锚点消息上的 thinking 块构成永久不可压缩地板,风暴会话实测 ~50%/75.8K tokens;对齐 opencode-acp #377 适配层方案)

## 校验

- typecheck/tests/build ✅ / kernel pin 0.0.61(已发布,无变化)

合并后 CI 自动发布。