### PR TITLE
release v0.1.63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.62",
+	"version": "0.1.63",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.62",
+			"version": "0.1.63",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.62",
+	"version": "0.1.63",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { makeStatusTool } from "./status-tool.js";
 import { makeDelegateTool, makeDelegateWaitTool, makeDelegateCancelTool, runningRunsSnapshot, resetDelegateUsage, setDelegateDisplayUsage, setDelegatePolicy, setDelegateDefaults, setDelegateNotifyIfRead, markDelegateResultRead, markDelegateRunReadByCommand } from "./delegate-tool.js";
 import { makeCommands } from "./commands.js";
 import { coreOutToAgentMessages, extractText } from "./messages.js";
-import { dropCompressReasoning } from "./reasoning-drop.js";
+import { countThinkingChars, dropCompressReasoning } from "./reasoning-drop.js";
 import { buildAcpSystemPrompt, ACP_DELEGATE_PROMPT } from "./system-prompt.js";
 import { delegateStatusWidget } from "./fleet-widget.js";
 import { openFleetInspector } from "./fleet-inspector.js";
@@ -412,7 +412,8 @@ function wireContextTransform(pi: ExtensionAPI, runtime: AcpRuntime, standDownIf
     const reasoningDrop = runtime.reasoningDropFor(ctx);
     const droppedThinking = dropCompressReasoning(rebuilt, reasoningDrop);
     if (droppedThinking !== rebuilt) {
-      debug.event("reasoning-drop", { sid, dropped: droppedThinking.length, drop: reasoningDrop.drop, threshold: reasoningDrop.threshold });
+      const droppedChars = countThinkingChars(rebuilt) - countThinkingChars(droppedThinking);
+      debug.event("reasoning-drop", { sid, droppedChars, drop: reasoningDrop.drop, threshold: reasoningDrop.threshold });
     }
     rebuilt = droppedThinking;
     const debugOn = debug.enabled;

--- a/src/reasoning-drop.ts
+++ b/src/reasoning-drop.ts
@@ -84,6 +84,10 @@ function reasoningLength(content: unknown): number {
   return content.reduce((n, p) => (isThinking(p) ? n + p.thinking.length : n), 0);
 }
 
+export function countThinkingChars(messages: AgentMessage[]): number {
+  return messages.reduce((n, m) => n + reasoningLength((m as { content?: unknown }).content), 0);
+}
+
 /** Request-time pass aligned with opencode-acp #377: remove `thinking` parts
  *  from a message only when ALL gates hold —
  *  1. closed round [#348]: EVERY `compress` toolCall in the message has its


### PR DESCRIPTION
Release v0.1.63 — publishes the round-evidence reasoning-drop closure (#348, PR #349, merged after v0.1.62 was cut) plus the stranded follow-up commit `9e20f0e` (debug event logs actual dropped thinking chars, not kept-message count). Cherry-picked onto the release branch so one merge ships everything. No acp-kernel bump (stays 0.0.60). Merging publishes 0.1.63 via CI; protects local autoUpdate from clobbering the manual fix dist with fix-less 0.1.62.