### PR TITLE
feat: report new block ids and actual ref spans in compress result panel (#376)

### DIFF
--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -154,13 +154,17 @@ function jsonParseError(content: CompressArgs["content"]): string | undefined {
 /** Panel block count, or -1 for non-panels. Accepts BOTH the legacy
  *  "… B blocks)" form (0-block runs; historical transcripts replayed by
  *  index/floor-stale) and the #376 "… blocks: b3=m00044–m00097*, …" form. */
-function compressPanelBlocks(text: string): number {
+export function compressPanelBlocks(text: string): number {
   if (!text.trimStart().startsWith("▣ ACP |")) return -1;
   const m = text.match(/, (\d+) blocks?\)/);
   if (m) return Number(m[1]);
-  const list = text.match(/, blocks: ([^)]*)\)/);
-  if (list) return (list[1] ?? "").split(",").map((s) => s.trim()).filter(Boolean).length;
-  return -1;
+  // Count span-form entries by their label tokens (bN= / bN(Tn)=), NOT by
+  // capturing to the next ")" — tier labels carry a ")" that would truncate a
+  // naive capture and undercount any batch whose first new block is T2/T3.
+  const idx = text.indexOf(", blocks: ");
+  if (idx === -1) return -1;
+  const header = text.slice(idx).split("\n", 1)[0] ?? "";
+  return header.match(/\bb\d+(?:\(T\d+\))?=/g)?.length ?? 0;
 }
 
 /** Success = completed run that created >= 1 block (partial range errors

--- a/src/compress-tool.ts
+++ b/src/compress-tool.ts
@@ -151,11 +151,16 @@ function jsonParseError(content: CompressArgs["content"]): string | undefined {
   }
 }
 
-/** Panel block count ("… (~N reclaimed, B blocks)"), or -1 for non-panels. */
+/** Panel block count, or -1 for non-panels. Accepts BOTH the legacy
+ *  "… B blocks)" form (0-block runs; historical transcripts replayed by
+ *  index/floor-stale) and the #376 "… blocks: b3=m00044–m00097*, …" form. */
 function compressPanelBlocks(text: string): number {
   if (!text.trimStart().startsWith("▣ ACP |")) return -1;
   const m = text.match(/, (\d+) blocks?\)/);
-  return m ? Number(m[1]) : -1;
+  if (m) return Number(m[1]);
+  const list = text.match(/, blocks: ([^)]*)\)/);
+  if (list) return (list[1] ?? "").split(",").map((s) => s.trim()).filter(Boolean).length;
+  return -1;
 }
 
 /** Success = completed run that created >= 1 block (partial range errors
@@ -186,6 +191,40 @@ const DEAD_REPEAT_REJECT = 2;
 
 function paddedRef(n: number): string {
   return `m${String(n).padStart(5, "0")}`;
+}
+
+// issue #376: report each new block's ACTUAL coverage, not the requested
+// startId/endId — kernel protection exclusions and turn-integrity rollback
+// can shrink a range post-hoc, so inferring coverage from the request drifts
+// the model's block ledger against nudge ranges. Span = first/last ref of
+// effectiveMessageIds; `*` marks spans containing still-existing refs the
+// block does not cover (excluded — see the ⚠️ warnings line); tier ≥ 2 marked.
+export function blockSpanLabel(block: CompressionBlock, state: CompressionState): string {
+  const nums: number[] = [];
+  for (const id of block.effectiveMessageIds) {
+    const ref = state.messageRefs.byRaw[id];
+    if (!ref || !ref.startsWith("m")) continue;
+    const n = Number(ref.slice(1));
+    if (Number.isInteger(n) && n > 0) nums.push(n);
+  }
+  const tierMark = block.tier >= 2 ? `(T${block.tier})` : "";
+  if (nums.length === 0) return `${block.blockId}${tierMark}`;
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const n of nums) {
+    if (n < lo) lo = n;
+    if (n > hi) hi = n;
+  }
+  const present = new Set(nums);
+  let star = "";
+  for (let n = lo; n <= hi; n++) {
+    if (!present.has(n) && state.messageRefs.byRef[paddedRef(n)] !== undefined) {
+      star = "*";
+      break;
+    }
+  }
+  const span = lo === hi ? paddedRef(lo) : `${paddedRef(lo)}–${paddedRef(hi)}`;
+  return `${block.blockId}${tierMark}=${span}${star}`;
 }
 
 function blockHasVisibleAnchor(block: CompressionBlock, visibleIds: Set<string>): boolean {
@@ -452,7 +491,10 @@ async function handleCompress(args: CompressArgs, runtime: AcpRuntime, ctx: Exte
     logWarn("compress", { sid: ctx.sessionManager.getSessionId(), event: "warnings", count: warnings.length, warnings: warnings.slice(0, 5) });
   }
 
-  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(reclaimed)} reclaimed, ${blocksCreated} block${blocksCreated > 1 ? "s" : ""})`];
+  const spanClause = blocksCreated > 0
+    ? `blocks: ${newBlocks.map((b) => blockSpanLabel(b, applied.state)).join(", ")}`
+    : "0 blocks";
+  const lines = [`▣ ACP | ${formatK(beforeTokens)} → ${formatK(afterTokens)} tokens (~${formatK(reclaimed)} reclaimed, ${spanClause})`];
   if (warnings.length > 0) lines.push("⚠️ " + warnings.join("; "));
   if (errors.length > 0) lines.push("Errors: " + errors.join("; "));
   return lines.join("\n");

--- a/tests/compress-tool.test.ts
+++ b/tests/compress-tool.test.ts
@@ -1,7 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile, rm } from "node:fs/promises";
+import type { CompressionBlock, CompressionState } from "acp-kernel";
 import { createAcpExtension } from "../src/index.js";
+import { blockSpanLabel, isCompressNoopText, isCompressSuccessText } from "../src/compress-tool.js";
 
 // ─── helpers (mirror decompress-tool.test.ts) ──────────────────────────────
 
@@ -201,4 +203,137 @@ test("compress in an in-memory session (no session file) survives to the next co
   report = await statusText();
   assert.match(report, /b1 \(T1\)/, `b1 must survive after the second compress: ${report}`);
   assert.match(report, /b2 \(T1\)/, `second block must be numbered b2 (nextBlockId retained), not reset to b1: ${report}`);
+});
+
+// issue #376: the panel line must report each NEW block's id and its ACTUAL
+// ref span (from effectiveMessageIds), so the model's block ledger matches
+// reality instead of being inferred from the requested startId/endId.
+test("compress panel lists every new block id with its actual ref span (#376)", async () => {
+  const { api, handlers } = captureApi();
+  // minCompressRange gate needs ≥5000 chars per range (same pattern as #309/#322).
+  createAcpExtension({ modelContextLimit: 200_000, preserveRecentMessages: 1 })(api as any);
+  const BIG = "中".repeat(6000);
+  const stateFile = "/tmp/pai-acp-compress-spans.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const entries = [userMsg("e1", BIG), userMsg("e2", BIG), userMsg("e3", BIG), userMsg("e4", BIG)];
+  const ctx = fakeCtx(entries, stateFile);
+  ctx.__setUsage(100_000);
+  await runContextRound(handlers, ctx);
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  const out = await compressTool.execute(
+    "tc1",
+    { content: [
+      { startId: "m00001", endId: "m00001", summary: "first range: span reporting test for issue 376 block ledger accuracy" },
+      { startId: "m00003", endId: "m00003", summary: "third entry compressed for the span reporting test of issue 376" },
+    ] },
+    undefined, undefined, ctx,
+  );
+  const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
+  assert.ok(text.includes("▣ ACP"), `compress failed: ${text}`);
+  assert.ok(!text.includes("Errors:"), `compress rejected: ${text}`);
+
+  const m = /reclaimed, blocks: (.+)\)$/.exec(text.split("\n")[0]!);
+  assert.ok(m, `panel missing per-block spans: ${text}`);
+  const parts = m![1]!.split(", ");
+  assert.equal(parts.length, 2, `expected two block entries: ${m![1]}`);
+  assert.match(parts[0]!, /^b1=(?:m\d{5}(?:–m\d{5})?\*?)$/, `first entry must be b1 with a ref span: ${parts[0]}`);
+  assert.match(parts[1]!, /^b2=(?:m\d{5}(?:–m\d{5})?\*?)$/, `second entry must be b2 with a ref span: ${parts[1]}`);
+});
+
+// issue #376 acceptance: on a PARTIAL run (one range rejected, one applied)
+// the panel must still list exactly the blocks that were created.
+test("partial compress panel lists only the created blocks accurately (#376)", async () => {
+  const { api, handlers } = captureApi();
+  createAcpExtension({ modelContextLimit: 200_000, preserveRecentMessages: 1 })(api as any);
+  const BIG = "中".repeat(6000);
+  const stateFile = "/tmp/pai-acp-compress-partial-spans.session.json";
+  await rm(`${stateFile}.acp.json`, { force: true });
+  const entries = [userMsg("e1", BIG), userMsg("e2", BIG), userMsg("e3", BIG), userMsg("e4", BIG)];
+  const ctx = fakeCtx(entries, stateFile);
+  ctx.__setUsage(100_000);
+  await runContextRound(handlers, ctx);
+
+  const compressTool = api.tools.find((t: any) => t.name === "compress")!;
+  async function doCompress(callId: string, ranges: any[]) {
+    const o = await compressTool.execute(callId, { content: ranges }, undefined, undefined, ctx);
+    return typeof o === "string" ? o : o.content?.[0]?.text ?? String(o);
+  }
+
+  const first = await doCompress("tc1", [{ startId: "m00001", endId: "m00001", summary: "first range for the partial span reporting regression test" }]);
+  assert.ok(first.includes("blocks: b1="), `first compress missing span clause: ${first}`);
+
+  const partial = await doCompress("tc2", [
+    { startId: "m00001", endId: "m00001", summary: "duplicate range that must be rejected because already compressed" },
+    { startId: "m00002", endId: "m00002", summary: "second range for the partial span reporting regression test" },
+  ]);
+  assert.ok(partial.includes("Errors:"), `partial run must report the rejected range: ${partial}`);
+  assert.match(partial, /already covered by active block/i, `expect already-covered rejection: ${partial}`);
+  const m = /reclaimed, blocks: (b\d+(?:\(T\d\))?=(?:m\d{5}(?:–m\d{5})?\*?))\)$/.exec(partial.split("\n")[0]!);
+  assert.ok(m, `partial panel missing per-block spans: ${partial}`);
+  assert.equal(m![1]!.startsWith("b2="), true, `only the new block b2 may be listed: ${m![1]}`);
+});
+
+function makeBlock(over: Partial<CompressionBlock>): CompressionBlock {
+  return {
+    blockId: "b1", runId: "r1", tier: 1, summary: "s",
+    directMessageIds: [], effectiveMessageIds: [], directBlockIds: [],
+    compressedTokens: 0, createdAt: 0, survivedCount: 0, generation: "young", active: true,
+    ...over,
+  };
+}
+
+function makeState(byRaw: Record<string, string>): CompressionState {
+  const byRef: Record<string, string> = {};
+  for (const [raw, ref] of Object.entries(byRaw)) byRef[ref] = raw;
+  return {
+    blocks: [], messageRefs: { byRaw, byRef }, tokenSnapshot: {},
+    nudge: { lastPerMessageNudgeTokens: 0, lastNudgeShownTokens: 0, baselineTokens: 0, anchors: {}, lastShownByTier: {} },
+    stats: { tokensCompressed: 0, compressionCount: 0 }, nextBlockId: 2, nextRunId: 1,
+  };
+}
+
+test("blockSpanLabel: contiguous span, no star", () => {
+  const refs = { r1: "m00001", r2: "m00002", r3: "m00003", r4: "m00004", r5: "m00005" };
+  const b = makeBlock({ effectiveMessageIds: ["r1", "r2", "r3", "r4", "r5"] });
+  assert.equal(blockSpanLabel(b, makeState(refs)), "b1=m00001–m00005");
+});
+
+test("blockSpanLabel: interior exclusion marked with *", () => {
+  const refs = { r1: "m00001", r2: "m00002", r3: "m00003", r4: "m00004", r5: "m00005" };
+  const b = makeBlock({ effectiveMessageIds: ["r1", "r3", "r5"] });
+  assert.equal(blockSpanLabel(b, makeState(refs)), "b1=m00001–m00005*");
+});
+
+test("blockSpanLabel: trailing exclusion is NOT a star (span itself is accurate)", () => {
+  const refs = { r1: "m00001", r2: "m00002", r3: "m00003", r4: "m00004" };
+  const b = makeBlock({ effectiveMessageIds: ["r1", "r2", "r3"] });
+  assert.equal(blockSpanLabel(b, makeState(refs)), "b1=m00001–m00003");
+});
+
+test("blockSpanLabel: pre-existing numbering gap without byRef entry is not an exclusion", () => {
+  const refs = { r1: "m00001", r2: "m00003" };
+  const b = makeBlock({ effectiveMessageIds: ["r1", "r2"] });
+  assert.equal(blockSpanLabel(b, makeState(refs)), "b1=m00001–m00003");
+});
+
+test("blockSpanLabel: single-message span renders bare; tier >= 2 marked", () => {
+  const refs = { r3: "m00003" };
+  assert.equal(blockSpanLabel(makeBlock({ effectiveMessageIds: ["r3"] }), makeState(refs)), "b1=m00003");
+  const t2 = makeBlock({ blockId: "b6", tier: 2, effectiveMessageIds: ["r3"] });
+  assert.equal(blockSpanLabel(t2, makeState(refs)), "b6(T2)=m00003");
+});
+
+test("blockSpanLabel: unresolvable ids fall back to the bare block id", () => {
+  const b = makeBlock({ effectiveMessageIds: ["orphan-raw-id"] });
+  assert.equal(blockSpanLabel(b, makeState({})), "b1");
+});
+
+test("panel parser accepts both legacy count form and #376 span form", () => {
+  assert.equal(isCompressSuccessText("▣ ACP | 58.5K → 5.7K tokens (~52.8K reclaimed, 4 blocks)"), true);
+  assert.equal(isCompressSuccessText("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4=m00103–m00123*)"), true);
+  assert.equal(isCompressNoopText("▣ ACP | 58.5K → 58.5K tokens (~0 reclaimed, 0 blocks)"), true);
+  assert.equal(isCompressNoopText("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4=m00103–m00123*)"), false);
+  assert.equal(isCompressSuccessText("No ranges provided."), false);
+  assert.equal(isCompressNoopText("No ranges provided."), false);
 });

--- a/tests/compress-tool.test.ts
+++ b/tests/compress-tool.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFile, rm } from "node:fs/promises";
 import type { CompressionBlock, CompressionState } from "acp-kernel";
 import { createAcpExtension } from "../src/index.js";
-import { blockSpanLabel, isCompressNoopText, isCompressSuccessText } from "../src/compress-tool.js";
+import { blockSpanLabel, compressPanelBlocks, isCompressNoopText, isCompressSuccessText } from "../src/compress-tool.js";
 
 // ─── helpers (mirror decompress-tool.test.ts) ──────────────────────────────
 
@@ -336,4 +336,16 @@ test("panel parser accepts both legacy count form and #376 span form", () => {
   assert.equal(isCompressNoopText("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4=m00103–m00123*)"), false);
   assert.equal(isCompressSuccessText("No ranges provided."), false);
   assert.equal(isCompressNoopText("No ranges provided."), false);
+});
+
+test("compressPanelBlocks counts tier labels correctly ((Tn) carries a paren)", () => {
+  assert.equal(compressPanelBlocks("▣ ACP | 58.5K → 5.7K tokens (~52.8K reclaimed, 4 blocks)"), 4);
+  assert.equal(compressPanelBlocks("▣ ACP | 58.5K → 5.7K tokens (~52.8K reclaimed, 1 block)"), 1);
+  assert.equal(compressPanelBlocks("▣ ACP | 58.5K → 58.5K tokens (~0 reclaimed, 0 blocks)"), 0);
+  assert.equal(compressPanelBlocks("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*)"), 1);
+  assert.equal(compressPanelBlocks("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4=m00103–m00123*)"), 2);
+  assert.equal(compressPanelBlocks("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4(T2)=m00103–m00123*)"), 2);
+  // regression: FIRST listed block is tier >= 2 — a capture-to-next-")" parse returns 1 here
+  assert.equal(compressPanelBlocks("▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3(T2)=m00044–m00097, b4(T2)=m00103–m00123*)"), 2);
+  assert.equal(compressPanelBlocks("No ranges provided."), -1);
 });

--- a/tests/decompress-cmd.test.ts
+++ b/tests/decompress-cmd.test.ts
@@ -82,7 +82,7 @@ test("/acp-decompress returns a block's content and stays repeatable (append mod
     ctx,
   );
   const compressText = (compressRes.content[0] as any).text as string;
-  assert.match(compressText, /1 block/, "compress created a block");
+  assert.match(compressText, /blocks: b\d+=/, "compress created a block");
 
   // 3) Run /acp-decompress b1 — returns content, does NOT deactivate.
   notifies.length = 0;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -360,7 +360,7 @@ test("omp matches emergency-truncated tool results before compression", async (t
   const targetRef = transformed.messages[0].content.find((block: { type: string; text: string }) => block.type === "text").text.match(/m\d{5}/)![0];
   const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
   const result = await compressTool.execute("tc-omp-truncation", { content: [{ startId: targetRef, endId: targetRef, summary: "This large tool result was emergency-truncated in provider context and is now safely compressed from the original entry." }] }, undefined, undefined, ctx);
-  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+  assert.match(result.content[0].text, /blocks: b\d+=/, result.content[0].text);
 });
 
 test("omp does not collapse distinct multimodal user messages with identical text (images survive)", async () => {
@@ -446,7 +446,7 @@ test("acp_status refs remain usable by the next compress call", async () => {
   const targetRef = status.content[0].text.match(/m\d{5}/)![0];
   const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
   const result = await compressTool.execute("tc-status-compress", { content: [{ startId: targetRef, endId: targetRef, summary: "This range was selected by acp_status and is now safely compressed from the original entry." }] }, undefined, undefined, ctx);
-  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+  assert.match(result.content[0].text, /blocks: b\d+=/, result.content[0].text);
 });
 
 test("omp rebuilds refs after stale live state before status compression", async () => {
@@ -468,7 +468,7 @@ test("omp rebuilds refs after stale live state before status compression", async
   assert.equal(targetRef, "m00001", status.content[0].text);
   const compressTool = api.tools.find((tool: { name: string }) => tool.name === "compress")!;
   const result = await compressTool.execute("tc-stale-live-compress", { content: [{ startId: targetRef, endId: targetRef, summary: "This stale live range was rebuilt against stable persisted entries and is now safely compressed." }] }, undefined, undefined, ctx);
-  assert.match(result.content[0].text, /1 block/, result.content[0].text);
+  assert.match(result.content[0].text, /blocks: b\d+=/, result.content[0].text);
 });
 
 test("system prompt sources compression rules from acp-kernel (no hardcoded drift, no markers)", () => {
@@ -653,7 +653,7 @@ test("omp keeps compression blocks active when provider context has an extra pre
     undefined,
     ctx,
   );
-  assert.match(compressed.content[0].text, /1 block/);
+  assert.match(compressed.content[0].text, /blocks: b\d+=/);
 
   const next = await handlers.get("context")![0]!(
     {
@@ -702,7 +702,7 @@ test("omp keeps compression active when persisted and provider tails diverge", a
     undefined,
     ctx,
   );
-  assert.match(compressed.content[0].text, /1 block/);
+  assert.match(compressed.content[0].text, /blocks: b\d+=/);
 
   const activeUserText = "current user on the active branch";
   persisted = [...persisted, userMsg("e-active-user", activeUserText)];

--- a/tests/view-recount.test.ts
+++ b/tests/view-recount.test.ts
@@ -98,7 +98,7 @@ test("#289 Fix A: sent-view recount suppresses spurious emergency", async () => 
 
     const out: any = await compressTool.execute("tc1", { content: [{ startId: refC1, endId: refC1, summary: "s".repeat(300) }] }, undefined, undefined, ctx);
     const text = typeof out === "string" ? out : out.content?.[0]?.text ?? String(out);
-    assert.match(text, /1 block/, `expected successful compress, got: ${text}`);
+    assert.match(text, /blocks: b\d+=/, `expected successful compress, got: ${text}`);
 
     // Session realism: the compress toolResult lands in the transcript.
     branchEntries.push(msg("cr1", "toolResult", [{ type: "text", text: "▣ ACP | 81.7K → 72.2K tokens (~9.5K reclaimed, 1 block)" }], { toolName: "compress", toolCallId: "tc1" }));


### PR DESCRIPTION
## 背景

#375 中发现:模型对"之前的压缩块覆盖到哪里"的记忆与 nudge 推荐的 ranges 矛盾,被迫先调 acp_status 验证再执行(~1.8K tokens + 一轮 LLM)。根因:compress 结果行只报 `N blocks`,不报新块 ID 与实际覆盖——模型只能从自己提交的 startId/endId 推断;而 kernel 的保护排除与 turn-integrity 撤回会在事后改变实际范围,每次 compress 后块账本都偏差一点,累积到与 nudge 冲突。

## 改动

- `src/compress-tool.ts`:新增 `blockSpanLabel(block, state)`——取 `effectiveMessageIds` 的首尾 ref 作为**实际**跨度(而非请求边界);跨度内存在仍存活但未被该块覆盖的 ref(被保护/撤回排除)时标 `*`;tier ≥ 2 标 `(T2)`/`(T3)`;单消息跨度渲染为裸 ref(与 kernel 渲染约定一致);无法解析 ref 时退化为裸块 ID。
- 成功面板逐块列出新块:
  `▣ ACP | 61.1K → 13.7K tokens (~47.4K reclaimed, blocks: b3=m00044–m00097*, b4=m00103–m00123*)`
- 0-block 运行保持旧格式 `0 blocks`(与 dead/cap 拒绝面板一致);`compressPanelBlocks` 双格式兼容——index/floor-stale 的日志回放路径必须继续解析历史 transcript 里的旧面板。

## 测试

- 新增 9 个测试:e2e 结果格式断言(多块逐一列出;partial 运行只列创建的块)、`blockSpanLabel` 单元(连续 / 内部排除 `*` / 尾部排除不标 `*` / 编号空洞非排除 / 单消息裸 ref / tier 标注 / 不可解析退化)、解析器双格式兼容。
- 更新 7 处旧 `/1 block/` 断言(decompress-cmd、integration ×5、view-recount)——它们对真实输出断言旧格式,随本次有意的输出契约变更同步更新。
- 全量:657 pass / 0 fail / 3 skipped(skipped 为既有);typecheck + tsup build clean。

无 acp-kernel 依赖 bump——纯本仓库改动。配套 acp-kernel#251(nudge 块地图)落地后,两项共同消除验证性 acp_status 往返。

Fixes #376
