### PR TITLE
test(export): assert post-#377 compress panel format — fix master-red (#391)

### DIFF
--- a/tests/export-cmd.test.ts
+++ b/tests/export-cmd.test.ts
@@ -86,7 +86,7 @@ async function setupSession(stateFile: string) {
     ctx,
   );
   const text = (res.content[0] as any).text as string;
-  assert.match(text, /1 block/, "compress created a block");
+  assert.match(text, /blocks: b1=m00002/, "compress created a block");
   return { api, ctx, notifies };
 }
 


### PR DESCRIPTION
Fixes #391

One-line fix: `tests/export-cmd.test.ts:89` still asserted the pre-#377 panel `/1 block/`; #377 changed the format to `blocks: b1=m00002` but its branch predated #272's merge, so neither PR's CI saw the other's tests. Master went red on merge; PR #380's CI failure is inherited from this.

Verified: 10/10 export-cmd + full suite green on this branch.