### PR TITLE
test(#385): match new compress panel format in export-cmd helper

### DIFF
--- a/tests/export-cmd.test.ts
+++ b/tests/export-cmd.test.ts
@@ -86,7 +86,7 @@ async function setupSession(stateFile: string) {
     ctx,
   );
   const text = (res.content[0] as any).text as string;
-  assert.match(text, /1 block/, "compress created a block");
+  assert.match(text, /blocks: b1=/, "compress created a block");
   return { api, ctx, notifies };
 }
 


### PR DESCRIPTION
One-line test fix, no production code touched.

`tests/export-cmd.test.ts:89` asserted the legacy compress-result format (`/1 block/`). #377 (cca0060) reworked the panel line to `blocks: bN=mXXXXX–mYYYYY` and updated four test files but missed this one — its branch predated #272's merge, so #377's CI never saw it. Result: 7 identical `compress created a block` failures on master (verified pre-existing on both acp-kernel 0.0.63 and 0.0.64, unrelated to any pin bump).

Verified: `tests/export-cmd.test.ts` 3/10 → **10/10**; full suite **725/725**.

Fixes #385