### PR TITLE
release v0.1.65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.64",
+	"version": "0.1.65",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.64",
+			"version": "0.1.65",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.64",
+	"version": "0.1.65",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
Release v0.1.65 — ships thinking-token metering (#353, PR #357): assistant thinking volume now counts toward ACP metering via CoreMessage.thinkingTokens (acp-kernel 0.0.62, #242/#243). Fixes the compression-band blind spot on relays without usage reporting. No further acp-kernel bump (already 0.0.62 on master).