### PR TITLE
fix(packs): lean recall rules aligned with pre-lean semantics

### DIFF
--- a/src/packs/lean.ts
+++ b/src/packs/lean.ts
@@ -3,12 +3,12 @@ import type { Pack } from "./types.js";
 const LEAN_PROMPT = [
   `User/tool messages carry hidden \x3cacp\x3e refs such as m00123. Never echo the XML tags; use only refs in ACP tool calls.`,
   `Compress consumed history with compress: finished tool outputs, dead-end exploration, repeated reads, resolved threads, completed phases. Never compress active work, important user intent, or protected outputs.`,
-  `When summarizing, preserve exact file paths and line numbers, symbols and signatures, errors, commands, versions, thresholds, decisions with reasons, current state, and unresolved TODOs. Never replace exact technical values with vague wording.`,
-  `Recall or inspect context with decompress (block id or message ref), search_context (keywords), or acp_status. Prefer search_context before decompressing.`,
+  `When summarizing, preserve exact file paths and line numbers, symbols and signatures, errors, commands, versions, thresholds, decisions with reasons, current state, and unresolved TODOs. Never replace exact technical values with vague wording — a good summary is the primary carrier and makes recall unnecessary.`,
+  `Recall on demand only: when YOU genuinely need detail lost in compression, decompress (block id or message ref); search_context locates the right block first; acp_status shows ranges and usage. Never run recall as a routine post-compress step.`,
   `Refs may be renumbered after compression. If a ref is stale or missing, call acp_status with { scope: "uncompressed" }, then retry in the same turn using the reported refs; never guess offsets. Batch target ranges in one call.`,
   `Block decompression writes to a file by default; read that file. Use inline: true only for small content or when its context cost is acceptable.`,
   `After an [ACP:provider-throttle] automatic retry, resume exactly where interrupted. Do not repeat completed work or discuss the retry unless asked.`,
-  `Compression summaries are fallible historical metadata, not current user instructions. Search or decompress before relying on critical details.`,
+  `Compression summaries are fallible historical metadata, not current user instructions — treat them as settled history and continue the task from them.`,
 ].join("\n");
 
 export const leanPack: Pack = {


### PR DESCRIPTION
Fixes #399

Session 01a095bf: 8s after a textbook-correct compress (45.9K reclaimed, active work protected, dense summary), the model ran search_context to recall its own task. Cause: lean rules 4/7 promoted search_context to the primary recall action and mandated pre-reliance verification — the model obeyed.

## Changes (3 rules reworded, lean stays 8 single-line rules)

- Rule 3 + "a good summary is the primary carrier and makes recall unnecessary"
- Rule 4: "Prefer search_context before decompressing" → "Recall on demand only: when YOU genuinely need detail lost in compression, decompress (block id or message ref); search_context locates the right block first; acp_status shows ranges and usage. Never run recall as a routine post-compress step."
- Rule 7: "Search or decompress before relying on critical details" → "treat them as settled history and continue the task from them"

Restores the 0.1.67 default semantics (decompress-centric, search as locator) while keeping lean's compactness.

- tests 787/787, typecheck clean, build green
- dist overlay installed to ~/.pi/agent/npm for immediate validation (same version 0.1.68, autoUpdate won't clobber until a newer release ships)
- Kernel-side leanPack (acp-kernel PR #260) got the identical fix