### PR TITLE
release v0.1.64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.63",
+	"version": "0.1.64",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.63",
+			"version": "0.1.64",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.63",
+	"version": "0.1.64",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.64 — ships the degeneration guard (#351, PR #352): request-time collapse of degenerate single-codepoint runs in assistant text/thinking + one-shot recovery notice + regex pre-screen perf pass; plus the repetitionGuard KNOWN-whitelist fix (#354). No acp-kernel bump (stays 0.0.60).