### PR TITLE
release v0.1.66

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.65",
+	"version": "0.1.66",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.65",
+			"version": "0.1.66",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.62",
+				"acp-kernel": "0.0.63",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3200,9 +3200,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.62",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.62.tgz",
-			"integrity": "sha512-NSoeUiGu77gFzayeYwLjytyPetEmZVvuFvlhGSfl3RtAgyvXxV2z8Iu1NCvLzzU23Ncx3eAa2EmwyEozJ2DlGw==",
+			"version": "0.0.63",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.63.tgz",
+			"integrity": "sha512-hM437yJ+iDeYzXMRZ6pIO37o+qS9i27GPO24xGDcEWKjFIb2GPJOQkqURI7rtdiouPnDX1bWojUjPyLghz0jDQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.65",
+	"version": "0.1.66",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -61,7 +61,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.62",
+		"acp-kernel": "0.0.63",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"


### PR DESCRIPTION
Bundles acp-kernel 0.0.63 (turn integrity — kernel #244/#245/#247, fixes the half-turn fold that 400'd DeepSeek thinking mode, billion-context#684) into the pi adapter; version 0.1.65 → 0.1.66. Dual-field release commit per AGENTS.md §5.

696 tests / 0 fail, typecheck clean, build clean (dist verified to contain the turn-integrity gate).

Merge is human-only. #361 (adapter-side strict-echo gate for the #651 drop) intentionally deferred to the next cycle.