### PR TITLE
release v0.1.67

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.66",
+	"version": "0.1.67",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-pi",
-			"version": "0.1.66",
+			"version": "0.1.67",
 			"license": "MIT",
 			"devDependencies": {
 				"@earendil-works/pi-coding-agent": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-pi",
-	"version": "0.1.66",
+	"version": "0.1.67",
 	"description": "One billion, not one million. Model-driven context management for the Pi coding agent.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
## 内容

- #327(`nudge`/压缩失败记账按 `sessionId` 隔离,#317 接缝 3)— 首次进入发布线,v0.1.66 发版晚于其合并

## 发布物

- `package.json` + `package-lock.json`:0.1.66 → 0.1.67(acp-kernel pin 不变,仍 0.0.63)

## 验证

- 699 tests / 0 fail / 3 skip(#327 合并后全量)
- typecheck ✓ / build ✓