### PR TITLE
chore: bump acp-kernel to 0.0.67

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@earendil-works/pi-coding-agent": "0.83.0",
 				"@earendil-works/pi-tui": "0.83.0",
 				"@types/node": "^26.1.2",
-				"acp-kernel": "0.0.66",
+				"acp-kernel": "0.0.67",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -3200,9 +3200,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.66",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.66.tgz",
-			"integrity": "sha512-zEg9KV9S6DFl6JNn3IPo9zDahjXESgZxw/Bx0Zgbj5syIGmH3GLvyGoq1HIQWGSDKlFE8vD1PRzrnhqnHo985g==",
+			"version": "0.0.67",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.67.tgz",
+			"integrity": "sha512-dcq1/GHcTlf6yFSDe6SHsSWOpk6mX1DeGDSVFeyGG3mne2mwnXnY4ptnl/cCQiYh3wlfzy/8gWwBvlQJlAxf3A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"@earendil-works/pi-coding-agent": "0.83.0",
 		"@earendil-works/pi-tui": "0.83.0",
 		"@types/node": "^26.1.2",
-		"acp-kernel": "0.0.66",
+		"acp-kernel": "0.0.67",
 		"tsup": "^8.5.1",
 		"tsx": "^4.23.1",
 		"typescript": "^7.0.2"

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -11,10 +11,13 @@ export interface PiPromptSections {
   decompressPhilosophy?: SectionOverride;
   contextBreakdown?: SectionOverride;
   throttleRetry?: SectionOverride;
-  philosophy?: null;
-  howToCompress?: null;
-  tier2?: null;
-  tier3?: null;
+  // Rule slots default to the kernel's full rule text; a pack may null them
+  // (drop the section) or REPLACE them with a condensed variant (kernel
+  // 0.0.67 lean ships a condensed howToCompress contract).
+  philosophy?: SectionOverride;
+  howToCompress?: SectionOverride;
+  tier2?: SectionOverride;
+  tier3?: SectionOverride;
 }
 
 const SECTIONS: ReadonlyArray<readonly [string, string]> = [
@@ -85,8 +88,8 @@ export function sanitizePromptSections(raw: unknown): Partial<PiPromptSections> 
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
     if (PROMPT_SECTION_KEYS.has(k) && (typeof v === "string" || v === null)) {
       (out as Record<string, SectionOverride>)[k] = v;
-    } else if (RULE_SLOT_KEYS.has(k) && v === null) {
-      (out as Record<string, SectionOverride>)[k] = null;
+    } else if (RULE_SLOT_KEYS.has(k) && (typeof v === "string" || v === null)) {
+      (out as Record<string, SectionOverride>)[k] = v;
     }
   }
   return out;

--- a/tests/prompt-pack.test.ts
+++ b/tests/prompt-pack.test.ts
@@ -51,10 +51,18 @@ test("lean pack is a kernel builtin carrying its pi surface under adapters", () 
   assert.ok(String(rules).includes("makes recall unnecessary"));
 });
 
-test("piAdapterSurface(leanPack): aligned rules kept, every other section nulled, lean tool extras", () => {
+test("piAdapterSurface(leanPack): aligned rules kept, condensed how-to-compress contract, other sections nulled, lean tool extras", () => {
   const s = piAdapterSurface(leanPack);
   assert.equal(s.promptSections.acpTags, leanPiSections().acpTags);
-  for (const k of ["summariesInContext", "tools", "philosophy", "howToCompress", "tier2", "tier3", "multiTierIntro", "decompressPhilosophy", "contextBreakdown", "throttleRetry", "whenToCompress", "whenNotToCompress"]) {
+  // kernel >= 0.0.67: the style contract slot is restored with a condensed
+  // distillation of the default rules (incident 01a09989 — unstyled summaries
+  // transcribed dialogue state). philosophy/tier sections stay nulled.
+  const howTo = s.promptSections.howToCompress;
+  assert.equal(typeof howTo, "string", "howToCompress is the condensed contract");
+  for (const marker of ["TASK AS OF THIS BLOCK", "PENDING", "no Q&A lists", "KEEP VERBATIM", "PRIORITY"]) {
+    assert.ok(String(howTo).includes(marker), `howToCompress missing: ${marker}`);
+  }
+  for (const k of ["summariesInContext", "tools", "philosophy", "tier2", "tier3", "multiTierIntro", "decompressPhilosophy", "contextBreakdown", "throttleRetry", "whenToCompress", "whenNotToCompress"]) {
     assert.equal((s.promptSections as Record<string, unknown>)[k], null, `${k} should be null`);
   }
   for (const t of ["compress", "decompress", "search_context", "acp_status"] as const) {

--- a/tests/prompt-pack.test.ts
+++ b/tests/prompt-pack.test.ts
@@ -195,7 +195,9 @@ test("piAdapterSurface sanitizes junk: bad section types dropped, malformed extr
     },
   };
   const s = piAdapterSurface(pack);
-  assert.deepEqual(s.promptSections, { tools: null, whenToCompress: "keep" });
+  // rule-slot strings are legit since kernel 0.0.67 (condensed contracts);
+  // only genuinely bad types (42) are dropped.
+  assert.deepEqual(s.promptSections, { tools: null, whenToCompress: "keep", philosophy: "no" });
   assert.deepEqual(s.toolExtras, {
     compress: { promptGuidelines: ["single"] },
     acp_status: { promptSnippet: "s" },

--- a/tests/prompt-pack.test.ts
+++ b/tests/prompt-pack.test.ts
@@ -72,6 +72,14 @@ test("piAdapterSurface(leanPack): aligned rules kept, condensed how-to-compress 
   assert.deepEqual(piAdapterSurface(defaultPack), { promptSections: {}, toolExtras: {} });
 });
 
+test("lean how-to-compress contract reaches the built prompt instead of the default rules", () => {
+  const merged = mergeSurface(leanPack, {});
+  const text = buildAcpSystemPrompt(defaultPrompts, merged.promptSections);
+  assert.ok(text.includes("HOW TO COMPRESS (condensed)"), "condensed contract header present");
+  assert.ok(text.includes("TASK AS OF THIS BLOCK"), "integrity rule present");
+  assert.ok(!text.includes(defaultPrompts.howToCompressRules), "default full rules not injected");
+});
+
 test("lean pack system prompt collapses to header + lean bullets", () => {
   const merged = mergeSurface(leanPack, {});
   const text = buildAcpSystemPrompt(defaultPrompts, merged.promptSections);


### PR DESCRIPTION
Bumps the pinned `acp-kernel` from 0.0.66 to 0.0.67 and fixes the pi side that the new kernel surfaced.

## Kernel side ([acp-kernel #264](https://github.com/ranxianglei/acp-kernel/pull/264), Fixes [acp-kernel #263](https://github.com/ranxianglei/acp-kernel/issues/263))

Lean pack carries a condensed how-to-compress style contract in the pi slot (~2.0K vs the 4.5K default) with integrity rules against the 01a09989 unstyled-summary hallucination class: no simulated Q&A transcripts, owed answers are PENDING, questions recorded as asked (with ref) — never as answered.

## Pi side (this PR)

`sanitizePromptSections` hard-nulled the rule slots (`philosophy`/`howToCompress`/`tier2`/`tier3`) even when a pack supplied a string, so the kernel contract was bundled but **never rendered** — caught by the updated prompt-pack test. Rule slots now accept string overrides (`SectionOverride`), the condensed contract flows into the lean system prompt, and the junk-sanitize test is updated to the new semantics.

E2E smoke: lean system prompt = 3572 bytes; condensed contract rendered; full default and philosophy absent.

## Verification

803 tests (0 fail, 3 pre-existing skips), typecheck clean, build green. The currently installed ~/.pi build carries the kernel data but NOT this render fix — this PR completes it locally once rebuilt.

Fixes #419.
