### PR TITLE
test(export-cmd): assert new compress panel block-span format (issue #385)

### DIFF
--- a/tests/export-cmd.test.ts
+++ b/tests/export-cmd.test.ts
@@ -86,7 +86,7 @@ async function setupSession(stateFile: string) {
     ctx,
   );
   const text = (res.content[0] as any).text as string;
-  assert.match(text, /1 block/, "compress created a block");
+  assert.match(text, /blocks: b\d+=/, "compress created a block");
   return { api, ctx, notifies };
 }
 


### PR DESCRIPTION
## Problem

Master test suite red: `node --import tsx --test tests/export-cmd.test.ts` → 7 fails, all `error: 'compress created a block'`.

## Root cause

Merge-order interaction between two PRs:

1. #272 (acp-export command) landed first; its `setupSession` helper at `tests/export-cmd.test.ts:89` asserted the old panel format `/1 block/` (`… (~N reclaimed, 1 block)`).
2. #377 changed the panel line to `… blocks: b1=mXXXXX–mYYYYY` (`blockSpanLabel`, src/compress-tool.ts:499) and updated four test files — but missed `tests/export-cmd.test.ts`.
3. The #377 branch was based on pre-#272-merge master, so its CI never ran this file; after both merges master went red.

Verified on master (2bdc831): reproduced all 7 failures before the change.

## Fix

One line in `tests/export-cmd.test.ts:89`: assert the new format using the sibling convention from #377 (`/blocks: b\d+=/`, same as `tests/decompress-cmd.test.ts:85` which carries the identical assertion message). The helper compresses only m00002 so span detail does not affect the match.

Remaining `/1 block/` strings in other tests are intentional legacy-parsing coverage (old panel lines replayed from session logs) and were left untouched.

## Verification

- `node --import tsx --test tests/export-cmd.test.ts` → 10 pass / 0 fail (was 3 pass / 7 fail)
- `npm test` → 725 tests, 722 pass, 0 fail, 3 skipped (pre-existing skips)
- `npm run typecheck` clean; `npm run build` success

Fixes #385

<!-- ework-agent-pr -->