### PR TITLE
fix(tests): use isCompressSuccessText in export-cmd setupSession (stale /1 block/ after #376/#377)

### DIFF
--- a/tests/export-cmd.test.ts
+++ b/tests/export-cmd.test.ts
@@ -4,6 +4,7 @@ import { mkdir, rm, writeFile, readFile } from "node:fs/promises";
 import * as path from "node:path";
 import { createAcpExtension } from "../src/index.js";
 import { listSessions, exportSession, parseExportArgs } from "../src/export.js";
+import { isCompressSuccessText } from "../src/compress-tool.js";
 import { createInitialState } from "acp-kernel";
 
 function captureApi() {
@@ -86,7 +87,7 @@ async function setupSession(stateFile: string) {
     ctx,
   );
   const text = (res.content[0] as any).text as string;
-  assert.match(text, /blocks: b1=m00002/, "compress created a block");
+  assert.ok(isCompressSuccessText(text), `compress created a block: ${text}`);
   return { api, ctx, notifies };
 }
 


### PR DESCRIPTION
## Context

Issue #389: 7 subtests in `tests/export-cmd.test.ts` fail on master. The shared helper `setupSession()` asserted `/1 block/` against the compress tool result, but since #376/#377 compress returns the span-form panel (`blocks: b1=m00002`) instead of the legacy count form (`1 block`).

## Fix

Replace the regex assertion with the production success predicate `isCompressSuccessText()` from `src/compress-tool.ts` — the same predicate the compress retry loop uses and that compress-retry / compress-loop-breaker / compress-tool tests already assert against. It encodes "completed run that created ≥ 1 block" and accepts BOTH panel forms (legacy count + #376 span), so the fixture no longer couples to panel wording.

## Verification

- Before (origin/master `2bdc831`): 3 pass / 7 fail, error verbatim matches the issue report.
- After: `tests/export-cmd.test.ts` 10/10 pass; full suite `npm test` → **722 pass / 0 fail / 3 skip**; `npm run typecheck` clean.

Fixes #389