### PR TITLE
docs: add QQ community group to README (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ Restore them next to each other on the target machine. For clone/fork children, 
 
 The compression engine is [`acp-kernel`](https://github.com/ranxianglei/acp-kernel) — a platform-agnostic, MIT-licensed library with 208 tests. It's bundled inline into `dist/index.js`, so there are zero runtime dependencies.
 
+## Community
+
+Discussion, help, and updates on QQ — one group covers all three projects (`billion-context`, `billion-context-pi`, `opencode-acp`):
+
+**QQ Group: 1056132097**
+
 ## License
 
 MIT.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -246,6 +246,12 @@ cp -r ~/.pi/agent/sessions  <备份>/pi-sessions
 
 压缩引擎是 [`acp-kernel`](https://github.com/ranxianglei/acp-kernel) — 平台无关、MIT 许可的库,有 208 个测试。它被内联打包进 `dist/index.js`,因此零运行时依赖。
 
+## 社区
+
+交流、求助与更新都在 QQ——同一个群覆盖三个项目(`billion-context`、`billion-context-pi`、`opencode-acp`):
+
+**QQ 群:1056132097**
+
 ## 许可证
 
 MIT.


### PR DESCRIPTION
Add a QQ community group (**1056132097**) to the README in both English and Chinese.

One shared group covers all three projects: `billion-context`, `billion-context-pi`, `opencode-acp`.

- `README.md`: new `## Community` section before `## License`
- `README.zh-CN.md`: new `## 社区` section before `## 许可证`

Docs-only; no version bump.