### PR TITLE
test(export): assert post-#377 panel format in setupSession

### DIFF
--- a/tests/export-cmd.test.ts
+++ b/tests/export-cmd.test.ts
@@ -86,7 +86,7 @@ async function setupSession(stateFile: string) {
     ctx,
   );
   const text = (res.content[0] as any).text as string;
-  assert.match(text, /1 block/, "compress created a block");
+  assert.match(text, /blocks: b1=m00002/, "compress created a block");
   return { api, ctx, notifies };
 }
 


### PR DESCRIPTION
Fixes #391

## Problem
After #272 and #377 merged sequentially, master was red: `tests/export-cmd.test.ts` failed 7/10 with `AssertionError: compress created a block`. #272's `setupSession` asserted the pre-#377 panel format `/1 block/`, while #377 changed the compress result panel to the span-label form (`blocks: b1=m00002` for a single-ref range). Neither PR's CI ever saw the other's change — cross-PR regression.

## Fix
One line in `tests/export-cmd.test.ts:89`: assert the new format `/blocks: b1=m00002/`.

## Verification (on this branch)
- Reproduced on master first: 7/10 fail, actual panel `▣ ACP | 8.0K → 6.2K tokens (~1.8K reclaimed, blocks: b1=m00002)` — matches issue report exactly.
- After fix: `tests/export-cmd.test.ts` 10/10 pass.
- Full suite: 722 pass / 0 fail / 3 skip; typecheck + build clean.
- Confirmed no other stale old-format assertions: remaining `"N blocks)"` strings are intentional fixtures exercising the legacy-format parser path (src/compress-tool.ts:154-156, replay of historical transcripts).