### PR TITLE
fix: count thinking tokens in ACP metering (Fixes #353)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.60",
+				"acp-kernel": "0.0.62",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3200,9 +3200,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.60",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.60.tgz",
-			"integrity": "sha512-AdvQ5hVsupmspjFJrmtD3sWBShKmd2I/ZzglO+0Z2djJI5f1T/4Cp7WDhhl3E7qqft7rExBr4qTxWiOSCj1BFw==",
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.62.tgz",
+			"integrity": "sha512-NSoeUiGu77gFzayeYwLjytyPetEmZVvuFvlhGSfl3RtAgyvXxV2z8Iu1NCvLzzU23Ncx3eAa2EmwyEozJ2DlGw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.60",
+		"acp-kernel": "0.0.62",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -159,7 +159,8 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
   const systemPromptTokens = systemPromptText ? defaultCountTokens(systemPromptText) : 0;
   const imageTokens = collectImageTokens(entries, modelSupportsImages(ctx.model));
   const imageTokensTotal = [...imageTokens.values()].reduce((a, b) => a + b, 0);
-  const sessionTokens = !anchorStale && realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n")) + imageTokensTotal;
+  const thinkingTokensTotal = coreMessages.reduce((sum, m) => sum + (m.thinkingTokens ?? 0), 0);
+  const sessionTokens = !anchorStale && realUsage?.tokens && realUsage.tokens > 0 ? realUsage.tokens : defaultCountTokens(coreMessages.map((m) => m.text ?? "").join("\n")) + imageTokensTotal + thinkingTokensTotal;
   const coveredIds = collectCoveredMessageIds(state);
   const sentTokens = estimateTokens(coreMessages, coveredIds, imageTokens) + systemPromptTokens;
   // View-based recount (issue #289): with active blocks the raw-view estimate
@@ -183,7 +184,7 @@ async function statusReport(runtime: AcpRuntime, ctx: ExtensionCommandContext): 
     state: turn.state,
     nudge: turn.nudge,
     modelContextLimit: config.modelContextLimit,
-    unprunedTokens: coreMessages.reduce((sum, m) => sum + defaultCountTokens(m.text ?? "") + (imageTokens.get(m.id) ?? 0), 0),
+    unprunedTokens: coreMessages.reduce((sum, m) => sum + defaultCountTokens(m.text ?? "") + (m.thinkingTokens ?? 0) + (imageTokens.get(m.id) ?? 0), 0),
     cacheUsages: cacheUsageSamples(entries ?? []),
   });
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,5 +1,5 @@
 import type { SessionEntry, SessionMessageEntry } from "@earendil-works/pi-coding-agent";
-import type { CoreMessage } from "acp-kernel";
+import { defaultCountTokens, type CoreMessage } from "acp-kernel";
 import { rewriteTagTokens } from "./tag-tokens.js";
 
 type AgentMessage = SessionMessageEntry["message"];
@@ -59,6 +59,11 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
     }];
   }
   if (role === "assistant") {
+    // Thinking rides in every request but never into the text projection — meter
+    // it via CoreMessage.thinkingTokens (issue #353). Kernel contract: attach to
+    // exactly one core per turn — the first emitted one.
+    const thinking = thinkingTokenCount(msg.content);
+    const thinkingField = thinking > 0 ? { thinkingTokens: thinking } : {};
     const calls = allToolCalls(msg.content);
     if (calls.length > 0) {
       const textParts = extractText(msg.content);
@@ -66,9 +71,9 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
         const call = calls[0]!;
         const argStr = stringifyArgs(call.arguments);
         const text = argStr && textParts ? `${textParts}\n${argStr}` : argStr || textParts;
-        return [{ id, role: "assistant", contentType: "tool-call", toolName: call.name, toolCallId: call.id, text }];
+        return [{ id, role: "assistant", contentType: "tool-call", toolName: call.name, toolCallId: call.id, text, ...thinkingField }];
       }
-      return calls.map((call) => {
+      return calls.map((call, i) => {
         const argStr = stringifyArgs(call.arguments);
         return {
           id: `${id}#${call.id}`,
@@ -77,6 +82,7 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
           toolName: call.name,
           toolCallId: call.id,
           text: argStr || textParts,
+          ...(i === 0 ? thinkingField : {}),
         };
       });
     }
@@ -84,7 +90,7 @@ function projectMessage(message: AgentMessage, id: string): CoreMessage[] {
     // Drop thinking-only turns: empty assistant text makes OpenAI-compatible
     // providers (e.g. GLM) return 400 (no body), which Pi misreads as overflow.
     if (!text.trim()) return [];
-    return [{ id, role: "assistant", contentType: "text", text }];
+    return [{ id, role: "assistant", contentType: "text", text, ...thinkingField }];
   }
   const customText = extractText(msg.content) || fallbackText(msg);
   return customText.length > 0
@@ -117,6 +123,18 @@ export function extractText(content: unknown): string {
     if (b.type === "text" && typeof b.text === "string") parts.push(stripRefTag(b.text));
   }
   return parts.join("\n");
+}
+
+// Thinking blocks are invisible to extractText but resent with every request —
+// measure their volume so kernel counting sees the full payload (issue #353).
+export function thinkingTokenCount(content: unknown): number {
+  if (!Array.isArray(content)) return 0;
+  const parts: string[] = [];
+  for (const block of content) {
+    const b = block as { type?: string; thinking?: string };
+    if (b.type === "thinking" && typeof b.thinking === "string") parts.push(b.thinking);
+  }
+  return parts.length > 0 ? defaultCountTokens(parts.join("\n")) : 0;
 }
 
 function stripRefTag(text: string): string {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -40,6 +40,7 @@ export function estimateTokens(messages: CoreMessage[], coveredIds?: Set<string>
     if (m.toolName === "compress") continue;
     if (coveredIds?.has(m.id)) continue;
     tokens += defaultCountTokens(m.text ?? "");
+    tokens += m.thinkingTokens ?? 0;
     const img = imageTokensById?.get(m.id);
     if (img) tokens += img;
   }

--- a/tests/thinking-tokens.test.ts
+++ b/tests/thinking-tokens.test.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile, rm } from "node:fs/promises";
+import type { SessionEntry } from "@earendil-works/pi-coding-agent";
+import { defaultCountTokens } from "acp-kernel";
+import { createAcpExtension } from "../src/index.js";
+import { estimateTokens } from "../src/tokens.js";
+import { entriesToCoreMessages, thinkingTokenCount } from "../src/messages.js";
+
+// Thinking blocks are resent with every request but were invisible to the
+// projection (extractText collects text blocks only), so every ACP meter
+// under-counted reasoning sessions by the cumulative thinking volume
+// (billion-context-pi#353). Thinking now rides on CoreMessage.thinkingTokens,
+// attached to exactly one core per assistant turn.
+
+const STATE_FILE = "/tmp/pai-acp-thinking-tokens-it.session.json";
+
+function captureApi() {
+  const handlers = new Map<string, ((event: any, ctx: any) => any)[]>();
+  const api = {
+    on(event: string, handler: (e: any, ctx: any) => any) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+    tools: [] as any[],
+    commands: new Map<string, any>(),
+    registerTool(tool: any) { this.tools.push(tool); },
+    registerCommand(name: string, options: any) { this.commands.set(name, options); },
+  };
+  return { api, handlers };
+}
+
+const nudgeCount = (r: any) =>
+  (r?.messages ?? []).filter((m: any) => m.role === "user" && /Context limit reached|compress/i.test(JSON.stringify(m.content))).length;
+
+function ctxWithModel(entries: any[], limit: number, input: string[]) {
+  return {
+    mode: "rpc",
+    hasUI: false,
+    ui: { notify: () => {}, confirm: async () => true, select: async () => undefined, input: async () => "", setStatus: () => {} },
+    model: { contextWindow: limit, input },
+    sessionManager: {
+      buildContextEntries: () => entries,
+      getSessionId: () => "thinking-tokens-session",
+      getSessionFile: () => STATE_FILE,
+    },
+  };
+}
+
+const entry = (id: string, content: unknown): SessionEntry => ({
+  type: "message",
+  id,
+  parentId: null,
+  timestamp: "",
+  message: { role: "assistant", content, timestamp: Date.now() },
+}) as SessionEntry;
+
+const thinkingContent = (chars: number, text = "ok") => [
+  { type: "thinking", thinking: "t".repeat(chars) },
+  { type: "text", text },
+];
+
+test("thinkingTokenCount counts only thinking blocks", () => {
+  assert.equal(thinkingTokenCount([{ type: "text", text: "hi" }]), 0);
+  assert.equal(thinkingTokenCount("plain string"), 0);
+  assert.equal(thinkingTokenCount(undefined), 0);
+  const t = "ab ".repeat(50);
+  assert.equal(thinkingTokenCount([{ type: "thinking", thinking: t }, { type: "text", text: "x" }]), defaultCountTokens(t));
+  const joined = "a".repeat(40) + "\n" + "b".repeat(40);
+  assert.equal(thinkingTokenCount([{ type: "thinking", thinking: "a".repeat(40) }, { type: "thinking", thinking: "b".repeat(40) }]), defaultCountTokens(joined));
+});
+
+test("entriesToCoreMessages attaches thinkingTokens to exactly one core per turn", () => {
+  const expected = defaultCountTokens("t".repeat(100));
+  const textTurn = entriesToCoreMessages([entry("a1", thinkingContent(100))] as SessionEntry[]);
+  assert.deepEqual(textTurn.map((c) => c.thinkingTokens), [expected]);
+
+  const singleCall = entry("a2", [
+    { type: "thinking", thinking: "t".repeat(100) },
+    { type: "text", text: "working" },
+    { type: "toolCall", name: "read", id: "c1", arguments: { path: "/x" } },
+  ]);
+  const cores2 = entriesToCoreMessages([singleCall] as SessionEntry[]);
+  assert.equal(cores2.length, 1);
+  assert.equal(cores2[0]!.id, "a2");
+  assert.equal(cores2[0]!.thinkingTokens, expected);
+
+  const multiCall = entry("a3", [
+    { type: "thinking", thinking: "t".repeat(100) },
+    { type: "toolCall", name: "read", id: "c1", arguments: {} },
+    { type: "toolCall", name: "write", id: "c2", arguments: {} },
+  ]);
+  const cores3 = entriesToCoreMessages([multiCall] as SessionEntry[]);
+  assert.deepEqual(cores3.map((c) => c.id), ["a3#c1", "a3#c2"]);
+  assert.deepEqual(cores3.map((c) => c.thinkingTokens), [expected, undefined], "split cores must not repeat the thinking volume");
+
+  const plain = entriesToCoreMessages([entry("a4", [{ type: "text", text: "no thinking" }])] as SessionEntry[]);
+  assert.equal(plain[0]!.thinkingTokens, undefined);
+});
+
+test("estimateTokens includes thinkingTokens and skips covered ids", () => {
+  const msgs = [
+    { id: "m1", role: "user", contentType: "text", text: "alpha beta gamma" },
+    { id: "m2", role: "assistant", contentType: "text", text: "", thinkingTokens: 777 },
+  ];
+  assert.equal(estimateTokens(msgs), 4 + 777);
+  assert.equal(estimateTokens(msgs, new Set(["m2"])), 4);
+});
+
+const lastTurnLine = async (logFile: string) => {
+  const lines = (await readFile(logFile, "utf8")).split("\n").filter((l) => l.includes("[turn]"));
+  return lines[lines.length - 1] ?? "";
+};
+
+test("sent-view token count includes thinking tokens", async () => {
+  const logFile = `${STATE_FILE}.think.log`;
+  await rm(logFile, { force: true });
+  process.env.ACP_LOG_FILE = logFile;
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const entries = Array.from({ length: 8 }, (_, i) => entry(`e${i}`, thinkingContent(400)));
+  const ctx = ctxWithModel(entries, 10_000, ["text"]);
+  await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // 8 × ceil(400/4) = 800 thinking tokens must land in the sent-view estimate
+  // even though the visible text is eight tiny "ok" blocks.
+  const m = (await lastTurnLine(logFile)).match(/tokens=(\d+)/);
+  assert.ok(m, "[turn] line present");
+  assert.ok(Number(m[1]) >= 800, `thinking tokens missing from the sent-view estimate, got ${m[1]}`);
+  await rm(logFile, { force: true });
+});
+
+test("nudge fires when thinking pushes the sent view past the window", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const filler = "lorem ".repeat(200);
+  const entries = [
+    ...Array.from({ length: 8 }, (_, i) => ({
+      type: "message",
+      id: `f${i}`,
+      parentId: null,
+      timestamp: "",
+      message: { role: i % 2 ? "assistant" : "user", content: `${i} ${filler}`, timestamp: Date.now() },
+    })),
+    // Old thinking-heavy turns sit outside the recent-protection window, so
+    // their (now-metered) volume is compressible pending for the benefit floor.
+    ...Array.from({ length: 40 }, (_, i) => entry(`t${i}`, thinkingContent(800))),
+    { type: "message", id: "u1", parentId: null, timestamp: "", message: { role: "user", content: "continue", timestamp: Date.now() } },
+    { type: "message", id: "a1", parentId: null, timestamp: "", message: { role: "assistant", content: "ok", timestamp: Date.now() } },
+  ];
+  const ctx = ctxWithModel(entries, 10_000, ["text"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  // ~2.4K filler + 40 × 200 thinking ≈ 10.4K (104% of the 10K window); the
+  // recent-5K-token protection leaves ≈ 5.4K compressible pending ≥ the 5K
+  // min-benefit floor; without metered thinking the session reads ~24%.
+  assert.ok(nudgeCount(r) >= 1, "metered thinking must push the session into the nudge band");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});
+
+test("identical session without thinking stays quiet (control)", async () => {
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 10_000 })(api as any);
+  const filler = "lorem ".repeat(200);
+  const entries = [
+    ...Array.from({ length: 8 }, (_, i) => ({
+      type: "message",
+      id: `f${i}`,
+      parentId: null,
+      timestamp: "",
+      message: { role: i % 2 ? "assistant" : "user", content: `${i} ${filler}`, timestamp: Date.now() },
+    })),
+    ...Array.from({ length: 40 }, (_, i) => ({
+      type: "message",
+      id: `t${i}`,
+      parentId: null,
+      timestamp: "",
+      message: { role: "assistant", content: "ok", timestamp: Date.now() },
+    })),
+    { type: "message", id: "u1", parentId: null, timestamp: "", message: { role: "user", content: "continue", timestamp: Date.now() } },
+    { type: "message", id: "a1", parentId: null, timestamp: "", message: { role: "assistant", content: "ok", timestamp: Date.now() } },
+  ];
+  const ctx = ctxWithModel(entries, 10_000, ["text"]);
+  const r = await handlers.get("context")![0]!({ type: "context", messages: entries.map((e) => e.message) }, ctx);
+  assert.equal(nudgeCount(r), 0, "~2.4K of filler at 24% of the window must stay quiet");
+  await rm(`${STATE_FILE}.acp.json`, { force: true });
+});


### PR DESCRIPTION
Fixes #353 — thinking/reasoning blocks ride along every request (pi replays them via reasoning_content / thinking-as-text) but were invisible to extractText(), so sessions on relays without usage reporting systematically under-metered context by the cumulative thinking volume → compression bands fired late → upstream overflow risk.\n\n- projectMessage attaches each assistant message's thinking volume (defaultCountTokens, same caliber as the kernel) to the FIRST emitted core only (text / single toolCall / multi-toolCall shapes covered) — the kernel contract from acp-kernel #242 (published 0.0.62): one core per original message, no double counting on split tool-call cores.\n- estimateTokens session fallback + /acp panel unprunedTokens include thinkingTokens; providers with reliable usage keep using the realUsage floor (no double counting).\n- Pinned acp-kernel to exact 0.0.62 (thinkingTokens field + countMessageTokens).\n- tests/thinking-tokens.test.ts: per-shape single-point attachment + sent-view [turn] counting + nudge-band crossing integration.\n\nReviewed independently: kernel side #242 + adapter diff checked (first-core-only attachment, fallback-only application, caliber parity).